### PR TITLE
Add workflow IR compiler pipeline

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,16 @@
+* text=auto
+
+*.py text eol=lf
+*.md text eol=lf
+*.toml text eol=lf
+*.lock text eol=lf
+*.yaml text eol=lf
+*.yml text eol=lf
+*.j2 text eol=lf
+*.sh text eol=lf
+
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.pdf binary

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
+    "python.analysis.extraPaths": [
+        "${workspaceFolder}/.venv/lib/python3.13/site-packages"
+    ]
+}

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,44 @@
+# AI-bioworkflow 开发与架构指南
+
+本文档用于记录基于 LangGraph 和 DeepSeek 搭建的 WDL 自动生成 Agent 的目录结构与核心设计理念，以供后续开发参考。
+
+## 📁 核心目录结构
+
+```text
+AI-bioworkflow/
+├── .env                  # 环境变量配置（DEEPSEEK_API_KEY等，勿提交至Git）
+├── pyproject.toml        # uv 依赖配置文件
+├── README.md             # 项目基础说明
+├── DEVELOPMENT.md        # 本开发指南
+│
+├── src/                  # 核心源代码目录
+│   ├── __init__.py
+│   │
+│   ├── state.py          # 1. 状态定义：定义 Agent 的全局状态 (WorkflowState)
+│   │
+│   ├── prompts.py        # 2. 提示词管理：存放所有 System Prompts 和 Few-shot 示例
+│   │
+│   ├── tools/            # 3. 工具箱：存放供大模型调用的外部工具
+│   │   ├── __init__.py
+│   │   └── validator.py  # 生信特定工具（如 miniwdl 语法校验）
+│   │
+│   ├── nodes/            # 4. 工作节点：LangGraph 的具体执行工位
+│   │   ├── __init__.py
+│   │   ├── planner.py    # 将结构化表单转化为步骤图的逻辑
+│   │   └── coder.py      # 负责输出具体 WDL 代码的逻辑
+│   │
+│   └── graph.py          # 5. 核心图纸：组装 nodes 和 tools 的 StateGraph
+│
+├── tests/                # 单元与集成测试
+│   ├── test_tools.py     
+│   └── test_graph.py     
+│
+└── main.py               # 项目入口，负责接收用户输入并触发 workflow
+```
+
+## 🧠 核心模块设计理念
+
+1. **状态管理 (`state.py`)**：必须保持强类型。除了 LangGraph 原生的 `messages` 列表，还需要定义好接收前端传入的 `parsed_json`（结构化表单数据）和流转中的 `current_wdl` 代码。
+2. **提示词隔离 (`prompts.py`)**：绝对不要将长篇大论的 System Prompt 硬编码在业务逻辑文件中。
+3. **工具封装 (`tools/`)**：所有与底层操作系统或第三方生信软件的交互（如调用 `miniwdl check`）都必须封装为独立的 Tool 节点，确保大模型生成的代码闭环验证。
+4. **渐进式重构**：初期 MVP 阶段确保数据流转清晰，后期再逐步引入更复杂的查库（如自动查询 biocontainers 镜像）节点。

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -22,26 +22,30 @@ AI-bioworkflow/
 │   │
 │   ├── analyzer.py       # 3. IR 静态分析：引用、类型、DAG 顺序等检查
 │   │
-│   ├── prompts.py        # 4. 提示词管理：存放所有 System Prompts 和 Few-shot 示例
+│   ├── catalog/          # 4. 生信工具目录：工具 schema、YAML 定义与 plan resolver
 │   │
-│   ├── renderers/        # 5. 确定性代码生成器
+│   ├── recipes/          # 5. 分析配方目录：配方 schema 与步骤定义
+│   │
+│   ├── prompts.py        # 6. 提示词管理：存放所有 System Prompts 和 Few-shot 示例
+│   │
+│   ├── renderers/        # 7. 确定性代码生成器
 │   │   ├── wdl.py        # IR -> WDL
 │   │   └── templates/
 │   │       └── workflow.wdl.j2
 │   │
-│   ├── tools/            # 6. 工具箱：存放外部工具封装
+│   ├── tools/            # 8. 工具箱：存放外部工具封装
 │   │   ├── __init__.py
 │   │   └── validator.py  # 生信特定工具（如 miniwdl 语法校验）
 │   │
-│   ├── nodes/            # 7. 工作节点：LangGraph 的具体执行工位
+│   ├── nodes/            # 9. 工作节点：LangGraph 的具体执行工位
 │   │   ├── __init__.py
-│   │   ├── planner.py    # 将输入 JSON 标准化为 Workflow IR
+│   │   ├── planner.py    # 将标准 IR 或 Recipe Tool Plan 标准化为 Workflow IR
 │   │   ├── analyzer.py   # 调用 IR 静态分析
 │   │   ├── renderer.py   # 调用 WDL renderer
 │   │   ├── checker.py    # 调用 miniwdl validator
 │   │   └── coder.py      # 旧版 LLM 直出 WDL 节点，保留作对照/实验
 │   │
-│   └── graph.py          # 8. 核心图纸：组装 nodes 和 tools 的 StateGraph
+│   └── graph.py          # 10. 核心图纸：组装 nodes 和 tools 的 StateGraph
 │
 ├── tests/                # 单元与集成测试
 │   ├── test_tools.py     
@@ -55,17 +59,18 @@ AI-bioworkflow/
 1. **状态管理 (`state.py`)**：必须保持强类型。除了 LangGraph 原生的 `messages` 列表，还需要定义好接收前端传入的 `parsed_json`、标准化后的 `workflow_ir`、流转中的 `current_wdl`、`analysis_errors` 和 `validation_message`。
 2. **提示词隔离 (`prompts.py`)**：绝对不要将长篇大论的 System Prompt 硬编码在业务逻辑文件中。
 3. **IR 优先 (`schema.py`)**：workflow 的调用关系与 task 的定义必须分离。`workflow.calls` 表达 DAG，`tasks` 表达可复用 task 模板。
-4. **静态分析先于渲染 (`analyzer.py`)**：在生成 WDL 前先检查 task 是否存在、输入是否齐全、上游输出引用是否有效、基础类型是否匹配。
-5. **确定性渲染 (`renderers/`)**：标准 IR 到 WDL 必须由模板或普通代码生成，不应依赖 LLM 的自由文本输出。
-6. **工具封装 (`tools/`)**：所有与底层操作系统或第三方生信软件的交互（如调用 `miniwdl check`）都必须封装为独立 Tool，确保生成代码闭环验证。
-7. **渐进式重构**：先保证 IR -> WDL -> miniwdl check 的主链路稳定，再逐步引入 LLM planner、LLM repairer、Biocontainers 镜像查询节点。
+4. **Catalog 先于自由生成 (`catalog/`, `recipes/`)**：常见生信工具、版本、参数、runtime 与配方步骤应沉淀为结构化目录，Planner 可以把 Recipe Tool Plan 解析成标准 IR。
+5. **静态分析先于渲染 (`analyzer.py`)**：在生成 WDL 前先检查 task 是否存在、输入是否齐全、上游输出引用是否有效、基础类型是否匹配。
+6. **确定性渲染 (`renderers/`)**：标准 IR 到 WDL 必须由模板或普通代码生成，不应依赖 LLM 的自由文本输出。
+7. **工具封装 (`tools/`)**：所有与底层操作系统或第三方生信软件的交互（如调用 `miniwdl check`）都必须封装为独立 Tool，确保生成代码闭环验证。
+8. **渐进式重构**：先保证 IR -> WDL -> miniwdl check 的主链路稳定，再逐步引入 LLM planner、LLM repairer、Biocontainers 镜像查询节点。
 
 ## 当前 LangGraph 流程
 
 ```text
 START
   ↓
-planner_node     # 结构化 JSON -> Workflow IR
+planner_node     # 标准 IR / Legacy JSON / Recipe Tool Plan -> Workflow IR
   ↓
 analyzer_node    # IR 静态分析
   ↓

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -22,23 +22,24 @@ AI-bioworkflow/
 │   │
 │   ├── analyzer.py       # 3. IR 静态分析：引用、类型、DAG 顺序等检查
 │   ├── repairer.py       # 4. IR 保守修复：call 顺序、输出字面量等确定性问题
+│   ├── nl_planner.py     # 5. 自然语言需求 -> Recipe Tool Plan
 │   │
-│   ├── catalog/          # 5. 生信工具目录：工具 schema、YAML 定义与 plan resolver
+│   ├── catalog/          # 6. 生信工具目录：工具 schema、YAML 定义与 plan resolver
 │   │
-│   ├── recipes/          # 6. 分析配方目录：配方 schema 与步骤定义
+│   ├── recipes/          # 7. 分析配方目录：配方 schema 与步骤定义
 │   │
-│   ├── prompts.py        # 7. 提示词管理：存放所有 System Prompts 和 Few-shot 示例
+│   ├── prompts.py        # 8. 提示词管理：存放所有 System Prompts 和 Few-shot 示例
 │   │
-│   ├── renderers/        # 8. 确定性代码生成器
+│   ├── renderers/        # 9. 确定性代码生成器
 │   │   ├── wdl.py        # IR -> WDL
 │   │   └── templates/
 │   │       └── workflow.wdl.j2
 │   │
-│   ├── tools/            # 9. 工具箱：存放外部工具封装
+│   ├── tools/            # 10. 工具箱：存放外部工具封装
 │   │   ├── __init__.py
 │   │   └── validator.py  # 生信特定工具（如 miniwdl 语法校验）
 │   │
-│   ├── nodes/            # 10. 工作节点：LangGraph 的具体执行工位
+│   ├── nodes/            # 11. 工作节点：LangGraph 的具体执行工位
 │   │   ├── __init__.py
 │   │   ├── planner.py    # 将标准 IR 或 Recipe Tool Plan 标准化为 Workflow IR
 │   │   ├── analyzer.py   # 调用 IR 静态分析
@@ -47,7 +48,7 @@ AI-bioworkflow/
 │   │   ├── checker.py    # 调用 miniwdl validator
 │   │   └── coder.py      # 旧版 LLM 直出 WDL 节点，保留作对照/实验
 │   │
-│   └── graph.py          # 11. 核心图纸：组装 nodes 和 tools 的 StateGraph
+│   └── graph.py          # 12. 核心图纸：组装 nodes 和 tools 的 StateGraph
 │
 ├── tests/                # 单元与集成测试
 │   ├── test_tools.py     
@@ -61,17 +62,20 @@ AI-bioworkflow/
 1. **状态管理 (`state.py`)**：必须保持强类型。除了 LangGraph 原生的 `messages` 列表，还需要定义好接收前端传入的 `parsed_json`、标准化后的 `workflow_ir`、流转中的 `current_wdl`、`analysis_errors` 和 `validation_message`。
 2. **提示词隔离 (`prompts.py`)**：绝对不要将长篇大论的 System Prompt 硬编码在业务逻辑文件中。
 3. **IR 优先 (`schema.py`)**：workflow 的调用关系与 task 的定义必须分离。`workflow.calls` 表达 DAG，`tasks` 表达可复用 task 模板。
-4. **Catalog 先于自由生成 (`catalog/`, `recipes/`)**：常见生信工具、版本、参数、runtime 与配方步骤应沉淀为结构化目录，Planner 可以把 Recipe Tool Plan 解析成标准 IR。
-5. **静态分析先于渲染 (`analyzer.py`)**：在生成 WDL 前先检查 task 是否存在、输入是否齐全、上游输出引用是否有效、基础类型是否匹配。
-6. **保守修复 (`repairer.py`)**：自动修复只处理可以由 IR 本身确定的问题，例如 call 拓扑顺序和明显漏引号的 File/String 输出字面量；无法确定的错误应保留给人工或后续 LLM repairer。
-7. **确定性渲染 (`renderers/`)**：标准 IR 到 WDL 必须由模板或普通代码生成，不应依赖 LLM 的自由文本输出。
-8. **工具封装 (`tools/`)**：所有与底层操作系统或第三方生信软件的交互（如调用 `miniwdl check`）都必须封装为独立 Tool，确保生成代码闭环验证。
-9. **渐进式重构**：先保证 IR -> WDL -> miniwdl check 的主链路稳定，再逐步引入 LLM planner、LLM repairer、Biocontainers 镜像查询节点。
+4. **自然语言只到 Plan (`nl_planner.py`)**：LLM 的职责是把用户需求转成 Recipe Tool Plan，不直接生成 WDL。
+5. **Catalog 先于自由生成 (`catalog/`, `recipes/`)**：常见生信工具、版本、参数、runtime 与配方步骤应沉淀为结构化目录，Planner 可以把 Recipe Tool Plan 解析成标准 IR。
+6. **静态分析先于渲染 (`analyzer.py`)**：在生成 WDL 前先检查 task 是否存在、输入是否齐全、上游输出引用是否有效、基础类型是否匹配。
+7. **保守修复 (`repairer.py`)**：自动修复只处理可以由 IR 本身确定的问题，例如 call 拓扑顺序和明显漏引号的 File/String 输出字面量；无法确定的错误应保留给人工或后续 LLM repairer。
+8. **确定性渲染 (`renderers/`)**：标准 IR 到 WDL 必须由模板或普通代码生成，不应依赖 LLM 的自由文本输出。
+9. **工具封装 (`tools/`)**：所有与底层操作系统或第三方生信软件的交互（如调用 `miniwdl check`）都必须封装为独立 Tool，确保生成代码闭环验证。
+10. **渐进式重构**：先保证 Natural Language -> Recipe Tool Plan -> IR -> WDL -> miniwdl check 的主链路稳定，再逐步引入 LLM repairer、Biocontainers 镜像查询节点。
 
 ## 当前 LangGraph 流程
 
 ```text
 START
+  ↓
+nl_planner        # 自然语言需求 -> Recipe Tool Plan（CLI 自然语言入口）
   ↓
 planner_node     # 标准 IR / Legacy JSON / Recipe Tool Plan -> Workflow IR
   ↓

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,6 +1,8 @@
 # AI-bioworkflow 开发与架构指南
 
-本文档用于记录基于 LangGraph 和 DeepSeek 搭建的 WDL 自动生成 Agent 的目录结构与核心设计理念，以供后续开发参考。
+本文档用于记录基于 LangGraph 的 WDL 工作流生成系统目录结构与核心设计理念，以供后续开发参考。
+
+当前工程方向是“Workflow IR 编译器 + LLM 辅助规划/修复”，而不是让大模型直接手写最终 WDL。标准 IR 到 WDL 的过程必须保持确定性、可测试。
 
 ## 📁 核心目录结构
 
@@ -16,18 +18,30 @@ AI-bioworkflow/
 │   │
 │   ├── state.py          # 1. 状态定义：定义 Agent 的全局状态 (WorkflowState)
 │   │
-│   ├── prompts.py        # 2. 提示词管理：存放所有 System Prompts 和 Few-shot 示例
+│   ├── schema.py         # 2. Workflow IR 的 Pydantic Schema 与兼容转换
 │   │
-│   ├── tools/            # 3. 工具箱：存放供大模型调用的外部工具
+│   ├── analyzer.py       # 3. IR 静态分析：引用、类型、DAG 顺序等检查
+│   │
+│   ├── prompts.py        # 4. 提示词管理：存放所有 System Prompts 和 Few-shot 示例
+│   │
+│   ├── renderers/        # 5. 确定性代码生成器
+│   │   ├── wdl.py        # IR -> WDL
+│   │   └── templates/
+│   │       └── workflow.wdl.j2
+│   │
+│   ├── tools/            # 6. 工具箱：存放外部工具封装
 │   │   ├── __init__.py
 │   │   └── validator.py  # 生信特定工具（如 miniwdl 语法校验）
 │   │
-│   ├── nodes/            # 4. 工作节点：LangGraph 的具体执行工位
+│   ├── nodes/            # 7. 工作节点：LangGraph 的具体执行工位
 │   │   ├── __init__.py
-│   │   ├── planner.py    # 将结构化表单转化为步骤图的逻辑
-│   │   └── coder.py      # 负责输出具体 WDL 代码的逻辑
+│   │   ├── planner.py    # 将输入 JSON 标准化为 Workflow IR
+│   │   ├── analyzer.py   # 调用 IR 静态分析
+│   │   ├── renderer.py   # 调用 WDL renderer
+│   │   ├── checker.py    # 调用 miniwdl validator
+│   │   └── coder.py      # 旧版 LLM 直出 WDL 节点，保留作对照/实验
 │   │
-│   └── graph.py          # 5. 核心图纸：组装 nodes 和 tools 的 StateGraph
+│   └── graph.py          # 8. 核心图纸：组装 nodes 和 tools 的 StateGraph
 │
 ├── tests/                # 单元与集成测试
 │   ├── test_tools.py     
@@ -38,7 +52,26 @@ AI-bioworkflow/
 
 ## 🧠 核心模块设计理念
 
-1. **状态管理 (`state.py`)**：必须保持强类型。除了 LangGraph 原生的 `messages` 列表，还需要定义好接收前端传入的 `parsed_json`（结构化表单数据）和流转中的 `current_wdl` 代码。
+1. **状态管理 (`state.py`)**：必须保持强类型。除了 LangGraph 原生的 `messages` 列表，还需要定义好接收前端传入的 `parsed_json`、标准化后的 `workflow_ir`、流转中的 `current_wdl`、`analysis_errors` 和 `validation_message`。
 2. **提示词隔离 (`prompts.py`)**：绝对不要将长篇大论的 System Prompt 硬编码在业务逻辑文件中。
-3. **工具封装 (`tools/`)**：所有与底层操作系统或第三方生信软件的交互（如调用 `miniwdl check`）都必须封装为独立的 Tool 节点，确保大模型生成的代码闭环验证。
-4. **渐进式重构**：初期 MVP 阶段确保数据流转清晰，后期再逐步引入更复杂的查库（如自动查询 biocontainers 镜像）节点。
+3. **IR 优先 (`schema.py`)**：workflow 的调用关系与 task 的定义必须分离。`workflow.calls` 表达 DAG，`tasks` 表达可复用 task 模板。
+4. **静态分析先于渲染 (`analyzer.py`)**：在生成 WDL 前先检查 task 是否存在、输入是否齐全、上游输出引用是否有效、基础类型是否匹配。
+5. **确定性渲染 (`renderers/`)**：标准 IR 到 WDL 必须由模板或普通代码生成，不应依赖 LLM 的自由文本输出。
+6. **工具封装 (`tools/`)**：所有与底层操作系统或第三方生信软件的交互（如调用 `miniwdl check`）都必须封装为独立 Tool，确保生成代码闭环验证。
+7. **渐进式重构**：先保证 IR -> WDL -> miniwdl check 的主链路稳定，再逐步引入 LLM planner、LLM repairer、Biocontainers 镜像查询节点。
+
+## 当前 LangGraph 流程
+
+```text
+START
+  ↓
+planner_node     # 结构化 JSON -> Workflow IR
+  ↓
+analyzer_node    # IR 静态分析
+  ↓
+renderer_node    # Workflow IR -> WDL
+  ↓
+checker_node     # miniwdl check
+  ↓
+END
+```

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -62,7 +62,7 @@ AI-bioworkflow/
 1. **状态管理 (`state.py`)**：必须保持强类型。除了 LangGraph 原生的 `messages` 列表，还需要定义好接收前端传入的 `parsed_json`、标准化后的 `workflow_ir`、流转中的 `current_wdl`、`analysis_errors` 和 `validation_message`。
 2. **提示词隔离 (`prompts.py`)**：绝对不要将长篇大论的 System Prompt 硬编码在业务逻辑文件中。
 3. **IR 优先 (`schema.py`)**：workflow 的调用关系与 task 的定义必须分离。`workflow.calls` 表达 DAG，`tasks` 表达可复用 task 模板。
-4. **自然语言只到 Plan (`nl_planner.py`)**：LLM 的职责是把用户需求转成 Recipe Tool Plan，不直接生成 WDL。
+4. **自然语言只到 Plan (`nl_planner.py`)**：LLM 的职责是把用户需求转成 Recipe Tool Plan，不直接生成 WDL。Planner 失败需要区分 JSON 解析、plan schema、recipe/catalog 校验三类错误，便于调试真实模型输出。
 5. **Catalog 先于自由生成 (`catalog/`, `recipes/`)**：常见生信工具、版本、参数、runtime 与配方步骤应沉淀为结构化目录，Planner 可以把 Recipe Tool Plan 解析成标准 IR。
 6. **静态分析先于渲染 (`analyzer.py`)**：在生成 WDL 前先检查 task 是否存在、输入是否齐全、上游输出引用是否有效、基础类型是否匹配。
 7. **保守修复 (`repairer.py`)**：自动修复只处理可以由 IR 本身确定的问题，例如 call 拓扑顺序和明显漏引号的 File/String 输出字面量；无法确定的错误应保留给人工或后续 LLM repairer。

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -21,31 +21,33 @@ AI-bioworkflow/
 │   ├── schema.py         # 2. Workflow IR 的 Pydantic Schema 与兼容转换
 │   │
 │   ├── analyzer.py       # 3. IR 静态分析：引用、类型、DAG 顺序等检查
+│   ├── repairer.py       # 4. IR 保守修复：call 顺序、输出字面量等确定性问题
 │   │
-│   ├── catalog/          # 4. 生信工具目录：工具 schema、YAML 定义与 plan resolver
+│   ├── catalog/          # 5. 生信工具目录：工具 schema、YAML 定义与 plan resolver
 │   │
-│   ├── recipes/          # 5. 分析配方目录：配方 schema 与步骤定义
+│   ├── recipes/          # 6. 分析配方目录：配方 schema 与步骤定义
 │   │
-│   ├── prompts.py        # 6. 提示词管理：存放所有 System Prompts 和 Few-shot 示例
+│   ├── prompts.py        # 7. 提示词管理：存放所有 System Prompts 和 Few-shot 示例
 │   │
-│   ├── renderers/        # 7. 确定性代码生成器
+│   ├── renderers/        # 8. 确定性代码生成器
 │   │   ├── wdl.py        # IR -> WDL
 │   │   └── templates/
 │   │       └── workflow.wdl.j2
 │   │
-│   ├── tools/            # 8. 工具箱：存放外部工具封装
+│   ├── tools/            # 9. 工具箱：存放外部工具封装
 │   │   ├── __init__.py
 │   │   └── validator.py  # 生信特定工具（如 miniwdl 语法校验）
 │   │
-│   ├── nodes/            # 9. 工作节点：LangGraph 的具体执行工位
+│   ├── nodes/            # 10. 工作节点：LangGraph 的具体执行工位
 │   │   ├── __init__.py
 │   │   ├── planner.py    # 将标准 IR 或 Recipe Tool Plan 标准化为 Workflow IR
 │   │   ├── analyzer.py   # 调用 IR 静态分析
+│   │   ├── repairer.py   # 调用 IR repairer 并记录修复动作
 │   │   ├── renderer.py   # 调用 WDL renderer
 │   │   ├── checker.py    # 调用 miniwdl validator
 │   │   └── coder.py      # 旧版 LLM 直出 WDL 节点，保留作对照/实验
 │   │
-│   └── graph.py          # 10. 核心图纸：组装 nodes 和 tools 的 StateGraph
+│   └── graph.py          # 11. 核心图纸：组装 nodes 和 tools 的 StateGraph
 │
 ├── tests/                # 单元与集成测试
 │   ├── test_tools.py     
@@ -61,9 +63,10 @@ AI-bioworkflow/
 3. **IR 优先 (`schema.py`)**：workflow 的调用关系与 task 的定义必须分离。`workflow.calls` 表达 DAG，`tasks` 表达可复用 task 模板。
 4. **Catalog 先于自由生成 (`catalog/`, `recipes/`)**：常见生信工具、版本、参数、runtime 与配方步骤应沉淀为结构化目录，Planner 可以把 Recipe Tool Plan 解析成标准 IR。
 5. **静态分析先于渲染 (`analyzer.py`)**：在生成 WDL 前先检查 task 是否存在、输入是否齐全、上游输出引用是否有效、基础类型是否匹配。
-6. **确定性渲染 (`renderers/`)**：标准 IR 到 WDL 必须由模板或普通代码生成，不应依赖 LLM 的自由文本输出。
-7. **工具封装 (`tools/`)**：所有与底层操作系统或第三方生信软件的交互（如调用 `miniwdl check`）都必须封装为独立 Tool，确保生成代码闭环验证。
-8. **渐进式重构**：先保证 IR -> WDL -> miniwdl check 的主链路稳定，再逐步引入 LLM planner、LLM repairer、Biocontainers 镜像查询节点。
+6. **保守修复 (`repairer.py`)**：自动修复只处理可以由 IR 本身确定的问题，例如 call 拓扑顺序和明显漏引号的 File/String 输出字面量；无法确定的错误应保留给人工或后续 LLM repairer。
+7. **确定性渲染 (`renderers/`)**：标准 IR 到 WDL 必须由模板或普通代码生成，不应依赖 LLM 的自由文本输出。
+8. **工具封装 (`tools/`)**：所有与底层操作系统或第三方生信软件的交互（如调用 `miniwdl check`）都必须封装为独立 Tool，确保生成代码闭环验证。
+9. **渐进式重构**：先保证 IR -> WDL -> miniwdl check 的主链路稳定，再逐步引入 LLM planner、LLM repairer、Biocontainers 镜像查询节点。
 
 ## 当前 LangGraph 流程
 
@@ -79,4 +82,10 @@ renderer_node    # Workflow IR -> WDL
 checker_node     # miniwdl check
   ↓
 END
+
+analyzer_node 或 checker_node 发现错误时，如果 repairer 还有重试预算，会进入：
+
+repairer_node    # 可确定修复时更新 IR
+  ↓
+analyzer_node    # 修复后重新分析、渲染、校验
 ```

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -69,7 +69,7 @@ AI-bioworkflow/
 7. **保守修复 (`repairer.py`)**：自动修复只处理可以由 IR 本身确定的问题，例如 call 拓扑顺序和明显漏引号的 File/String 输出字面量；无法确定的错误应保留给人工或后续 LLM repairer。
 8. **确定性渲染 (`renderers/`)**：标准 IR 到 WDL 必须由模板或普通代码生成，不应依赖 LLM 的自由文本输出。
 9. **工具封装 (`tools/`)**：所有与底层操作系统或第三方生信软件的交互（如调用 `miniwdl check`）都必须封装为独立 Tool，确保生成代码闭环验证。
-10. **Container 补全可插拔 (`catalog/container_resolver.py`)**：镜像解析先定义 provider 协议与确定性离线实现；真实 Biocontainers / Quay 查询应作为 provider 或独立节点接入，避免让主编译链路默认依赖网络。
+10. **Container 补全可插拔 (`catalog/container_resolver.py`)**：镜像解析先定义 provider 协议与确定性离线实现；CLI 只能通过显式 `--fill-containers` / `--container-images` 启用补全。真实 Biocontainers / Quay 查询应作为 provider 或独立节点接入，避免让主编译链路默认依赖网络。
 11. **渐进式重构**：先保证 Natural Language -> Recipe Tool Plan -> IR -> WDL -> miniwdl check 的主链路稳定，再逐步引入 LLM repairer、Biocontainers 镜像查询节点。
 
 ## 当前 LangGraph 流程

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -25,6 +25,7 @@ AI-bioworkflow/
 │   ├── nl_planner.py     # 5. 自然语言需求 -> Recipe Tool Plan
 │   │
 │   ├── catalog/          # 6. 生信工具目录：工具 schema、YAML 定义与 plan resolver
+│   │   └── container_resolver.py # Container 镜像补全边界与离线 provider
 │   │
 │   ├── recipes/          # 7. 分析配方目录：配方 schema 与步骤定义
 │   │
@@ -68,7 +69,8 @@ AI-bioworkflow/
 7. **保守修复 (`repairer.py`)**：自动修复只处理可以由 IR 本身确定的问题，例如 call 拓扑顺序和明显漏引号的 File/String 输出字面量；无法确定的错误应保留给人工或后续 LLM repairer。
 8. **确定性渲染 (`renderers/`)**：标准 IR 到 WDL 必须由模板或普通代码生成，不应依赖 LLM 的自由文本输出。
 9. **工具封装 (`tools/`)**：所有与底层操作系统或第三方生信软件的交互（如调用 `miniwdl check`）都必须封装为独立 Tool，确保生成代码闭环验证。
-10. **渐进式重构**：先保证 Natural Language -> Recipe Tool Plan -> IR -> WDL -> miniwdl check 的主链路稳定，再逐步引入 LLM repairer、Biocontainers 镜像查询节点。
+10. **Container 补全可插拔 (`catalog/container_resolver.py`)**：镜像解析先定义 provider 协议与确定性离线实现；真实 Biocontainers / Quay 查询应作为 provider 或独立节点接入，避免让主编译链路默认依赖网络。
+11. **渐进式重构**：先保证 Natural Language -> Recipe Tool Plan -> IR -> WDL -> miniwdl check 的主链路稳定，再逐步引入 LLM repairer、Biocontainers 镜像查询节点。
 
 ## 当前 LangGraph 流程
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ uv run main.py --input examples/rnaseq_deg_recipe_plan.json --output outputs/rna
 - `--input` / `-i`：开发模式，读取标准 Workflow IR 或 Recipe Tool Plan。
 - `--output` / `-o`：写出生成的 WDL；不传则打印到终端。
 - `--print-plan`：打印自然语言 Planner 生成的结构化 Recipe Tool Plan。
+- `--save-plan`：将自然语言 Planner 生成的 Recipe Tool Plan 保存为 JSON 文件。
+- `--save-planner-prompt`：保存完整 Planner prompt，方便调试模型输出。
 - `--print-ir`：打印 Planner 标准化后的 Workflow IR。
 - `--no-check`：跳过 `miniwdl` 语法校验，仅执行 IR 分析与 WDL 渲染。
 - `--planner-model`：指定自然语言 Planner 使用的模型。
@@ -93,6 +95,16 @@ uv run main.py --input examples/rnaseq_deg_recipe_plan.json --output outputs/rna
 
 ```bash
 uv run main.py --input examples/rnaseq_workflow_ir.json --no-check > workflow.wdl
+```
+
+调试自然语言规划时，可以保存模型看到的 prompt 和模型生成的 plan：
+
+```bash
+uv run main.py \
+  --prompt-file examples/rnaseq_deg_request.txt \
+  --save-planner-prompt debug/planner_prompt.txt \
+  --save-plan debug/plan.json \
+  --output outputs/rnaseq_deg.wdl
 ```
 
 ## 📥 支持的输入格式

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ LLM 在这个架构中更适合承担规划、补全、修复与解释任务；�
 - **确定性 WDL 编译**：通过 Jinja2 Renderer 从 IR 生成 WDL，避免让 LLM 承担模板引擎职责。
 - **静态分析**：在渲染前检查 task/call 引用、输入完整性、上游输出引用和基础类型匹配。
 - **Recipe / Tool Catalog**：支持用预定义生信工具目录和分析配方生成 Workflow IR。
-- **Agentic 架构**：基于 LangGraph 串联 Planner、Analyzer、Renderer 与 Checker 节点，支持继续扩展 LLM planner / repairer。
+- **Agentic 架构**：基于 LangGraph 串联 Planner、Analyzer、Repairer、Renderer 与 Checker 节点，支持继续扩展 LLM planner / repairer。
 - **模块化设计**：高度解耦的 State、Prompts、Nodes 与 Tools 设计，极佳的代码可维护性。
 
 ## 🛠️ 快速开始
@@ -111,7 +111,7 @@ Recipe Tool Plan 示例：
 - [x] 引入 `miniwdl` / `womtool` 作为 Tool 节点，实现生成的 WDL 自动化本地校验。
 - [x] 引入 Workflow IR、静态分析器与确定性 WDL Renderer。
 - [x] 接入 Recipe / Tool Catalog 输入到 LangGraph Planner。
-- [ ] 闭环修复机制：当校验器报错时，优先修复 IR 而不是重写整份 WDL。
+- [x] 闭环修复机制初版：当分析器或校验器发现可确定修复的问题时，优先修复 IR 并重新编译 WDL。
 - [ ] 接入 Biocontainers 镜像搜索节点，实现 Docker 地址的自动补全。
 
 ## 📄 许可证

--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ uv run main.py
 
 - [x] 搭建基础 LangGraph 状态机与 DeepSeek 连通。
 - [x] 实现从结构化 JSON 到 WDL 的单向代码生成。
-- [ ] 引入 `miniwdl` / `womtool` 作为 Tool 节点，实现生成的 WDL 自动化本地校验。
-- [ ] 闭环重试机制：当校验器报错时，将 Error Message 返回给大模型进行自我修复。
+- [x] 引入 `miniwdl` / `womtool` 作为 Tool 节点，实现生成的 WDL 自动化本地校验。
+- [x] 闭环重试机制：当校验器报错时，将 Error Message 返回给大模型进行自我修复。
 - [ ] 接入 Biocontainers 镜像搜索节点，实现 Docker 地址的自动补全。
 
 ## 📄 许可证

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AI-bioworkflow 🧬🤖
 
-[![Python Version](https://img.shields.io/badge/Python-3.10+-blue.svg?style=flat-square&logo=python&logoColor=white)](https://www.python.org/)
+[![Python Version](https://img.shields.io/badge/Python-3.13+-blue.svg?style=flat-square&logo=python&logoColor=white)](https://www.python.org/)
 [![Package Manager: uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg?style=flat-square)](./LICENSE)
 [![Framework](https://img.shields.io/badge/Agent-LangGraph-1C3C3C?style=flat-square)](https://github.com/langchain-ai/langgraph)
@@ -8,14 +8,17 @@
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](http://makeapullrequest.com)
 
 
-AI-bioworkflow 是一个基于大语言模型（LLM）驱动的生物信息学工作流生成智能体（Agent）。
-本项目利用 **LangGraph** 构建稳健的状态流转架构，并接入 **DeepSeek V4 Pro** 模型，能够将用户提供的结构化表单（JSON）自动翻译为标准、合规的 **WDL (Workflow Description Language) 1.0** 代码。
+AI-bioworkflow 是一个面向生物信息学工作流生成的 Agent / 编译器原型。
+项目利用 **LangGraph** 构建状态流转架构，将用户提供的结构化 JSON 标准化为内部 **Workflow IR**，再通过确定性的 Renderer 编译为标准、合规的 **WDL (Workflow Description Language) 1.0** 代码，并使用 `miniwdl` 做本地语法校验。
+
+LLM 在这个架构中更适合承担规划、补全、修复与解释任务；从标准 IR 到 WDL 的最终生成由普通代码完成，保证输出稳定、可测试、可维护。
 
 ## ✨ 核心特性
 
-- **结构化驱动**：摒弃纯自然语言的模糊性，通过结构化 JSON 保证上下游步骤变量传递的准确性。
-- **Agentic 架构**：基于 LangGraph 构建的多节点智能体架构，支持灵活扩展（未来将支持自动化闭环语法校验与查错）。
-- **DeepSeek 强力驱动**：使用 `deepseek-v4-pro`（已深度优化 Tool Calling 并关闭发散思考模式），提供卓越的代码生成质量。
+- **Workflow IR 驱动**：将 workflow 调用关系与 task 定义分离，支持多个 task、复用 task 和明确的数据依赖。
+- **确定性 WDL 编译**：通过 Jinja2 Renderer 从 IR 生成 WDL，避免让 LLM 承担模板引擎职责。
+- **静态分析**：在渲染前检查 task/call 引用、输入完整性、上游输出引用和基础类型匹配。
+- **Agentic 架构**：基于 LangGraph 串联 Planner、Analyzer、Renderer 与 Checker 节点，支持继续扩展 LLM planner / repairer。
 - **模块化设计**：高度解耦的 State、Prompts、Nodes 与 Tools 设计，极佳的代码可维护性。
 
 ## 🛠️ 快速开始
@@ -23,7 +26,7 @@ AI-bioworkflow 是一个基于大语言模型（LLM）驱动的生物信息学�
 ### 1. 环境准备
 
 确保你的本地开发环境已安装以下基础工具：
-- Python 3.10+
+- Python 3.13+
 - [uv](https://github.com/astral-sh/uv) (极速的 Python 包管理器)
 
 ### 2. 克隆与安装
@@ -37,9 +40,9 @@ cd AI-bioworkflow
 uv sync
 ```
 
-### 3. 配置环境变量
+### 3. 配置环境变量（可选）
 
-在项目根目录下创建一个 `.env` 文件，并填入你的 DeepSeek API 密钥。**请务必不要将此文件提交到版本控制系统中！**
+当前确定性 IR -> WDL 编译链路不需要 API Key。如果后续启用 LLM planner / repairer，可在项目根目录下创建 `.env` 文件，并填入 DeepSeek API 密钥。**请务必不要将此文件提交到版本控制系统中！**
 
 ```env
 # .env 文件内容
@@ -48,12 +51,12 @@ DEEPSEEK_API_KEY="sk-你的真实API密钥"
 
 ### 4. 运行 MVP 测试
 
-执行主入口文件，验证 Agent 是否能正常根据预设的 JSON 生成 WDL 代码：
+执行主入口文件，验证 Agent 是否能正常根据预设的多 task Workflow IR 生成并校验 WDL 代码：
 
 ```bash
 uv run main.py
 ```
-*如果配置正确，终端将在几秒钟后输出一段完整的、包含 fastp 质控步骤的合规 WDL 代码。*
+*如果配置正确，终端将输出一段包含 `fastp` 和 `bwa_mem` 两个 task 的合规 WDL 代码。*
 
 ## 🏗️ 架构与开发指南
 
@@ -63,10 +66,11 @@ uv run main.py
 
 ## 📅 未来路线图 (Roadmap)
 
-- [x] 搭建基础 LangGraph 状态机与 DeepSeek 连通。
+- [x] 搭建基础 LangGraph 状态机。
 - [x] 实现从结构化 JSON 到 WDL 的单向代码生成。
 - [x] 引入 `miniwdl` / `womtool` 作为 Tool 节点，实现生成的 WDL 自动化本地校验。
-- [x] 闭环重试机制：当校验器报错时，将 Error Message 返回给大模型进行自我修复。
+- [x] 引入 Workflow IR、静态分析器与确定性 WDL Renderer。
+- [ ] 闭环修复机制：当校验器报错时，优先修复 IR 而不是重写整份 WDL。
 - [ ] 接入 Biocontainers 镜像搜索节点，实现 Docker 地址的自动补全。
 
 ## 📄 许可证

--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ Recipe Tool Plan 示例：
 - [x] 引入 Workflow IR、静态分析器与确定性 WDL Renderer。
 - [x] 接入 Recipe / Tool Catalog 输入到 LangGraph Planner。
 - [x] 闭环修复机制初版：当分析器或校验器发现可确定修复的问题时，优先修复 IR 并重新编译 WDL。
+- [x] 建立 Container Resolver 的 provider 接口与离线测试基础。
 - [ ] 接入 Biocontainers 镜像搜索节点，实现 Docker 地址的自动补全。
 
 ## 📄 许可证

--- a/README.md
+++ b/README.md
@@ -1,1 +1,74 @@
-# AI-bioworkflow
+# AI-bioworkflow 🧬🤖
+
+[![Python Version](https://img.shields.io/badge/Python-3.10+-blue.svg?style=flat-square&logo=python&logoColor=white)](https://www.python.org/)
+[![Package Manager: uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg?style=flat-square)](./LICENSE)
+[![Framework](https://img.shields.io/badge/Agent-LangGraph-1C3C3C?style=flat-square)](https://github.com/langchain-ai/langgraph)
+[![Model](https://img.shields.io/badge/Model-DeepSeek_V4_Pro-4D6BFE?style=flat-square)](https://www.deepseek.com/)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](http://makeapullrequest.com)
+
+
+AI-bioworkflow 是一个基于大语言模型（LLM）驱动的生物信息学工作流生成智能体（Agent）。
+本项目利用 **LangGraph** 构建稳健的状态流转架构，并接入 **DeepSeek V4 Pro** 模型，能够将用户提供的结构化表单（JSON）自动翻译为标准、合规的 **WDL (Workflow Description Language) 1.0** 代码。
+
+## ✨ 核心特性
+
+- **结构化驱动**：摒弃纯自然语言的模糊性，通过结构化 JSON 保证上下游步骤变量传递的准确性。
+- **Agentic 架构**：基于 LangGraph 构建的多节点智能体架构，支持灵活扩展（未来将支持自动化闭环语法校验与查错）。
+- **DeepSeek 强力驱动**：使用 `deepseek-v4-pro`（已深度优化 Tool Calling 并关闭发散思考模式），提供卓越的代码生成质量。
+- **模块化设计**：高度解耦的 State、Prompts、Nodes 与 Tools 设计，极佳的代码可维护性。
+
+## 🛠️ 快速开始
+
+### 1. 环境准备
+
+确保你的本地开发环境已安装以下基础工具：
+- Python 3.10+
+- [uv](https://github.com/astral-sh/uv) (极速的 Python 包管理器)
+
+### 2. 克隆与安装
+
+```bash
+# 克隆仓库
+git clone [https://github.com/yourusername/AI-bioworkflow.git](https://github.com/yourusername/AI-bioworkflow.git)
+cd AI-bioworkflow
+
+# 使用 uv 同步依赖并创建虚拟环境
+uv sync
+```
+
+### 3. 配置环境变量
+
+在项目根目录下创建一个 `.env` 文件，并填入你的 DeepSeek API 密钥。**请务必不要将此文件提交到版本控制系统中！**
+
+```env
+# .env 文件内容
+DEEPSEEK_API_KEY="sk-你的真实API密钥"
+```
+
+### 4. 运行 MVP 测试
+
+执行主入口文件，验证 Agent 是否能正常根据预设的 JSON 生成 WDL 代码：
+
+```bash
+uv run main.py
+```
+*如果配置正确，终端将在几秒钟后输出一段完整的、包含 fastp 质控步骤的合规 WDL 代码。*
+
+## 🏗️ 架构与开发指南
+
+对于希望了解本项目底层实现原理、LangGraph 状态图设计，或有志于参与二次开发的工程师，请务必阅读我们的开发文档：
+
+👉 **[查看 DEVELOPMENT.md 开发指南](./DEVELOPMENT.md)**
+
+## 📅 未来路线图 (Roadmap)
+
+- [x] 搭建基础 LangGraph 状态机与 DeepSeek 连通。
+- [x] 实现从结构化 JSON 到 WDL 的单向代码生成。
+- [ ] 引入 `miniwdl` / `womtool` 作为 Tool 节点，实现生成的 WDL 自动化本地校验。
+- [ ] 闭环重试机制：当校验器报错时，将 Error Message 返回给大模型进行自我修复。
+- [ ] 接入 Biocontainers 镜像搜索节点，实现 Docker 地址的自动补全。
+
+## 📄 许可证
+
+[Apache License 2.0](./LICENSE)

--- a/README.md
+++ b/README.md
@@ -41,9 +41,10 @@ cd AI-bioworkflow
 uv sync
 ```
 
-### 3. 配置环境变量（可选）
+### 3. 配置环境变量
 
-当前确定性 IR -> WDL 编译链路不需要 API Key。如果后续启用 LLM planner / repairer，可在项目根目录下创建 `.env` 文件，并填入 DeepSeek API 密钥。**请务必不要将此文件提交到版本控制系统中！**
+自然语言规划入口需要 DeepSeek API Key。确定性的 `--input` 结构化编译模式不需要 API Key。
+可在项目根目录下创建 `.env` 文件，并填入 DeepSeek API 密钥。**请务必不要将此文件提交到版本控制系统中！**
 
 ```env
 # .env 文件内容
@@ -52,14 +53,25 @@ DEEPSEEK_API_KEY="sk-你的真实API密钥"
 
 ### 4. 编译工作流
 
-无参数运行时会使用内置 demo，并打印生成的 WDL：
+无参数运行时会使用内置自然语言 demo，先规划成 Recipe Tool Plan，再编译并打印生成的 WDL：
 
 ```bash
 uv run main.py
 ```
-*如果配置正确，终端将输出一段包含 `fastp` 和 `bwa_mem` 两个 task 的合规 WDL 代码。*
 
-也可以传入 JSON/YAML 文件并写出 WDL：
+也可以直接传入自然语言需求：
+
+```bash
+uv run main.py --prompt "做一个 bulk RNA-seq 差异表达分析流程，输入双端 FASTQ、Salmon index 和样本分组表，先 fastp，再 salmon，最后 DESeq2。"
+```
+
+或者从文本文件读取需求并写出 WDL：
+
+```bash
+uv run main.py --prompt-file examples/rnaseq_deg_request.txt --output outputs/rnaseq_deg.wdl
+```
+
+结构化 JSON/YAML 输入仍然保留为开发/调试模式：
 
 ```bash
 uv run main.py --input examples/rnaseq_deg_recipe_plan.json --output outputs/rnaseq_deg.wdl
@@ -67,10 +79,14 @@ uv run main.py --input examples/rnaseq_deg_recipe_plan.json --output outputs/rna
 
 常用选项：
 
-- `--input` / `-i`：读取标准 Workflow IR 或 Recipe Tool Plan。
+- `--prompt`：读取自然语言 workflow 需求。
+- `--prompt-file`：从文本文件读取自然语言 workflow 需求。
+- `--input` / `-i`：开发模式，读取标准 Workflow IR 或 Recipe Tool Plan。
 - `--output` / `-o`：写出生成的 WDL；不传则打印到终端。
+- `--print-plan`：打印自然语言 Planner 生成的结构化 Recipe Tool Plan。
 - `--print-ir`：打印 Planner 标准化后的 Workflow IR。
 - `--no-check`：跳过 `miniwdl` 语法校验，仅执行 IR 分析与 WDL 渲染。
+- `--planner-model`：指定自然语言 Planner 使用的模型。
 - `--verbose`：将节点进度日志输出到 stderr。
 
 默认情况下，CLI 会把 WDL / JSON IR 等机器可消费内容写到 stdout，将状态、错误和校验信息写到 stderr，因此可以直接重定向生成 WDL：
@@ -81,7 +97,9 @@ uv run main.py --input examples/rnaseq_workflow_ir.json --no-check > workflow.wd
 
 ## 📥 支持的输入格式
 
-Planner 当前支持两类结构化输入：
+面向用户的主要入口是自然语言。系统会先用 LLM Planner 将需求转成结构化 Recipe Tool Plan，然后交给确定性编译链路处理。
+
+结构化输入用于开发、调试和集成测试，目前支持两类：
 
 1. **标准 Workflow IR**：直接提供 `workflow.calls` 和 `tasks`，适合精确控制每个 task 的命令、输入、输出和 runtime。
 2. **Recipe Tool Plan**：提供 `workflow.recipe` 和 `workflow.tool_calls`，由内置 recipe/tool catalog 自动解析为 Workflow IR。

--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ uv run main.py --input examples/rnaseq_deg_recipe_plan.json --output outputs/rna
 - `--save-planner-prompt`：保存完整 Planner prompt，方便调试模型输出。
 - `--print-ir`：打印 Planner 标准化后的 Workflow IR。
 - `--no-check`：跳过 `miniwdl` 语法校验，仅执行 IR 分析与 WDL 渲染。
+- `--fill-containers`：从离线候选映射补全缺失的 `runtime.docker`。
+- `--container-images`：读取 JSON/YAML 格式的 container 候选映射，并隐式启用 `--fill-containers`。
 - `--planner-model`：指定自然语言 Planner 使用的模型。
 - `--verbose`：将节点进度日志输出到 stderr。
 
@@ -104,6 +106,21 @@ uv run main.py \
   --prompt-file examples/rnaseq_deg_request.txt \
   --save-planner-prompt debug/planner_prompt.txt \
   --save-plan debug/plan.json \
+  --output outputs/rnaseq_deg.wdl
+```
+
+补全缺失 container 镜像时，可以传入离线映射。键使用 `tool@version`，值可以是单个镜像或候选镜像列表：
+
+```json
+{
+  "fastp@0.23.2": "quay.io/biocontainers/fastp:0.23.2--h5f740d0_0"
+}
+```
+
+```bash
+uv run main.py \
+  --input examples/rnaseq_deg_recipe_plan.json \
+  --container-images debug/container_images.json \
   --output outputs/rnaseq_deg.wdl
 ```
 
@@ -163,6 +180,7 @@ Recipe Tool Plan 示例：
 - [x] 接入 Recipe / Tool Catalog 输入到 LangGraph Planner。
 - [x] 闭环修复机制初版：当分析器或校验器发现可确定修复的问题时，优先修复 IR 并重新编译 WDL。
 - [x] 建立 Container Resolver 的 provider 接口与离线测试基础。
+- [x] CLI 支持显式离线 container 镜像补全。
 - [ ] 接入 Biocontainers 镜像搜索节点，实现 Docker 地址的自动补全。
 
 ## 📄 许可证

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ LLM 在这个架构中更适合承担规划、补全、修复与解释任务；�
 - **Workflow IR 驱动**：将 workflow 调用关系与 task 定义分离，支持多个 task、复用 task 和明确的数据依赖。
 - **确定性 WDL 编译**：通过 Jinja2 Renderer 从 IR 生成 WDL，避免让 LLM 承担模板引擎职责。
 - **静态分析**：在渲染前检查 task/call 引用、输入完整性、上游输出引用和基础类型匹配。
+- **Recipe / Tool Catalog**：支持用预定义生信工具目录和分析配方生成 Workflow IR。
 - **Agentic 架构**：基于 LangGraph 串联 Planner、Analyzer、Renderer 与 Checker 节点，支持继续扩展 LLM planner / repairer。
 - **模块化设计**：高度解耦的 State、Prompts、Nodes 与 Tools 设计，极佳的代码可维护性。
 
@@ -58,6 +59,45 @@ uv run main.py
 ```
 *如果配置正确，终端将输出一段包含 `fastp` 和 `bwa_mem` 两个 task 的合规 WDL 代码。*
 
+## 📥 支持的输入格式
+
+Planner 当前支持两类结构化输入：
+
+1. **标准 Workflow IR**：直接提供 `workflow.calls` 和 `tasks`，适合精确控制每个 task 的命令、输入、输出和 runtime。
+2. **Recipe Tool Plan**：提供 `workflow.recipe` 和 `workflow.tool_calls`，由内置 recipe/tool catalog 自动解析为 Workflow IR。
+
+Recipe Tool Plan 示例：
+
+```json
+{
+  "workflow": {
+    "name": "RNASeqDEG",
+    "recipe": "rnaseq_differential_expression",
+    "inputs": {
+      "raw_r1": "File",
+      "raw_r2": "File",
+      "transcriptome_index": "File",
+      "sample_groups": "File"
+    },
+    "tool_calls": [
+      {
+        "id": "qc",
+        "step": "qc",
+        "tool": "fastp",
+        "version": "0.23.2",
+        "inputs": {
+          "r1": "raw_r1",
+          "r2": "raw_r2"
+        },
+        "params": {
+          "thread": 4
+        }
+      }
+    ]
+  }
+}
+```
+
 ## 🏗️ 架构与开发指南
 
 对于希望了解本项目底层实现原理、LangGraph 状态图设计，或有志于参与二次开发的工程师，请务必阅读我们的开发文档：
@@ -70,6 +110,7 @@ uv run main.py
 - [x] 实现从结构化 JSON 到 WDL 的单向代码生成。
 - [x] 引入 `miniwdl` / `womtool` 作为 Tool 节点，实现生成的 WDL 自动化本地校验。
 - [x] 引入 Workflow IR、静态分析器与确定性 WDL Renderer。
+- [x] 接入 Recipe / Tool Catalog 输入到 LangGraph Planner。
 - [ ] 闭环修复机制：当校验器报错时，优先修复 IR 而不是重写整份 WDL。
 - [ ] 接入 Biocontainers 镜像搜索节点，实现 Docker 地址的自动补全。
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,74 @@
-# AI-bioworkflow
+# AI-bioworkflow 🧬🤖
+
+[![Python Version](https://img.shields.io/badge/Python-3.10+-blue.svg?style=flat-square&logo=python&logoColor=white)](https://www.python.org/)
+[![Package Manager: uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg?style=flat-square)](./LICENSE)
+[![Framework](https://img.shields.io/badge/Agent-LangGraph-1C3C3C?style=flat-square)](https://github.com/langchain-ai/langgraph)
+[![Model](https://img.shields.io/badge/Model-DeepSeek_V4_Pro-4D6BFE?style=flat-square)](https://www.deepseek.com/)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](http://makeapullrequest.com)
+
+
+AI-bioworkflow 是一个基于大语言模型（LLM）驱动的生物信息学工作流生成智能体（Agent）。
+本项目利用 **LangGraph** 构建稳健的状态流转架构，并接入 **DeepSeek V4 Pro** 模型，能够将用户提供的结构化表单（JSON）自动翻译为标准、合规的 **WDL (Workflow Description Language) 1.0** 代码。
+
+## ✨ 核心特性
+
+- **结构化驱动**：摒弃纯自然语言的模糊性，通过结构化 JSON 保证上下游步骤变量传递的准确性。
+- **Agentic 架构**：基于 LangGraph 构建的多节点智能体架构，支持灵活扩展（未来将支持自动化闭环语法校验与查错）。
+- **DeepSeek 强力驱动**：使用 `deepseek-v4-pro`（已深度优化 Tool Calling 并关闭发散思考模式），提供卓越的代码生成质量。
+- **模块化设计**：高度解耦的 State、Prompts、Nodes 与 Tools 设计，极佳的代码可维护性。
+
+## 🛠️ 快速开始
+
+### 1. 环境准备
+
+确保你的本地开发环境已安装以下基础工具：
+- Python 3.10+
+- [uv](https://github.com/astral-sh/uv) (极速的 Python 包管理器)
+
+### 2. 克隆与安装
+
+```bash
+# 克隆仓库
+git clone [https://github.com/yourusername/AI-bioworkflow.git](https://github.com/yourusername/AI-bioworkflow.git)
+cd AI-bioworkflow
+
+# 使用 uv 同步依赖并创建虚拟环境
+uv sync
+```
+
+### 3. 配置环境变量
+
+在项目根目录下创建一个 `.env` 文件，并填入你的 DeepSeek API 密钥。**请务必不要将此文件提交到版本控制系统中！**
+
+```env
+# .env 文件内容
+DEEPSEEK_API_KEY="sk-你的真实API密钥"
+```
+
+### 4. 运行 MVP 测试
+
+执行主入口文件，验证 Agent 是否能正常根据预设的 JSON 生成 WDL 代码：
+
+```bash
+uv run main.py
+```
+*如果配置正确，终端将在几秒钟后输出一段完整的、包含 fastp 质控步骤的合规 WDL 代码。*
+
+## 🏗️ 架构与开发指南
+
+对于希望了解本项目底层实现原理、LangGraph 状态图设计，或有志于参与二次开发的工程师，请务必阅读我们的开发文档：
+
+👉 **[查看 DEVELOPMENT.md 开发指南](./DEVELOPMENT.md)**
+
+## 📅 未来路线图 (Roadmap)
+
+- [x] 搭建基础 LangGraph 状态机与 DeepSeek 连通。
+- [x] 实现从结构化 JSON 到 WDL 的单向代码生成。
+- [x] 引入 `miniwdl` / `womtool` 作为 Tool 节点，实现生成的 WDL 自动化本地校验。
+- [x] 闭环重试机制：当校验器报错时，将 Error Message 返回给大模型进行自我修复。
+- [ ] 接入 Biocontainers 镜像搜索节点，实现 Docker 地址的自动补全。
+
+## 📄 许可证
+
+[Apache License 2.0](./LICENSE)

--- a/README.md
+++ b/README.md
@@ -50,14 +50,34 @@ uv sync
 DEEPSEEK_API_KEY="sk-你的真实API密钥"
 ```
 
-### 4. 运行 MVP 测试
+### 4. 编译工作流
 
-执行主入口文件，验证 Agent 是否能正常根据预设的多 task Workflow IR 生成并校验 WDL 代码：
+无参数运行时会使用内置 demo，并打印生成的 WDL：
 
 ```bash
 uv run main.py
 ```
 *如果配置正确，终端将输出一段包含 `fastp` 和 `bwa_mem` 两个 task 的合规 WDL 代码。*
+
+也可以传入 JSON/YAML 文件并写出 WDL：
+
+```bash
+uv run main.py --input examples/rnaseq_deg_recipe_plan.json --output outputs/rnaseq_deg.wdl
+```
+
+常用选项：
+
+- `--input` / `-i`：读取标准 Workflow IR 或 Recipe Tool Plan。
+- `--output` / `-o`：写出生成的 WDL；不传则打印到终端。
+- `--print-ir`：打印 Planner 标准化后的 Workflow IR。
+- `--no-check`：跳过 `miniwdl` 语法校验，仅执行 IR 分析与 WDL 渲染。
+- `--verbose`：将节点进度日志输出到 stderr。
+
+默认情况下，CLI 会把 WDL / JSON IR 等机器可消费内容写到 stdout，将状态、错误和校验信息写到 stderr，因此可以直接重定向生成 WDL：
+
+```bash
+uv run main.py --input examples/rnaseq_workflow_ir.json --no-check > workflow.wdl
+```
 
 ## 📥 支持的输入格式
 

--- a/examples/rnaseq_deg_recipe_plan.json
+++ b/examples/rnaseq_deg_recipe_plan.json
@@ -1,0 +1,57 @@
+{
+  "workflow": {
+    "name": "RNASeqDEG",
+    "recipe": "rnaseq_differential_expression",
+    "inputs": {
+      "raw_r1": "File",
+      "raw_r2": "File",
+      "transcriptome_index": "File",
+      "sample_groups": "File"
+    },
+    "tool_calls": [
+      {
+        "id": "qc",
+        "step": "qc",
+        "tool": "fastp",
+        "version": "0.23.2",
+        "inputs": {
+          "r1": "raw_r1",
+          "r2": "raw_r2"
+        },
+        "params": {
+          "thread": 4
+        }
+      },
+      {
+        "id": "quantify",
+        "step": "quantify",
+        "tool": "salmon",
+        "version": "1.10.2",
+        "inputs": {
+          "r1": "qc.clean_r1",
+          "r2": "qc.clean_r2",
+          "index": "transcriptome_index"
+        },
+        "params": {
+          "thread": 8
+        }
+      },
+      {
+        "id": "deg",
+        "step": "differential_expression",
+        "tool": "deseq2",
+        "version": "1.42.0",
+        "inputs": {
+          "counts": "quantify.gene_counts",
+          "sample_groups": "sample_groups"
+        },
+        "params": {
+          "contrast": "condition"
+        }
+      }
+    ],
+    "outputs": {
+      "deg_table": "deg.deg_table"
+    }
+  }
+}

--- a/examples/rnaseq_deg_request.txt
+++ b/examples/rnaseq_deg_request.txt
@@ -1,0 +1,9 @@
+Build a bulk RNA-seq differential expression workflow.
+
+Inputs:
+- paired-end FASTQ files
+- a Salmon transcriptome index
+- a sample metadata table with group labels
+
+Run fastp for read quality control, Salmon for quantification, and DESeq2 for
+differential expression. Return the differential expression table.

--- a/examples/rnaseq_workflow_ir.json
+++ b/examples/rnaseq_workflow_ir.json
@@ -1,0 +1,75 @@
+{
+  "workflow": {
+    "name": "RNASeqPipeline",
+    "inputs": {
+      "raw_r1": "File",
+      "raw_r2": "File",
+      "reference": "File"
+    },
+    "calls": [
+      {
+        "id": "qc",
+        "task": "fastp",
+        "inputs": {
+          "r1": "raw_r1",
+          "r2": "raw_r2"
+        }
+      },
+      {
+        "id": "align",
+        "task": "bwa_mem",
+        "inputs": {
+          "r1": "qc.clean_r1",
+          "r2": "qc.clean_r2",
+          "ref": "reference"
+        }
+      }
+    ],
+    "outputs": {
+      "bam": "align.bam"
+    }
+  },
+  "tasks": {
+    "fastp": {
+      "inputs": {
+        "r1": "File",
+        "r2": "File"
+      },
+      "command": "fastp -i ~{r1} -I ~{r2} -o clean_R1.fq.gz -O clean_R2.fq.gz",
+      "outputs": {
+        "clean_r1": {
+          "type": "File",
+          "value": "\"clean_R1.fq.gz\""
+        },
+        "clean_r2": {
+          "type": "File",
+          "value": "\"clean_R2.fq.gz\""
+        }
+      },
+      "runtime": {
+        "docker": "quay.io/biocontainers/fastp:0.23.2",
+        "cpu": 4,
+        "memory": "8G"
+      }
+    },
+    "bwa_mem": {
+      "inputs": {
+        "r1": "File",
+        "r2": "File",
+        "ref": "File"
+      },
+      "command": "bwa mem ~{ref} ~{r1} ~{r2} > aligned.sam",
+      "outputs": {
+        "bam": {
+          "type": "File",
+          "value": "\"aligned.sam\""
+        }
+      },
+      "runtime": {
+        "docker": "quay.io/biocontainers/bwa:0.7.17--hed695b0_7",
+        "cpu": 8,
+        "memory": "32G"
+      }
+    }
+  }
+}

--- a/main.py
+++ b/main.py
@@ -1,6 +1,8 @@
 import os
 from dotenv import load_dotenv
 
+from src.state import WorkflowState
+
 # 确保在导入任何核心逻辑前加载环境变量
 load_dotenv()
 
@@ -33,7 +35,7 @@ def main():
     }
     
     # 初始化状态笔记本
-    initial_state = {
+    initial_state: WorkflowState = {
         "parsed_json": mock_user_input,
         "messages": [],
         "current_wdl": "",

--- a/main.py
+++ b/main.py
@@ -9,7 +9,12 @@ import yaml
 from dotenv import load_dotenv
 
 from src.graph import agent
-from src.nl_planner import DEFAULT_PLANNER_MODEL, plan_from_natural_language
+from src.nl_planner import (
+    DEFAULT_PLANNER_MODEL,
+    NaturalLanguagePlanningError,
+    build_default_planner_prompt,
+    create_natural_language_plan,
+)
 from src.nodes.analyzer import analyzer_node
 from src.nodes.planner import planner_node
 from src.nodes.renderer import renderer_node
@@ -144,6 +149,16 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Print the structured plan produced from natural language before compilation.",
     )
     parser.add_argument(
+        "--save-plan",
+        type=Path,
+        help="Write the structured plan produced from natural language to JSON.",
+    )
+    parser.add_argument(
+        "--save-planner-prompt",
+        type=Path,
+        help="Write the full natural-language planner prompt to a text file for debugging.",
+    )
+    parser.add_argument(
         "--no-check",
         action="store_true",
         help="Skip miniwdl syntax validation after rendering.",
@@ -223,6 +238,16 @@ def write_wdl_output(path: Path, wdl_code: str) -> None:
     path.write_text(wdl_code, encoding="utf-8")
 
 
+def write_json_output(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+
+def write_text_output(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
 def workflow_succeeded(state: WorkflowState, check: bool) -> bool:
     if state["analysis_errors"]:
         return False
@@ -242,10 +267,22 @@ def main(argv: list[str] | None = None) -> int:
             planned_from_natural_language = False
         else:
             prompt = load_prompt(args.prompt, args.prompt_file)
-            parsed_json = plan_from_natural_language(prompt, model=args.planner_model)
+            if args.save_planner_prompt:
+                write_text_output(args.save_planner_prompt, build_default_planner_prompt(prompt))
+                print(f"Planner prompt written to {args.save_planner_prompt}", file=sys.stderr)
+
+            plan_result = create_natural_language_plan(prompt, model=args.planner_model)
+            parsed_json = plan_result.plan
             planned_from_natural_language = True
 
+            if args.save_plan:
+                write_json_output(args.save_plan, parsed_json)
+                print(f"Planner plan written to {args.save_plan}", file=sys.stderr)
+
         final_state = compile_workflow(parsed_json, check=check)
+    except NaturalLanguagePlanningError as exc:
+        print(f"Natural language planning failed: {exc}", file=sys.stderr)
+        return 1
     except Exception as exc:
         print(f"Compilation failed before workflow execution: {exc}", file=sys.stderr)
         return 1

--- a/main.py
+++ b/main.py
@@ -9,6 +9,7 @@ import yaml
 from dotenv import load_dotenv
 
 from src.graph import agent
+from src.nl_planner import DEFAULT_PLANNER_MODEL, plan_from_natural_language
 from src.nodes.analyzer import analyzer_node
 from src.nodes.planner import planner_node
 from src.nodes.renderer import renderer_node
@@ -17,6 +18,14 @@ from src.state import WorkflowState
 
 
 load_dotenv()
+
+
+DEMO_PROMPT = """
+Build a bulk RNA-seq differential expression workflow. The inputs are paired-end
+FASTQ files, a Salmon transcriptome index, and a sample metadata table. Run fastp
+for read QC, Salmon for quantification, and DESeq2 for differential expression.
+Return the differential expression table as the workflow output.
+""".strip()
 
 
 DEMO_INPUT: dict[str, Any] = {
@@ -98,14 +107,26 @@ DEMO_INPUT: dict[str, Any] = {
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Compile a Workflow IR or Recipe Tool Plan into WDL.",
+        description="Plan and compile a bioinformatics workflow into WDL.",
     )
-    parser.add_argument(
+
+    source = parser.add_mutually_exclusive_group()
+    source.add_argument(
+        "--prompt",
+        help="Natural-language workflow request. Uses a built-in RNA-seq demo prompt if no source is provided.",
+    )
+    source.add_argument(
+        "--prompt-file",
+        type=Path,
+        help="Path to a UTF-8 text file containing a natural-language workflow request.",
+    )
+    source.add_argument(
         "-i",
         "--input",
         type=Path,
-        help="Path to a JSON/YAML Workflow IR or Recipe Tool Plan. Uses a built-in demo if omitted.",
+        help="Developer mode: path to a JSON/YAML Workflow IR or Recipe Tool Plan.",
     )
+
     parser.add_argument(
         "-o",
         "--output",
@@ -118,9 +139,19 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Print the normalized Workflow IR after compilation.",
     )
     parser.add_argument(
+        "--print-plan",
+        action="store_true",
+        help="Print the structured plan produced from natural language before compilation.",
+    )
+    parser.add_argument(
         "--no-check",
         action="store_true",
         help="Skip miniwdl syntax validation after rendering.",
+    )
+    parser.add_argument(
+        "--planner-model",
+        default=DEFAULT_PLANNER_MODEL,
+        help=f"LLM model for natural-language planning. Default: {DEFAULT_PLANNER_MODEL}.",
     )
     parser.add_argument(
         "--verbose",
@@ -130,7 +161,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
-def load_workflow_input(path: Path | None) -> dict[str, Any]:
+def load_workflow_input(path: Path | None = None) -> dict[str, Any]:
     if path is None:
         return DEMO_INPUT
 
@@ -143,6 +174,14 @@ def load_workflow_input(path: Path | None) -> dict[str, Any]:
     if not isinstance(data, dict):
         raise ValueError(f"workflow input must be a JSON/YAML object: {path}")
     return data
+
+
+def load_prompt(prompt: str | None = None, prompt_file: Path | None = None) -> str:
+    if prompt_file is not None:
+        return prompt_file.read_text(encoding="utf-8").strip()
+    if prompt is not None:
+        return prompt.strip()
+    return DEMO_PROMPT
 
 
 def build_initial_state(parsed_json: dict[str, Any]) -> WorkflowState:
@@ -198,13 +237,23 @@ def main(argv: list[str] | None = None) -> int:
     check = not args.no_check
 
     try:
-        parsed_json = load_workflow_input(args.input)
+        if args.input:
+            parsed_json = load_workflow_input(args.input)
+            planned_from_natural_language = False
+        else:
+            prompt = load_prompt(args.prompt, args.prompt_file)
+            parsed_json = plan_from_natural_language(prompt, model=args.planner_model)
+            planned_from_natural_language = True
+
         final_state = compile_workflow(parsed_json, check=check)
     except Exception as exc:
         print(f"Compilation failed before workflow execution: {exc}", file=sys.stderr)
         return 1
 
     _print_report(final_state, check=check)
+
+    if args.print_plan and planned_from_natural_language:
+        print(json.dumps(parsed_json, indent=2, ensure_ascii=False))
 
     if args.print_ir and final_state["workflow_ir"]:
         print(json.dumps(final_state["workflow_ir"], indent=2, ensure_ascii=False))

--- a/main.py
+++ b/main.py
@@ -8,6 +8,7 @@ from typing import Any, Mapping, cast
 import yaml
 from dotenv import load_dotenv
 
+from src.catalog import parse_tool_version_key
 from src.graph import agent
 from src.nl_planner import (
     DEFAULT_PLANNER_MODEL,
@@ -164,6 +165,19 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Skip miniwdl syntax validation after rendering.",
     )
     parser.add_argument(
+        "--fill-containers",
+        action="store_true",
+        help="Fill missing runtime.docker values from offline container image candidates.",
+    )
+    parser.add_argument(
+        "--container-images",
+        type=Path,
+        help=(
+            "Path to a JSON/YAML map of '<tool>@<version>' to image or image list. "
+            "Implies --fill-containers."
+        ),
+    )
+    parser.add_argument(
         "--planner-model",
         default=DEFAULT_PLANNER_MODEL,
         help=f"LLM model for natural-language planning. Default: {DEFAULT_PLANNER_MODEL}.",
@@ -199,9 +213,48 @@ def load_prompt(prompt: str | None = None, prompt_file: Path | None = None) -> s
     return DEMO_PROMPT
 
 
-def build_initial_state(parsed_json: dict[str, Any]) -> WorkflowState:
+def load_container_image_candidates(path: Path) -> dict[str, list[str]]:
+    raw_text = path.read_text(encoding="utf-8")
+    if path.suffix.lower() in {".yaml", ".yml"}:
+        data = yaml.safe_load(raw_text)
+    else:
+        data = json.loads(raw_text)
+
+    if not isinstance(data, dict):
+        raise ValueError(f"container image map must be a JSON/YAML object: {path}")
+
+    normalized: dict[str, list[str]] = {}
+    for key, value in data.items():
+        if not isinstance(key, str):
+            raise ValueError(f"container image map keys must be strings: {path}")
+        parse_tool_version_key(key)
+
+        if isinstance(value, str):
+            candidates = [value]
+        elif isinstance(value, list) and all(isinstance(candidate, str) for candidate in value):
+            candidates = value
+        else:
+            raise ValueError(
+                "container image map values must be an image string or list of image strings"
+            )
+
+        if not candidates:
+            raise ValueError(f"container image map entry has no candidates: {key}")
+        normalized[key] = candidates
+
+    return normalized
+
+
+def build_initial_state(
+    parsed_json: dict[str, Any],
+    *,
+    fill_containers: bool = False,
+    container_image_candidates: dict[str, list[str]] | None = None,
+) -> WorkflowState:
     return {
         "parsed_json": parsed_json,
+        "fill_containers": fill_containers,
+        "container_image_candidates": container_image_candidates or {},
         "workflow_ir": {},
         "analysis_errors": [],
         "analysis_warnings": [],
@@ -215,8 +268,18 @@ def build_initial_state(parsed_json: dict[str, Any]) -> WorkflowState:
     }
 
 
-def compile_workflow(parsed_json: dict[str, Any], check: bool = True) -> WorkflowState:
-    state = build_initial_state(parsed_json)
+def compile_workflow(
+    parsed_json: dict[str, Any],
+    check: bool = True,
+    *,
+    fill_containers: bool = False,
+    container_image_candidates: dict[str, list[str]] | None = None,
+) -> WorkflowState:
+    state = build_initial_state(
+        parsed_json,
+        fill_containers=fill_containers,
+        container_image_candidates=container_image_candidates,
+    )
     if check:
         return cast(WorkflowState, agent.invoke(state))
 
@@ -279,7 +342,17 @@ def main(argv: list[str] | None = None) -> int:
                 write_json_output(args.save_plan, parsed_json)
                 print(f"Planner plan written to {args.save_plan}", file=sys.stderr)
 
-        final_state = compile_workflow(parsed_json, check=check)
+        container_image_candidates = (
+            load_container_image_candidates(args.container_images)
+            if args.container_images
+            else {}
+        )
+        final_state = compile_workflow(
+            parsed_json,
+            check=check,
+            fill_containers=args.fill_containers or bool(container_image_candidates),
+            container_image_candidates=container_image_candidates,
+        )
     except NaturalLanguagePlanningError as exc:
         print(f"Natural language planning failed: {exc}", file=sys.stderr)
         return 1

--- a/main.py
+++ b/main.py
@@ -1,4 +1,5 @@
 import os
+
 from dotenv import load_dotenv
 
 from src.state import WorkflowState
@@ -12,6 +13,7 @@ if not os.environ.get("DEEPSEEK_API_KEY"):
 
 # 导入我们编译好的总 Agent
 from src.graph import agent
+
 
 def main():
     print("🚀 启动 AI-bioworkflow MVP 测试...\n")

--- a/main.py
+++ b/main.py
@@ -1,15 +1,9 @@
-import os
-
 from dotenv import load_dotenv
 
 from src.state import WorkflowState
 
-# 确保在导入任何核心逻辑前加载环境变量
+# 仍然加载 .env，后续如果接入 LLM planner / repairer 可以直接复用
 load_dotenv()
-
-# 检查 API Key 是否存在
-if not os.environ.get("DEEPSEEK_API_KEY"):
-    raise ValueError("未找到 DEEPSEEK_API_KEY，请检查 .env 文件是否配置正确！")
 
 # 导入我们编译好的总 Agent
 from src.graph import agent
@@ -18,40 +12,103 @@ from src.graph import agent
 def main():
     print("🚀 启动 AI-bioworkflow MVP 测试...\n")
     
-    # 模拟用户在前端界面填写的结构化表单
+    # 模拟用户在前端界面填写或由 LLM planner 产出的标准 Workflow IR
     mock_user_input = {
-        "workflow_name": "SimpleQC",
-        "inputs": {
-            "raw_fastq": "File"
+        "workflow": {
+            "name": "RNASeqPipeline",
+            "inputs": {
+                "raw_r1": "File",
+                "raw_r2": "File",
+                "reference": "File"
+            },
+            "calls": [
+                {
+                    "id": "qc",
+                    "task": "fastp",
+                    "inputs": {
+                        "r1": "raw_r1",
+                        "r2": "raw_r2"
+                    }
+                },
+                {
+                    "id": "align",
+                    "task": "bwa_mem",
+                    "inputs": {
+                        "r1": "qc.clean_r1",
+                        "r2": "qc.clean_r2",
+                        "ref": "reference"
+                    }
+                }
+            ],
+            "outputs": {
+                "bam": "align.bam"
+            }
         },
-        "tasks": [
-            {
-                "name": "fastp_qc",
-                "docker": "quay.io/biocontainers/fastp:0.23.2",
-                "command": "fastp -i ~{raw_fastq} -o out.fq",
+        "tasks": {
+            "fastp": {
+                "inputs": {
+                    "r1": "File",
+                    "r2": "File"
+                },
+                "command": "fastp -i ~{r1} -I ~{r2} -o clean_R1.fq.gz -O clean_R2.fq.gz",
                 "outputs": {
-                    "clean_fastq": "File"
+                    "clean_r1": {
+                        "type": "File",
+                        "value": "\"clean_R1.fq.gz\""
+                    },
+                    "clean_r2": {
+                        "type": "File",
+                        "value": "\"clean_R2.fq.gz\""
+                    }
+                },
+                "runtime": {
+                    "docker": "quay.io/biocontainers/fastp:0.23.2",
+                    "cpu": 4,
+                    "memory": "8G"
+                }
+            },
+            "bwa_mem": {
+                "inputs": {
+                    "r1": "File",
+                    "r2": "File",
+                    "ref": "File"
+                },
+                "command": "bwa mem ~{ref} ~{r1} ~{r2} > aligned.sam",
+                "outputs": {
+                    "bam": {
+                        "type": "File",
+                        "value": "\"aligned.sam\""
+                    }
+                },
+                "runtime": {
+                    "docker": "quay.io/biocontainers/bwa:0.7.17--hed695b0_7",
+                    "cpu": 8,
+                    "memory": "32G"
                 }
             }
-        ]
+        }
     }
     
     # 初始化状态笔记本
     initial_state: WorkflowState = {
         "parsed_json": mock_user_input,
+        "workflow_ir": {},
+        "analysis_errors": [],
+        "analysis_warnings": [],
         "messages": [],
         "current_wdl": "",
+        "validation_message": "",
         "error_count": 0,
         "is_valid": False
     }
     
     # 启动 Agent！
-    print("⏳ 正在请求 DeepSeek 生成代码，请稍候...")
+    print("⏳ 正在标准化 IR、渲染 WDL 并运行 miniwdl 校验...")
     final_state = agent.invoke(initial_state)
     
     # 打印最终结果
     print("\n" + "="*50)
-    print("🎉 WDL 生成成功！以下是代码：\n")
+    print("🎉 WDL 生成完成！以下是代码：\n")
     print(final_state["current_wdl"])
     print("="*50)
 

--- a/main.py
+++ b/main.py
@@ -99,6 +99,8 @@ def main():
         "current_wdl": "",
         "validation_message": "",
         "error_count": 0,
+        "repair_count": 0,
+        "repair_actions": [],
         "is_valid": False
     }
     

--- a/main.py
+++ b/main.py
@@ -1,97 +1,153 @@
+import argparse
+import json
+import logging
+import sys
+from pathlib import Path
+from typing import Any, Mapping, cast
+
+import yaml
 from dotenv import load_dotenv
 
+from src.graph import agent
+from src.nodes.analyzer import analyzer_node
+from src.nodes.planner import planner_node
+from src.nodes.renderer import renderer_node
+from src.nodes.repairer import repairer_node
 from src.state import WorkflowState
 
-# 仍然加载 .env，后续如果接入 LLM planner / repairer 可以直接复用
+
 load_dotenv()
 
-# 导入我们编译好的总 Agent
-from src.graph import agent
 
-
-def main():
-    print("🚀 启动 AI-bioworkflow MVP 测试...\n")
-    
-    # 模拟用户在前端界面填写或由 LLM planner 产出的标准 Workflow IR
-    mock_user_input = {
-        "workflow": {
-            "name": "RNASeqPipeline",
-            "inputs": {
-                "raw_r1": "File",
-                "raw_r2": "File",
-                "reference": "File"
-            },
-            "calls": [
-                {
-                    "id": "qc",
-                    "task": "fastp",
-                    "inputs": {
-                        "r1": "raw_r1",
-                        "r2": "raw_r2"
-                    }
-                },
-                {
-                    "id": "align",
-                    "task": "bwa_mem",
-                    "inputs": {
-                        "r1": "qc.clean_r1",
-                        "r2": "qc.clean_r2",
-                        "ref": "reference"
-                    }
-                }
-            ],
-            "outputs": {
-                "bam": "align.bam"
-            }
+DEMO_INPUT: dict[str, Any] = {
+    "workflow": {
+        "name": "RNASeqPipeline",
+        "inputs": {
+            "raw_r1": "File",
+            "raw_r2": "File",
+            "reference": "File",
         },
-        "tasks": {
-            "fastp": {
+        "calls": [
+            {
+                "id": "qc",
+                "task": "fastp",
                 "inputs": {
-                    "r1": "File",
-                    "r2": "File"
+                    "r1": "raw_r1",
+                    "r2": "raw_r2",
                 },
-                "command": "fastp -i ~{r1} -I ~{r2} -o clean_R1.fq.gz -O clean_R2.fq.gz",
-                "outputs": {
-                    "clean_r1": {
-                        "type": "File",
-                        "value": "\"clean_R1.fq.gz\""
-                    },
-                    "clean_r2": {
-                        "type": "File",
-                        "value": "\"clean_R2.fq.gz\""
-                    }
-                },
-                "runtime": {
-                    "docker": "quay.io/biocontainers/fastp:0.23.2",
-                    "cpu": 4,
-                    "memory": "8G"
-                }
             },
-            "bwa_mem": {
+            {
+                "id": "align",
+                "task": "bwa_mem",
                 "inputs": {
-                    "r1": "File",
-                    "r2": "File",
-                    "ref": "File"
+                    "r1": "qc.clean_r1",
+                    "r2": "qc.clean_r2",
+                    "ref": "reference",
                 },
-                "command": "bwa mem ~{ref} ~{r1} ~{r2} > aligned.sam",
-                "outputs": {
-                    "bam": {
-                        "type": "File",
-                        "value": "\"aligned.sam\""
-                    }
+            },
+        ],
+        "outputs": {
+            "bam": "align.bam",
+        },
+    },
+    "tasks": {
+        "fastp": {
+            "inputs": {
+                "r1": "File",
+                "r2": "File",
+            },
+            "command": "fastp -i ~{r1} -I ~{r2} -o clean_R1.fq.gz -O clean_R2.fq.gz",
+            "outputs": {
+                "clean_r1": {
+                    "type": "File",
+                    "value": "\"clean_R1.fq.gz\"",
                 },
-                "runtime": {
-                    "docker": "quay.io/biocontainers/bwa:0.7.17--hed695b0_7",
-                    "cpu": 8,
-                    "memory": "32G"
-                }
-            }
-        }
-    }
-    
-    # 初始化状态笔记本
-    initial_state: WorkflowState = {
-        "parsed_json": mock_user_input,
+                "clean_r2": {
+                    "type": "File",
+                    "value": "\"clean_R2.fq.gz\"",
+                },
+            },
+            "runtime": {
+                "docker": "quay.io/biocontainers/fastp:0.23.2",
+                "cpu": 4,
+                "memory": "8G",
+            },
+        },
+        "bwa_mem": {
+            "inputs": {
+                "r1": "File",
+                "r2": "File",
+                "ref": "File",
+            },
+            "command": "bwa mem ~{ref} ~{r1} ~{r2} > aligned.sam",
+            "outputs": {
+                "bam": {
+                    "type": "File",
+                    "value": "\"aligned.sam\"",
+                },
+            },
+            "runtime": {
+                "docker": "quay.io/biocontainers/bwa:0.7.17--hed695b0_7",
+                "cpu": 8,
+                "memory": "32G",
+            },
+        },
+    },
+}
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Compile a Workflow IR or Recipe Tool Plan into WDL.",
+    )
+    parser.add_argument(
+        "-i",
+        "--input",
+        type=Path,
+        help="Path to a JSON/YAML Workflow IR or Recipe Tool Plan. Uses a built-in demo if omitted.",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        help="Path where the generated WDL should be written. Prints WDL when omitted.",
+    )
+    parser.add_argument(
+        "--print-ir",
+        action="store_true",
+        help="Print the normalized Workflow IR after compilation.",
+    )
+    parser.add_argument(
+        "--no-check",
+        action="store_true",
+        help="Skip miniwdl syntax validation after rendering.",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Write workflow progress logs to stderr.",
+    )
+    return parser.parse_args(argv)
+
+
+def load_workflow_input(path: Path | None) -> dict[str, Any]:
+    if path is None:
+        return DEMO_INPUT
+
+    raw_text = path.read_text(encoding="utf-8")
+    if path.suffix.lower() in {".yaml", ".yml"}:
+        data = yaml.safe_load(raw_text)
+    else:
+        data = json.loads(raw_text)
+
+    if not isinstance(data, dict):
+        raise ValueError(f"workflow input must be a JSON/YAML object: {path}")
+    return data
+
+
+def build_initial_state(parsed_json: dict[str, Any]) -> WorkflowState:
+    return {
+        "parsed_json": parsed_json,
         "workflow_ir": {},
         "analysis_errors": [],
         "analysis_warnings": [],
@@ -101,18 +157,131 @@ def main():
         "error_count": 0,
         "repair_count": 0,
         "repair_actions": [],
-        "is_valid": False
+        "is_valid": False,
     }
-    
-    # 启动 Agent！
-    print("⏳ 正在标准化 IR、渲染 WDL 并运行 miniwdl 校验...")
-    final_state = agent.invoke(initial_state)
-    
-    # 打印最终结果
-    print("\n" + "="*50)
-    print("🎉 WDL 生成完成！以下是代码：\n")
-    print(final_state["current_wdl"])
-    print("="*50)
+
+
+def compile_workflow(parsed_json: dict[str, Any], check: bool = True) -> WorkflowState:
+    state = build_initial_state(parsed_json)
+    if check:
+        return cast(WorkflowState, agent.invoke(state))
+
+    _merge_state(state, planner_node(state))
+    if state["analysis_errors"]:
+        return state
+
+    _analyze_with_repair(state)
+    if state["analysis_errors"]:
+        return state
+
+    _merge_state(state, renderer_node(state))
+    state["validation_message"] = "WDL syntax validation skipped (--no-check)."
+    return state
+
+
+def write_wdl_output(path: Path, wdl_code: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(wdl_code, encoding="utf-8")
+
+
+def workflow_succeeded(state: WorkflowState, check: bool) -> bool:
+    if state["analysis_errors"]:
+        return False
+    if not state["current_wdl"]:
+        return False
+    return state["is_valid"] if check else True
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    configure_logging(verbose=args.verbose)
+    check = not args.no_check
+
+    try:
+        parsed_json = load_workflow_input(args.input)
+        final_state = compile_workflow(parsed_json, check=check)
+    except Exception as exc:
+        print(f"Compilation failed before workflow execution: {exc}", file=sys.stderr)
+        return 1
+
+    _print_report(final_state, check=check)
+
+    if args.print_ir and final_state["workflow_ir"]:
+        print(json.dumps(final_state["workflow_ir"], indent=2, ensure_ascii=False))
+
+    if not workflow_succeeded(final_state, check=check):
+        return 1
+
+    if args.output:
+        write_wdl_output(args.output, final_state["current_wdl"])
+        print(f"WDL written to {args.output}", file=sys.stderr)
+    else:
+        print(final_state["current_wdl"])
+
+    return 0
+
+
+def configure_logging(verbose: bool = False) -> None:
+    logging.basicConfig(
+        level=logging.INFO if verbose else logging.WARNING,
+        format="%(message)s",
+        stream=sys.stderr,
+        force=True,
+    )
+
+
+def _analyze_with_repair(state: WorkflowState) -> None:
+    while True:
+        _merge_state(state, analyzer_node(state))
+        if not state["analysis_errors"]:
+            return
+
+        _merge_state(state, repairer_node(state))
+        if not state["repair_actions"]:
+            return
+
+
+def _merge_state(state: WorkflowState, update: Mapping[str, Any]) -> None:
+    for key, value in update.items():
+        if key == "messages":
+            state["messages"] = state["messages"] + value
+        elif key == "parsed_json":
+            state["parsed_json"] = value
+        elif key == "workflow_ir":
+            state["workflow_ir"] = value
+        elif key == "analysis_errors":
+            state["analysis_errors"] = value
+        elif key == "analysis_warnings":
+            state["analysis_warnings"] = value
+        elif key == "current_wdl":
+            state["current_wdl"] = value
+        elif key == "validation_message":
+            state["validation_message"] = value
+        elif key == "error_count":
+            state["error_count"] = value
+        elif key == "repair_count":
+            state["repair_count"] = value
+        elif key == "repair_actions":
+            state["repair_actions"] = value
+        elif key == "is_valid":
+            state["is_valid"] = value
+
+
+def _print_report(state: WorkflowState, check: bool) -> None:
+    for action in state["repair_actions"]:
+        print(f"repair: {action}", file=sys.stderr)
+
+    for warning in state["analysis_warnings"]:
+        print(f"warning: {warning}", file=sys.stderr)
+
+    for error in state["analysis_errors"]:
+        print(f"error: {error}", file=sys.stderr)
+
+    if check and state["validation_message"]:
+        print(state["validation_message"], file=sys.stderr)
+    elif not check and state["validation_message"]:
+        print(state["validation_message"], file=sys.stderr)
+
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/main.py
+++ b/main.py
@@ -1,0 +1,54 @@
+import os
+from dotenv import load_dotenv
+
+# 确保在导入任何核心逻辑前加载环境变量
+load_dotenv()
+
+# 检查 API Key 是否存在
+if not os.environ.get("DEEPSEEK_API_KEY"):
+    raise ValueError("未找到 DEEPSEEK_API_KEY，请检查 .env 文件是否配置正确！")
+
+# 导入我们编译好的总 Agent
+from src.graph import agent
+
+def main():
+    print("🚀 启动 AI-bioworkflow MVP 测试...\n")
+    
+    # 模拟用户在前端界面填写的结构化表单
+    mock_user_input = {
+        "workflow_name": "SimpleQC",
+        "inputs": {
+            "raw_fastq": "File"
+        },
+        "tasks": [
+            {
+                "name": "fastp_qc",
+                "docker": "quay.io/biocontainers/fastp:0.23.2",
+                "command": "fastp -i ~{raw_fastq} -o out.fq",
+                "outputs": {
+                    "clean_fastq": "File"
+                }
+            }
+        ]
+    }
+    
+    # 初始化状态笔记本
+    initial_state = {
+        "parsed_json": mock_user_input,
+        "messages": [],
+        "current_wdl": "",
+        "error_count": 0
+    }
+    
+    # 启动 Agent！
+    print("⏳ 正在请求 DeepSeek 生成代码，请稍候...")
+    final_state = agent.invoke(initial_state)
+    
+    # 打印最终结果
+    print("\n" + "="*50)
+    print("🎉 WDL 生成成功！以下是代码：\n")
+    print(final_state["current_wdl"])
+    print("="*50)
+
+if __name__ == "__main__":
+    main()

--- a/main.py
+++ b/main.py
@@ -39,7 +39,8 @@ def main():
         "parsed_json": mock_user_input,
         "messages": [],
         "current_wdl": "",
-        "error_count": 0
+        "error_count": 0,
+        "is_valid": False
     }
     
     # 启动 Agent！

--- a/main.py
+++ b/main.py
@@ -1,0 +1,57 @@
+import os
+from dotenv import load_dotenv
+
+from src.state import WorkflowState
+
+# 确保在导入任何核心逻辑前加载环境变量
+load_dotenv()
+
+# 检查 API Key 是否存在
+if not os.environ.get("DEEPSEEK_API_KEY"):
+    raise ValueError("未找到 DEEPSEEK_API_KEY，请检查 .env 文件是否配置正确！")
+
+# 导入我们编译好的总 Agent
+from src.graph import agent
+
+def main():
+    print("🚀 启动 AI-bioworkflow MVP 测试...\n")
+    
+    # 模拟用户在前端界面填写的结构化表单
+    mock_user_input = {
+        "workflow_name": "SimpleQC",
+        "inputs": {
+            "raw_fastq": "File"
+        },
+        "tasks": [
+            {
+                "name": "fastp_qc",
+                "docker": "quay.io/biocontainers/fastp:0.23.2",
+                "command": "fastp -i ~{raw_fastq} -o out.fq",
+                "outputs": {
+                    "clean_fastq": "File"
+                }
+            }
+        ]
+    }
+    
+    # 初始化状态笔记本
+    initial_state: WorkflowState = {
+        "parsed_json": mock_user_input,
+        "messages": [],
+        "current_wdl": "",
+        "error_count": 0,
+        "is_valid": False
+    }
+    
+    # 启动 Agent！
+    print("⏳ 正在请求 DeepSeek 生成代码，请稍候...")
+    final_state = agent.invoke(initial_state)
+    
+    # 打印最终结果
+    print("\n" + "="*50)
+    print("🎉 WDL 生成成功！以下是代码：\n")
+    print(final_state["current_wdl"])
+    print("="*50)
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
+    "jinja2>=3.1.6",
     "langchain>=1.2.18",
     "langchain-anthropic>=1.4.3",
     "langchain-deepseek>=1.0.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,5 +11,6 @@ dependencies = [
     "langchain-deepseek>=1.0.1",
     "langchain-openai>=1.2.1",
     "langgraph>=1.1.10",
+    "miniwdl>=1.14.2",
     "python-dotenv>=1.2.2",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "ai-bioworkflow"
 version = "0.1.0"
-description = "Add your description here"
+description = "Agentic compiler for bioinformatics Workflow IR to WDL"
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "langgraph>=1.1.10",
     "miniwdl>=1.14.2",
     "python-dotenv>=1.2.2",
+    "pyyaml>=6.0.3",
 ]
 
 [dependency-groups]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,5 +5,8 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
+    "langchain>=1.2.18",
+    "langchain-anthropic>=1.4.3",
+    "langchain-openai>=1.2.1",
     "langgraph>=1.1.10",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,5 +5,12 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
+    "jinja2>=3.1.6",
+    "langchain>=1.2.18",
+    "langchain-anthropic>=1.4.3",
+    "langchain-deepseek>=1.0.1",
+    "langchain-openai>=1.2.1",
     "langgraph>=1.1.10",
+    "miniwdl>=1.14.2",
+    "python-dotenv>=1.2.2",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ requires-python = ">=3.13"
 dependencies = [
     "langchain>=1.2.18",
     "langchain-anthropic>=1.4.3",
+    "langchain-deepseek>=1.0.1",
     "langchain-openai>=1.2.1",
     "langgraph>=1.1.10",
     "python-dotenv>=1.2.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,4 +9,5 @@ dependencies = [
     "langchain-anthropic>=1.4.3",
     "langchain-openai>=1.2.1",
     "langgraph>=1.1.10",
+    "python-dotenv>=1.2.2",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,3 +14,8 @@ dependencies = [
     "miniwdl>=1.14.2",
     "python-dotenv>=1.2.2",
 ]
+
+[dependency-groups]
+dev = [
+    "isort>=8.0.1",
+]

--- a/src/analyzer.py
+++ b/src/analyzer.py
@@ -73,12 +73,17 @@ def _analyze_calls(ir: WorkflowIR, report: AnalysisReport) -> None:
             report.errors.append(f"call '{call.id}' references unknown task '{call.task}'")
             continue
 
-        expected_inputs = set(task.inputs)
+        expected_inputs = {
+            input_name
+            for input_name, input_type in task.inputs.items()
+            if not _is_optional_type(input_type)
+        }
+        declared_inputs = set(task.inputs)
         provided_inputs = set(call.inputs)
 
         for missing in sorted(expected_inputs - provided_inputs):
             report.errors.append(f"call '{call.id}' is missing input '{missing}'")
-        for unexpected in sorted(provided_inputs - expected_inputs):
+        for unexpected in sorted(provided_inputs - declared_inputs):
             report.errors.append(f"call '{call.id}' provides unknown input '{unexpected}'")
 
         for input_name, expression in call.inputs.items():
@@ -170,3 +175,7 @@ def _types_compatible(expected: str, actual: str) -> bool:
 
 def _normalize_type(value: str) -> str:
     return value.strip().rstrip("?")
+
+
+def _is_optional_type(value: str) -> bool:
+    return value.strip().endswith("?")

--- a/src/analyzer.py
+++ b/src/analyzer.py
@@ -1,0 +1,172 @@
+from dataclasses import dataclass, field
+
+from src.schema import IDENTIFIER_PATTERN, WorkflowIR, extract_command_inputs
+
+
+@dataclass
+class AnalysisReport:
+    errors: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+
+    @property
+    def is_valid(self) -> bool:
+        return not self.errors
+
+    def to_dict(self) -> dict:
+        return {
+            "is_valid": self.is_valid,
+            "errors": self.errors,
+            "warnings": self.warnings,
+        }
+
+
+def analyze_workflow_ir(ir: WorkflowIR) -> AnalysisReport:
+    report = AnalysisReport()
+
+    if not ir.tasks:
+        report.errors.append("workflow IR must define at least one task")
+    if not ir.workflow.calls:
+        report.errors.append("workflow must contain at least one call")
+
+    _analyze_tasks(ir, report)
+    _analyze_calls(ir, report)
+    _analyze_workflow_outputs(ir, report)
+
+    return report
+
+
+def resolve_workflow_output_type(ir: WorkflowIR, expression: str) -> str | None:
+    call_by_id = {call.id: call for call in ir.workflow.calls}
+    return _resolve_expression_type(ir, expression, call_by_id)
+
+
+def _analyze_tasks(ir: WorkflowIR, report: AnalysisReport) -> None:
+    for task_name, task in ir.tasks.items():
+        placeholders = extract_command_inputs(task.command)
+        for placeholder in sorted(placeholders):
+            if placeholder not in task.inputs:
+                report.errors.append(
+                    f"task '{task_name}' command references '~{{{placeholder}}}' "
+                    "but the input is not declared"
+                )
+
+        if not task.outputs:
+            report.warnings.append(f"task '{task_name}' does not declare outputs")
+
+        for output_name, output_spec in task.outputs.items():
+            if not output_spec.type:
+                report.errors.append(f"task '{task_name}' output '{output_name}' has empty type")
+            if not output_spec.value:
+                report.errors.append(f"task '{task_name}' output '{output_name}' has empty value")
+
+
+def _analyze_calls(ir: WorkflowIR, report: AnalysisReport) -> None:
+    seen_calls = {}
+
+    for call in ir.workflow.calls:
+        if call.id in seen_calls:
+            report.errors.append(f"duplicate call id '{call.id}'")
+            continue
+
+        task = ir.tasks.get(call.task)
+        if task is None:
+            report.errors.append(f"call '{call.id}' references unknown task '{call.task}'")
+            continue
+
+        expected_inputs = set(task.inputs)
+        provided_inputs = set(call.inputs)
+
+        for missing in sorted(expected_inputs - provided_inputs):
+            report.errors.append(f"call '{call.id}' is missing input '{missing}'")
+        for unexpected in sorted(provided_inputs - expected_inputs):
+            report.errors.append(f"call '{call.id}' provides unknown input '{unexpected}'")
+
+        for input_name, expression in call.inputs.items():
+            if input_name not in task.inputs:
+                continue
+
+            source_type = _resolve_expression_type(ir, expression, seen_calls)
+            target_type = task.inputs[input_name]
+
+            if source_type is None:
+                if "." in expression:
+                    report.errors.append(
+                        f"call '{call.id}' input '{input_name}' references unavailable output "
+                        f"'{expression}'"
+                    )
+                elif _looks_like_unknown_identifier(expression):
+                    report.errors.append(
+                        f"call '{call.id}' input '{input_name}' references unknown value '{expression}'"
+                    )
+                continue
+
+            if not _types_compatible(target_type, source_type):
+                report.errors.append(
+                    f"call '{call.id}' input '{input_name}' expects {target_type} "
+                    f"but received {source_type} from '{expression}'"
+                )
+
+        seen_calls[call.id] = call
+
+
+def _analyze_workflow_outputs(ir: WorkflowIR, report: AnalysisReport) -> None:
+    call_by_id = {call.id: call for call in ir.workflow.calls}
+    for output_name, expression in ir.workflow.outputs.items():
+        output_type = _resolve_expression_type(ir, expression, call_by_id)
+        if output_type is None:
+            report.errors.append(
+                f"workflow output '{output_name}' references unknown value '{expression}'"
+            )
+
+
+def _resolve_expression_type(
+    ir: WorkflowIR,
+    expression: str,
+    available_calls: dict,
+) -> str | None:
+    expression = expression.strip()
+
+    if expression in ir.workflow.inputs:
+        return ir.workflow.inputs[expression]
+
+    literal_type = _infer_literal_type(expression)
+    if literal_type:
+        return literal_type
+
+    if "." in expression:
+        call_id, output_name = expression.split(".", 1)
+        call = available_calls.get(call_id)
+        if call is None:
+            return None
+        task = ir.tasks.get(call.task)
+        if task is None or output_name not in task.outputs:
+            return None
+        return task.outputs[output_name].type
+
+    return None
+
+
+def _infer_literal_type(expression: str) -> str | None:
+    if expression.startswith('"') and expression.endswith('"'):
+        return "String"
+    if expression in {"true", "false"}:
+        return "Boolean"
+    if expression.isdigit() or (expression.startswith("-") and expression[1:].isdigit()):
+        return "Int"
+    try:
+        float(expression)
+    except ValueError:
+        return None
+    return "Float"
+
+
+def _looks_like_unknown_identifier(expression: str) -> bool:
+    return bool(IDENTIFIER_PATTERN.match(expression))
+
+
+def _types_compatible(expected: str, actual: str) -> bool:
+    return _normalize_type(expected) == _normalize_type(actual)
+
+
+def _normalize_type(value: str) -> str:
+    return value.strip().rstrip("?")

--- a/src/catalog/__init__.py
+++ b/src/catalog/__init__.py
@@ -1,0 +1,6 @@
+from src.catalog.loader import ToolCatalog, load_tool_catalog
+from src.catalog.resolver import resolve_tool_plan
+from src.catalog.schema import ToolSpec
+
+
+__all__ = ["ToolCatalog", "ToolSpec", "load_tool_catalog", "resolve_tool_plan"]

--- a/src/catalog/__init__.py
+++ b/src/catalog/__init__.py
@@ -6,7 +6,9 @@ from src.catalog.container_resolver import (
     ContainerResolutionError,
     StaticContainerImageProvider,
     fill_missing_tool_container,
+    parse_tool_version_key,
     resolve_tool_container,
+    static_provider_from_image_map,
 )
 from src.catalog.loader import ToolCatalog, load_tool_catalog
 from src.catalog.resolver import resolve_tool_plan
@@ -24,6 +26,8 @@ __all__ = [
     "ToolSpec",
     "fill_missing_tool_container",
     "load_tool_catalog",
+    "parse_tool_version_key",
     "resolve_tool_container",
     "resolve_tool_plan",
+    "static_provider_from_image_map",
 ]

--- a/src/catalog/__init__.py
+++ b/src/catalog/__init__.py
@@ -1,6 +1,29 @@
+from src.catalog.container_resolver import (
+    AmbiguousContainerImageError,
+    ContainerImageCandidate,
+    ContainerImageNotFoundError,
+    ContainerImageProvider,
+    ContainerResolutionError,
+    StaticContainerImageProvider,
+    fill_missing_tool_container,
+    resolve_tool_container,
+)
 from src.catalog.loader import ToolCatalog, load_tool_catalog
 from src.catalog.resolver import resolve_tool_plan
 from src.catalog.schema import ToolSpec
 
 
-__all__ = ["ToolCatalog", "ToolSpec", "load_tool_catalog", "resolve_tool_plan"]
+__all__ = [
+    "AmbiguousContainerImageError",
+    "ContainerImageCandidate",
+    "ContainerImageNotFoundError",
+    "ContainerImageProvider",
+    "ContainerResolutionError",
+    "StaticContainerImageProvider",
+    "ToolCatalog",
+    "ToolSpec",
+    "fill_missing_tool_container",
+    "load_tool_catalog",
+    "resolve_tool_container",
+    "resolve_tool_plan",
+]

--- a/src/catalog/container_resolver.py
+++ b/src/catalog/container_resolver.py
@@ -1,0 +1,95 @@
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Protocol
+
+from src.catalog.schema import ToolSpec
+
+
+@dataclass(frozen=True)
+class ContainerImageCandidate:
+    image: str
+    source: str = "static"
+
+
+class ContainerResolutionError(ValueError):
+    pass
+
+
+class ContainerImageNotFoundError(ContainerResolutionError):
+    pass
+
+
+class AmbiguousContainerImageError(ContainerResolutionError):
+    pass
+
+
+class ContainerImageProvider(Protocol):
+    def search(
+        self,
+        tool_id: str,
+        version: str,
+        aliases: Sequence[str] = (),
+    ) -> Sequence[ContainerImageCandidate]:
+        ...
+
+
+ImageCandidateInput = str | ContainerImageCandidate
+
+
+class StaticContainerImageProvider:
+    """Offline provider used by tests and deterministic local development."""
+
+    def __init__(self, images: Mapping[tuple[str, str], Sequence[ImageCandidateInput]]):
+        self._images = {
+            key: tuple(_coerce_candidate(candidate) for candidate in candidates)
+            for key, candidates in images.items()
+        }
+
+    def search(
+        self,
+        tool_id: str,
+        version: str,
+        aliases: Sequence[str] = (),
+    ) -> Sequence[ContainerImageCandidate]:
+        return list(self._images.get((tool_id, version), ()))
+
+
+def resolve_tool_container(
+    tool: ToolSpec,
+    provider: ContainerImageProvider,
+) -> str:
+    """Return the docker image for a tool, consulting the provider only when missing."""
+    if tool.runtime.docker:
+        return tool.runtime.docker
+
+    candidates = list(provider.search(tool.id, tool.version, aliases=tool.aliases))
+    if not candidates:
+        raise ContainerImageNotFoundError(
+            f"no container image found for tool '{tool.id}@{tool.version}'"
+        )
+    if len(candidates) > 1:
+        images = ", ".join(candidate.image for candidate in candidates)
+        raise AmbiguousContainerImageError(
+            f"multiple container images found for tool '{tool.id}@{tool.version}': {images}"
+        )
+
+    return candidates[0].image
+
+
+def fill_missing_tool_container(
+    tool: ToolSpec,
+    provider: ContainerImageProvider,
+) -> ToolSpec:
+    """Return a ToolSpec with runtime.docker populated when it is missing."""
+    if tool.runtime.docker:
+        return tool
+
+    docker = resolve_tool_container(tool, provider)
+    runtime = tool.runtime.model_copy(update={"docker": docker})
+    return tool.model_copy(update={"runtime": runtime})
+
+
+def _coerce_candidate(candidate: ImageCandidateInput) -> ContainerImageCandidate:
+    if isinstance(candidate, ContainerImageCandidate):
+        return candidate
+    return ContainerImageCandidate(image=candidate)

--- a/src/catalog/container_resolver.py
+++ b/src/catalog/container_resolver.py
@@ -54,6 +54,30 @@ class StaticContainerImageProvider:
         return list(self._images.get((tool_id, version), ()))
 
 
+def static_provider_from_image_map(
+    images: Mapping[str, str | Sequence[ImageCandidateInput]],
+) -> StaticContainerImageProvider:
+    normalized: dict[tuple[str, str], list[ImageCandidateInput]] = {}
+    for key, candidates in images.items():
+        tool_id, version = parse_tool_version_key(key)
+        if isinstance(candidates, str) or isinstance(candidates, ContainerImageCandidate):
+            candidate_values = [candidates]
+        else:
+            candidate_values = list(candidates)
+        normalized[(tool_id, version)] = candidate_values
+    return StaticContainerImageProvider(normalized)
+
+
+def parse_tool_version_key(key: str) -> tuple[str, str]:
+    if "@" not in key:
+        raise ValueError(f"container image key must use '<tool>@<version>': {key!r}")
+
+    tool_id, version = key.split("@", 1)
+    if not tool_id or not version:
+        raise ValueError(f"container image key must use '<tool>@<version>': {key!r}")
+    return tool_id, version
+
+
 def resolve_tool_container(
     tool: ToolSpec,
     provider: ContainerImageProvider,

--- a/src/catalog/loader.py
+++ b/src/catalog/loader.py
@@ -1,0 +1,50 @@
+from pathlib import Path
+
+import yaml
+
+from src.catalog.schema import ToolSpec
+
+
+DEFAULT_TOOL_DIR = Path(__file__).parent / "tools"
+
+
+class ToolCatalog:
+    def __init__(self, tools: dict[tuple[str, str], ToolSpec]):
+        self._tools = tools
+
+    def get(self, tool_id: str, version: str) -> ToolSpec:
+        key = (tool_id, version)
+        if key not in self._tools:
+            raise KeyError(f"unknown tool version: {tool_id}@{version}")
+        return self._tools[key]
+
+    def has_tool_id(self, tool_id: str) -> bool:
+        return any(candidate_id == tool_id for candidate_id, _version in self._tools)
+
+    def versions(self, tool_id: str) -> list[str]:
+        return sorted(version for candidate_id, version in self._tools if candidate_id == tool_id)
+
+    def all(self) -> list[ToolSpec]:
+        return list(self._tools.values())
+
+
+def load_tool_catalog(root: str | Path = DEFAULT_TOOL_DIR) -> ToolCatalog:
+    root_path = Path(root)
+    tools: dict[tuple[str, str], ToolSpec] = {}
+
+    for yaml_path in sorted(root_path.rglob("*.yaml")):
+        spec = ToolSpec.model_validate(_load_yaml(yaml_path))
+        key = (spec.id, spec.version)
+        if key in tools:
+            raise ValueError(f"duplicate tool definition: {spec.id}@{spec.version}")
+        tools[key] = spec
+
+    return ToolCatalog(tools)
+
+
+def _load_yaml(path: Path) -> dict:
+    with path.open("r", encoding="utf-8") as handle:
+        data = yaml.safe_load(handle)
+    if not isinstance(data, dict):
+        raise ValueError(f"YAML file must contain a mapping: {path}")
+    return data

--- a/src/catalog/resolver.py
+++ b/src/catalog/resolver.py
@@ -10,6 +10,7 @@ from src.catalog.schema import (
     ToolParamSpec,
     ToolSpec,
     validate_identifier,
+    validate_mapping_keys,
     validate_value_range,
     validate_value_type,
 )
@@ -50,6 +51,18 @@ class PlannedWorkflow(BaseModel):
         validate_identifier(value, "planned workflow identifier")
         return value
 
+    @field_validator("inputs")
+    @classmethod
+    def validate_input_names(cls, value: dict[str, str]) -> dict[str, str]:
+        validate_mapping_keys(value, "planned workflow input")
+        return value
+
+    @field_validator("outputs")
+    @classmethod
+    def validate_output_names(cls, value: dict[str, str]) -> dict[str, str]:
+        validate_mapping_keys(value, "planned workflow output")
+        return value
+
     @model_validator(mode="after")
     def validate_call_ids(self):
         seen_call_ids = set()
@@ -73,6 +86,7 @@ def resolve_tool_plan(
 ) -> WorkflowIR:
     plan = plan_data if isinstance(plan_data, ToolCallPlan) else ToolCallPlan.model_validate(plan_data)
     recipe = recipe_catalog.get(plan.workflow.recipe)
+    validate_recipe_plan(plan, recipe)
 
     task_defs: dict[str, dict[str, Any]] = {}
     calls: list[dict[str, Any]] = []
@@ -136,9 +150,33 @@ def validate_recipe_plan(plan_data: ToolCallPlan | dict[str, Any], recipe: Recip
         raise ValueError(f"plan references recipe '{plan.workflow.recipe}', expected '{recipe.id}'")
 
     known_steps = {step.id for step in recipe.steps}
+    required_steps = {step.id for step in recipe.steps if not step.optional}
+    planned_steps = []
     for tool_call in plan.workflow.tool_calls:
         if tool_call.step not in known_steps:
             raise ValueError(f"tool call '{tool_call.id}' references unknown recipe step '{tool_call.step}'")
+        planned_steps.append(tool_call.step)
+
+    duplicate_steps = _duplicates(planned_steps)
+    if duplicate_steps:
+        joined = ", ".join(duplicate_steps)
+        raise ValueError(f"duplicate tool calls for recipe step(s): {joined}")
+
+    missing_steps = sorted(required_steps - set(planned_steps))
+    if missing_steps:
+        joined = ", ".join(missing_steps)
+        raise ValueError(f"plan is missing required recipe step(s): {joined}")
+
+    for input_name, spec in recipe.required_inputs.items():
+        if input_name not in plan.workflow.inputs:
+            raise ValueError(f"plan is missing required workflow input '{input_name}'")
+
+        provided_type = plan.workflow.inputs[input_name]
+        if not _types_compatible(spec.type, provided_type):
+            raise ValueError(
+                f"workflow input '{input_name}' expects {spec.type} "
+                f"but received {provided_type}"
+            )
 
 
 def _task_inputs_for_tool(tool: ToolSpec) -> dict[str, str]:
@@ -153,6 +191,20 @@ def _task_inputs_for_tool(tool: ToolSpec) -> dict[str, str]:
         inputs[param_name] = param_spec.type
 
     return inputs
+
+
+def _duplicates(values: list[str]) -> list[str]:
+    seen = set()
+    duplicates = []
+    for value in values:
+        if value in seen and value not in duplicates:
+            duplicates.append(value)
+        seen.add(value)
+    return duplicates
+
+
+def _types_compatible(expected: str, actual: str) -> bool:
+    return expected.strip().rstrip("?") == actual.strip().rstrip("?")
 
 
 def _resolve_inputs(tool_call: PlannedToolCall, tool: ToolSpec) -> dict[str, str]:

--- a/src/catalog/resolver.py
+++ b/src/catalog/resolver.py
@@ -5,6 +5,7 @@ from typing import Any
 from jinja2 import Environment, StrictUndefined
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
+from src.catalog.container_resolver import ContainerImageProvider, fill_missing_tool_container
 from src.catalog.loader import ToolCatalog
 from src.catalog.schema import (
     ToolParamSpec,
@@ -83,6 +84,7 @@ def resolve_tool_plan(
     plan_data: ToolCallPlan | dict[str, Any],
     recipe_catalog: RecipeCatalog,
     tool_catalog: ToolCatalog,
+    container_provider: ContainerImageProvider | None = None,
 ) -> WorkflowIR:
     plan = plan_data if isinstance(plan_data, ToolCallPlan) else ToolCallPlan.model_validate(plan_data)
     recipe = recipe_catalog.get(plan.workflow.recipe)
@@ -100,6 +102,8 @@ def resolve_tool_plan(
             )
 
         tool = tool_catalog.get(tool_call.tool, tool_call.version)
+        if container_provider is not None:
+            tool = fill_missing_tool_container(tool, container_provider)
         task_name = _task_name_for_call(tool_call)
         task_inputs = _task_inputs_for_tool(tool)
         params = _resolve_params(tool_call, tool)

--- a/src/catalog/resolver.py
+++ b/src/catalog/resolver.py
@@ -1,0 +1,256 @@
+import json
+import re
+from typing import Any
+
+from jinja2 import Environment, StrictUndefined
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from src.catalog.loader import ToolCatalog
+from src.catalog.schema import (
+    ToolParamSpec,
+    ToolSpec,
+    validate_identifier,
+    validate_value_range,
+    validate_value_type,
+)
+from src.recipes.loader import RecipeCatalog
+from src.recipes.schema import RecipeSpec
+from src.schema import WorkflowIR
+
+
+class PlannedToolCall(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    step: str
+    tool: str
+    version: str
+    inputs: dict[str, str] = Field(default_factory=dict)
+    params: dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator("id", "step", "tool")
+    @classmethod
+    def validate_ids(cls, value: str) -> str:
+        validate_identifier(value, "planned tool call identifier")
+        return value
+
+
+class PlannedWorkflow(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    recipe: str
+    inputs: dict[str, str] = Field(default_factory=dict)
+    tool_calls: list[PlannedToolCall] = Field(default_factory=list)
+    outputs: dict[str, str] = Field(default_factory=dict)
+
+    @field_validator("name", "recipe")
+    @classmethod
+    def validate_workflow_ids(cls, value: str) -> str:
+        validate_identifier(value, "planned workflow identifier")
+        return value
+
+    @model_validator(mode="after")
+    def validate_call_ids(self):
+        seen_call_ids = set()
+        for tool_call in self.tool_calls:
+            if tool_call.id in seen_call_ids:
+                raise ValueError(f"duplicate tool call id: {tool_call.id}")
+            seen_call_ids.add(tool_call.id)
+        return self
+
+
+class ToolCallPlan(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    workflow: PlannedWorkflow
+
+
+def resolve_tool_plan(
+    plan_data: ToolCallPlan | dict[str, Any],
+    recipe_catalog: RecipeCatalog,
+    tool_catalog: ToolCatalog,
+) -> WorkflowIR:
+    plan = plan_data if isinstance(plan_data, ToolCallPlan) else ToolCallPlan.model_validate(plan_data)
+    recipe = recipe_catalog.get(plan.workflow.recipe)
+
+    task_defs: dict[str, dict[str, Any]] = {}
+    calls: list[dict[str, Any]] = []
+
+    for tool_call in plan.workflow.tool_calls:
+        step = recipe.step_by_id(tool_call.step)
+        if tool_call.tool not in step.allowed_tools:
+            raise ValueError(
+                f"tool call '{tool_call.id}' uses tool '{tool_call.tool}', "
+                f"which is not allowed for recipe step '{tool_call.step}'"
+            )
+
+        tool = tool_catalog.get(tool_call.tool, tool_call.version)
+        task_name = _task_name_for_call(tool_call)
+        task_inputs = _task_inputs_for_tool(tool)
+        params = _resolve_params(tool_call, tool)
+        command = _render_command(tool, tool_call, params)
+
+        task_defs[task_name] = {
+            "inputs": task_inputs,
+            "command": command,
+            "outputs": {
+                output_name: output.model_dump(mode="json", exclude_none=True)
+                for output_name, output in tool.outputs.items()
+            },
+            "runtime": tool.runtime.model_dump(mode="json", exclude_none=True),
+        }
+
+        calls.append(
+            {
+                "id": tool_call.id,
+                "task": task_name,
+                "inputs": {
+                    **_resolve_inputs(tool_call, tool),
+                    **{
+                        param_name: _format_wdl_literal(param_value)
+                        for param_name, param_value in params.items()
+                    },
+                },
+            }
+        )
+
+    workflow_outputs = plan.workflow.outputs or _default_workflow_outputs(calls, task_defs)
+    return WorkflowIR.model_validate(
+        {
+            "version": "1.0",
+            "workflow": {
+                "name": plan.workflow.name,
+                "inputs": plan.workflow.inputs,
+                "calls": calls,
+                "outputs": workflow_outputs,
+            },
+            "tasks": task_defs,
+        }
+    )
+
+
+def validate_recipe_plan(plan_data: ToolCallPlan | dict[str, Any], recipe: RecipeSpec) -> None:
+    plan = plan_data if isinstance(plan_data, ToolCallPlan) else ToolCallPlan.model_validate(plan_data)
+    if plan.workflow.recipe != recipe.id:
+        raise ValueError(f"plan references recipe '{plan.workflow.recipe}', expected '{recipe.id}'")
+
+    known_steps = {step.id for step in recipe.steps}
+    for tool_call in plan.workflow.tool_calls:
+        if tool_call.step not in known_steps:
+            raise ValueError(f"tool call '{tool_call.id}' references unknown recipe step '{tool_call.step}'")
+
+
+def _task_inputs_for_tool(tool: ToolSpec) -> dict[str, str]:
+    inputs = {}
+    for input_name, input_spec in tool.inputs.items():
+        input_type = input_spec.type
+        if not input_spec.required and not input_type.endswith("?"):
+            input_type = f"{input_type}?"
+        inputs[input_name] = input_type
+
+    for param_name, param_spec in tool.params.items():
+        inputs[param_name] = param_spec.type
+
+    return inputs
+
+
+def _resolve_inputs(tool_call: PlannedToolCall, tool: ToolSpec) -> dict[str, str]:
+    provided = set(tool_call.inputs)
+    expected = set(tool.inputs)
+
+    for unexpected in sorted(provided - expected):
+        raise ValueError(f"tool call '{tool_call.id}' provides unknown input '{unexpected}'")
+    for input_name, spec in tool.inputs.items():
+        if spec.required and input_name not in tool_call.inputs:
+            raise ValueError(f"tool call '{tool_call.id}' is missing required input '{input_name}'")
+
+    return dict(tool_call.inputs)
+
+
+def _resolve_params(tool_call: PlannedToolCall, tool: ToolSpec) -> dict[str, Any]:
+    provided = set(tool_call.params)
+    expected = set(tool.params)
+
+    for unexpected in sorted(provided - expected):
+        raise ValueError(f"tool call '{tool_call.id}' provides unknown param '{unexpected}'")
+
+    resolved = {}
+    for param_name, spec in tool.params.items():
+        if param_name in tool_call.params:
+            value = tool_call.params[param_name]
+        elif spec.default is not None:
+            value = spec.default
+        elif spec.required:
+            raise ValueError(f"tool call '{tool_call.id}' is missing required param '{param_name}'")
+        else:
+            continue
+
+        _validate_param_value(tool_call.id, param_name, value, spec)
+        resolved[param_name] = value
+
+    return resolved
+
+
+def _validate_param_value(
+    call_id: str,
+    param_name: str,
+    value: Any,
+    spec: ToolParamSpec,
+) -> None:
+    try:
+        validate_value_type(param_name, value, spec.type)
+        validate_value_range(param_name, value, spec)
+    except ValueError as exc:
+        raise ValueError(f"tool call '{call_id}' invalid param '{param_name}': {exc}") from exc
+
+
+def _render_command(
+    tool: ToolSpec,
+    tool_call: PlannedToolCall,
+    params: dict[str, Any],
+) -> str:
+    env = Environment(undefined=StrictUndefined, trim_blocks=True, lstrip_blocks=True)
+    template = env.from_string(tool.command_template)
+    context = {
+        input_name: input_name in tool_call.inputs
+        for input_name in tool.inputs
+    }
+    context.update(params)
+
+    rendered = template.render(**context)
+    return "\n".join(line.rstrip() for line in rendered.strip().splitlines() if line.strip())
+
+
+def _default_workflow_outputs(
+    calls: list[dict[str, Any]],
+    task_defs: dict[str, dict[str, Any]],
+) -> dict[str, str]:
+    if not calls:
+        return {}
+
+    last_call = calls[-1]
+    last_task = task_defs[last_call["task"]]
+    return {
+        output_name: f"{last_call['id']}.{output_name}"
+        for output_name in last_task["outputs"]
+    }
+
+
+def _task_name_for_call(tool_call: PlannedToolCall) -> str:
+    return _sanitize_identifier(f"{tool_call.tool}_{tool_call.id}")
+
+
+def _sanitize_identifier(value: str) -> str:
+    sanitized = re.sub(r"[^A-Za-z0-9_]", "_", value)
+    if not re.match(r"^[A-Za-z_]", sanitized):
+        sanitized = f"task_{sanitized}"
+    return sanitized
+
+
+def _format_wdl_literal(value: Any) -> str:
+    if isinstance(value, str):
+        return json.dumps(value)
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    return str(value)

--- a/src/catalog/resolver.py
+++ b/src/catalog/resolver.py
@@ -262,7 +262,7 @@ def _render_command(
     tool_call: PlannedToolCall,
     params: dict[str, Any],
 ) -> str:
-    env = Environment(undefined=StrictUndefined, trim_blocks=True, lstrip_blocks=True)
+    env = Environment(undefined=StrictUndefined, trim_blocks=False, lstrip_blocks=True)
     template = env.from_string(tool.command_template)
     context = {
         input_name: input_name in tool_call.inputs

--- a/src/catalog/schema.py
+++ b/src/catalog/schema.py
@@ -1,0 +1,125 @@
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from src.schema import IDENTIFIER_PATTERN, RuntimeSpec, extract_command_inputs
+
+
+WDL_PRIMITIVE_TYPES = {"Boolean", "File", "Float", "Int", "String"}
+
+
+class ToolInputSpec(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    type: str
+    required: bool = True
+    description: str | None = None
+
+
+class ToolParamSpec(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    type: Literal["Boolean", "Float", "Int", "String"]
+    required: bool = False
+    default: Any = None
+    min: int | float | None = None
+    max: int | float | None = None
+    choices: list[Any] | None = None
+    description: str | None = None
+
+    @model_validator(mode="after")
+    def validate_default(self):
+        if self.default is not None:
+            validate_value_type("default", self.default, self.type)
+            validate_value_range("default", self.default, self)
+        return self
+
+
+class ToolOutputSpec(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    type: str
+    value: str
+    description: str | None = None
+
+
+class ToolSpec(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    version: str
+    aliases: list[str] = Field(default_factory=list)
+    description: str = ""
+    inputs: dict[str, ToolInputSpec] = Field(default_factory=dict)
+    params: dict[str, ToolParamSpec] = Field(default_factory=dict)
+    outputs: dict[str, ToolOutputSpec] = Field(default_factory=dict)
+    command_template: str
+    runtime: RuntimeSpec = Field(default_factory=RuntimeSpec)
+
+    @field_validator("id")
+    @classmethod
+    def validate_id(cls, value: str) -> str:
+        validate_identifier(value, "tool id")
+        return value
+
+    @field_validator("inputs")
+    @classmethod
+    def validate_input_names(cls, value: dict[str, ToolInputSpec]) -> dict[str, ToolInputSpec]:
+        validate_mapping_keys(value, "tool input")
+        return value
+
+    @field_validator("params")
+    @classmethod
+    def validate_param_names(cls, value: dict[str, ToolParamSpec]) -> dict[str, ToolParamSpec]:
+        validate_mapping_keys(value, "tool param")
+        return value
+
+    @field_validator("outputs")
+    @classmethod
+    def validate_output_names(cls, value: dict[str, ToolOutputSpec]) -> dict[str, ToolOutputSpec]:
+        validate_mapping_keys(value, "tool output")
+        return value
+
+    @model_validator(mode="after")
+    def validate_command_template(self):
+        duplicate_names = set(self.inputs).intersection(self.params)
+        if duplicate_names:
+            joined = ", ".join(sorted(duplicate_names))
+            raise ValueError(f"tool '{self.id}' has duplicate input/param names: {joined}")
+
+        known_variables = set(self.inputs) | set(self.params)
+        for variable in sorted(extract_command_inputs(self.command_template) - known_variables):
+            raise ValueError(
+                f"tool '{self.id}' command_template references unknown variable '{variable}'"
+            )
+        return self
+
+
+def validate_identifier(value: str, label: str) -> None:
+    if not IDENTIFIER_PATTERN.match(value):
+        raise ValueError(f"invalid {label}: {value!r}")
+
+
+def validate_mapping_keys(value: dict[str, Any], label: str) -> None:
+    for key in value:
+        validate_identifier(key, label)
+
+
+def validate_value_type(label: str, value: Any, expected_type: str) -> None:
+    if expected_type == "Boolean" and not isinstance(value, bool):
+        raise ValueError(f"{label} must be Boolean")
+    if expected_type == "Float" and (not isinstance(value, int | float) or isinstance(value, bool)):
+        raise ValueError(f"{label} must be Float")
+    if expected_type == "Int" and (not isinstance(value, int) or isinstance(value, bool)):
+        raise ValueError(f"{label} must be Int")
+    if expected_type == "String" and not isinstance(value, str):
+        raise ValueError(f"{label} must be String")
+
+
+def validate_value_range(label: str, value: Any, spec: ToolParamSpec) -> None:
+    if spec.choices is not None and value not in spec.choices:
+        raise ValueError(f"{label} must be one of {spec.choices}")
+    if isinstance(value, int | float) and spec.min is not None and value < spec.min:
+        raise ValueError(f"{label} must be >= {spec.min}")
+    if isinstance(value, int | float) and spec.max is not None and value > spec.max:
+        raise ValueError(f"{label} must be <= {spec.max}")

--- a/src/catalog/tools/deseq2/1.42.0.yaml
+++ b/src/catalog/tools/deseq2/1.42.0.yaml
@@ -1,0 +1,38 @@
+id: deseq2
+version: "1.42.0"
+aliases:
+  - differential expression
+  - DEG
+description: Differential expression analysis from count matrix and sample groups.
+
+inputs:
+  counts:
+    type: File
+    required: true
+    description: Gene count matrix.
+  sample_groups:
+    type: File
+    required: true
+    description: Sample metadata and group labels.
+
+params:
+  contrast:
+    type: String
+    default: condition
+
+outputs:
+  deg_table:
+    type: File
+    value: '"differential_expression.tsv"'
+
+command_template: |
+  Rscript run_deseq2.R
+  --counts ~{counts}
+  --sample-groups ~{sample_groups}
+  --contrast ~{contrast}
+  --output differential_expression.tsv
+
+runtime:
+  docker: bioconductor/bioconductor_docker:RELEASE_3_18
+  cpu: 4
+  memory: 16G

--- a/src/catalog/tools/fastp/0.23.2.yaml
+++ b/src/catalog/tools/fastp/0.23.2.yaml
@@ -1,0 +1,48 @@
+id: fastp
+version: "0.23.2"
+aliases:
+  - fastq qc
+  - adapter trimming
+description: FASTQ quality control and adapter trimming.
+
+inputs:
+  r1:
+    type: File
+    required: true
+    description: First FASTQ read file.
+  r2:
+    type: File
+    required: false
+    description: Optional second FASTQ read file.
+
+params:
+  thread:
+    type: Int
+    default: 4
+    min: 1
+  qualified_quality_phred:
+    type: Int
+    default: 15
+    min: 0
+    max: 40
+
+outputs:
+  clean_r1:
+    type: File
+    value: '"clean_R1.fq.gz"'
+  clean_r2:
+    type: File
+    value: '"clean_R2.fq.gz"'
+
+command_template: |
+  fastp -i ~{r1}
+  {% if r2 %}-I ~{r2}{% endif %}
+  -o clean_R1.fq.gz
+  {% if r2 %}-O clean_R2.fq.gz{% endif %}
+  --thread ~{thread}
+  --qualified_quality_phred ~{qualified_quality_phred}
+
+runtime:
+  docker: quay.io/biocontainers/fastp:0.23.2
+  cpu: 4
+  memory: 8G

--- a/src/catalog/tools/salmon/1.10.2.yaml
+++ b/src/catalog/tools/salmon/1.10.2.yaml
@@ -1,0 +1,48 @@
+id: salmon
+version: "1.10.2"
+aliases:
+  - transcript quantification
+  - RNA-seq quantification
+description: Transcript-level quantification for RNA-seq reads.
+
+inputs:
+  r1:
+    type: File
+    required: true
+    description: First cleaned FASTQ read file.
+  r2:
+    type: File
+    required: true
+    description: Second cleaned FASTQ read file.
+  index:
+    type: File
+    required: true
+    description: Salmon transcriptome index.
+
+params:
+  thread:
+    type: Int
+    default: 8
+    min: 1
+
+outputs:
+  gene_counts:
+    type: File
+    value: '"gene_counts.tsv"'
+  quant_dir:
+    type: File
+    value: '"salmon_quant"'
+
+command_template: |
+  salmon quant
+  -i ~{index}
+  -1 ~{r1}
+  -2 ~{r2}
+  -p ~{thread}
+  -o salmon_quant
+  && touch gene_counts.tsv
+
+runtime:
+  docker: quay.io/biocontainers/salmon:1.10.2--h6dccd9a_2
+  cpu: 8
+  memory: 16G

--- a/src/graph.py
+++ b/src/graph.py
@@ -1,0 +1,20 @@
+from langgraph.graph import StateGraph, START, END
+from src.state import WorkflowState
+from src.nodes.coder import coder_node
+
+# 1. 实例化状态图，传入我们的 WorkflowState 笔记本
+builder = StateGraph(WorkflowState)
+
+# 2. 添加工作节点
+# 第一个参数是节点的内部名称（随便起），第二个参数是我们刚才写的处理函数
+builder.add_node("coder", coder_node)
+
+# 3. 规划工作流向 (连线)
+# START -> coder -> END
+builder.add_edge(START, "coder")
+builder.add_edge("coder", END)
+
+# 4. 编译打包成最终的 Agent
+agent = builder.compile()
+
+print("✅ Agent 图纸编译完成！")

--- a/src/graph.py
+++ b/src/graph.py
@@ -1,44 +1,48 @@
 from langgraph.graph import END, START, StateGraph
 
+from src.nodes.analyzer import analyzer_node
 from src.nodes.checker import checker_node
-from src.nodes.coder import coder_node
+from src.nodes.planner import planner_node
+from src.nodes.renderer import renderer_node
 from src.state import WorkflowState
 
 
-# --- 定义路由逻辑 (大脑) ---
-def router(state: WorkflowState):
-    """
-    决定下一步去哪里的十字路口警察
-    """
-    # 1. 安全锁：如果重试了 3 次还是错，强制下班，防止破产
-    if state["error_count"] >= 3:
-        print("⚠️ 超过最大重试次数 (3次)，强制结束流转。")
+def route_after_planner(state: WorkflowState):
+    if state.get("analysis_errors"):
         return END
-        
-    # 2. 检查最后一条消息的内容
-    last_message = state["messages"][-1]
-    
-    # 如果is_valid 是 False，说明 Checker 打回了错误消息，那么就让它回去 coder 重写
-    # 那就打回给 coder 重新写
-    if state.get("is_valid") is False:
-        return "coder"
-        
-    # 如果顺利通过（没有报错产生新的 HumanMessage），就顺利结束
+    return "analyzer"
+
+
+def route_after_analyzer(state: WorkflowState):
+    if state.get("analysis_errors"):
+        return END
+    return "renderer"
+
+
+def route_after_checker(_state: WorkflowState):
+    """
+    End after syntax validation. A future repairer can branch from here.
+    """
     return END
+
 
 # 1. 实例化状态图，传入我们的 WorkflowState 笔记本
 builder = StateGraph(WorkflowState)
 
 # 2. 添加工作节点
 # 第一个参数是节点的内部名称（随便起），第二个参数是我们刚才写的处理函数
-builder.add_node("coder", coder_node)
+builder.add_node("planner", planner_node)
+builder.add_node("analyzer", analyzer_node)
+builder.add_node("renderer", renderer_node)
 builder.add_node("checker", checker_node)
 
 # 3. 规划工作流向 (连线)
-# START -> coder -> checker -> END
-builder.add_edge(START, "coder")
-builder.add_edge("coder", "checker")
-builder.add_conditional_edges("checker", router)  # 根据 router 的判断，checker 可以去 coder 重试，或者直接去 END 结束
+# START -> planner -> analyzer -> renderer -> checker -> END
+builder.add_edge(START, "planner")
+builder.add_conditional_edges("planner", route_after_planner)
+builder.add_conditional_edges("analyzer", route_after_analyzer)
+builder.add_edge("renderer", "checker")
+builder.add_conditional_edges("checker", route_after_checker)
 # 4. 编译打包成最终的 Agent
 agent = builder.compile()
 

--- a/src/graph.py
+++ b/src/graph.py
@@ -1,6 +1,28 @@
 from langgraph.graph import StateGraph, START, END
 from src.state import WorkflowState
 from src.nodes.coder import coder_node
+from src.nodes.checker import checker_node
+
+# --- 定义路由逻辑 (大脑) ---
+def router(state: WorkflowState):
+    """
+    决定下一步去哪里的十字路口警察
+    """
+    # 1. 安全锁：如果重试了 3 次还是错，强制下班，防止破产
+    if state["error_count"] >= 3:
+        print("⚠️ 超过最大重试次数 (3次)，强制结束流转。")
+        return END
+        
+    # 2. 检查最后一条消息的内容
+    last_message = state["messages"][-1]
+    
+    # 如果is_valid 是 False，说明 Checker 打回了错误消息，那么就让它回去 coder 重写
+    # 那就打回给 coder 重新写
+    if state.get("is_valid") is False:
+        return "coder"
+        
+    # 如果顺利通过（没有报错产生新的 HumanMessage），就顺利结束
+    return END
 
 # 1. 实例化状态图，传入我们的 WorkflowState 笔记本
 builder = StateGraph(WorkflowState)
@@ -8,12 +30,13 @@ builder = StateGraph(WorkflowState)
 # 2. 添加工作节点
 # 第一个参数是节点的内部名称（随便起），第二个参数是我们刚才写的处理函数
 builder.add_node("coder", coder_node)
+builder.add_node("checker", checker_node)
 
 # 3. 规划工作流向 (连线)
-# START -> coder -> END
+# START -> coder -> checker -> END
 builder.add_edge(START, "coder")
-builder.add_edge("coder", END)
-
+builder.add_edge("coder", "checker")
+builder.add_conditional_edges("checker", router)  # 根据 router 的判断，checker 可以去 coder 重试，或者直接去 END 结束
 # 4. 编译打包成最终的 Agent
 agent = builder.compile()
 

--- a/src/graph.py
+++ b/src/graph.py
@@ -3,8 +3,12 @@ from langgraph.graph import END, START, StateGraph
 from src.nodes.analyzer import analyzer_node
 from src.nodes.checker import checker_node
 from src.nodes.planner import planner_node
+from src.nodes.repairer import repairer_node
 from src.nodes.renderer import renderer_node
 from src.state import WorkflowState
+
+
+MAX_REPAIR_ATTEMPTS = 2
 
 
 def route_after_planner(state: WorkflowState):
@@ -15,15 +19,34 @@ def route_after_planner(state: WorkflowState):
 
 def route_after_analyzer(state: WorkflowState):
     if state.get("analysis_errors"):
+        if _can_attempt_repair(state):
+            return "repairer"
         return END
     return "renderer"
 
 
-def route_after_checker(_state: WorkflowState):
-    """
-    End after syntax validation. A future repairer can branch from here.
-    """
+def route_after_checker(state: WorkflowState):
+    if state.get("is_valid"):
+        return END
+    if _missing_local_validator(state):
+        return END
+    if _can_attempt_repair(state):
+        return "repairer"
     return END
+
+
+def route_after_repairer(state: WorkflowState):
+    if state.get("repair_actions"):
+        return "analyzer"
+    return END
+
+
+def _can_attempt_repair(state: WorkflowState) -> bool:
+    return bool(state.get("workflow_ir")) and state.get("repair_count", 0) < MAX_REPAIR_ATTEMPTS
+
+
+def _missing_local_validator(state: WorkflowState) -> bool:
+    return "未找到 miniwdl" in state.get("validation_message", "")
 
 
 # 1. 实例化状态图，传入我们的 WorkflowState 笔记本
@@ -35,14 +58,17 @@ builder.add_node("planner", planner_node)
 builder.add_node("analyzer", analyzer_node)
 builder.add_node("renderer", renderer_node)
 builder.add_node("checker", checker_node)
+builder.add_node("repairer", repairer_node)
 
 # 3. 规划工作流向 (连线)
 # START -> planner -> analyzer -> renderer -> checker -> END
+# analyzer/checker can branch to repairer, then repairer returns to analyzer.
 builder.add_edge(START, "planner")
 builder.add_conditional_edges("planner", route_after_planner)
 builder.add_conditional_edges("analyzer", route_after_analyzer)
 builder.add_edge("renderer", "checker")
 builder.add_conditional_edges("checker", route_after_checker)
+builder.add_conditional_edges("repairer", route_after_repairer)
 # 4. 编译打包成最终的 Agent
 agent = builder.compile()
 

--- a/src/graph.py
+++ b/src/graph.py
@@ -1,3 +1,5 @@
+import logging
+
 from langgraph.graph import END, START, StateGraph
 
 from src.nodes.analyzer import analyzer_node
@@ -9,6 +11,7 @@ from src.state import WorkflowState
 
 
 MAX_REPAIR_ATTEMPTS = 2
+logger = logging.getLogger(__name__)
 
 
 def route_after_planner(state: WorkflowState):
@@ -72,4 +75,4 @@ builder.add_conditional_edges("repairer", route_after_repairer)
 # 4. 编译打包成最终的 Agent
 agent = builder.compile()
 
-print("✅ Agent 图纸编译完成！")
+logger.info("Agent graph compiled.")

--- a/src/graph.py
+++ b/src/graph.py
@@ -1,7 +1,9 @@
-from langgraph.graph import StateGraph, START, END
-from src.state import WorkflowState
-from src.nodes.coder import coder_node
+from langgraph.graph import END, START, StateGraph
+
 from src.nodes.checker import checker_node
+from src.nodes.coder import coder_node
+from src.state import WorkflowState
+
 
 # --- 定义路由逻辑 (大脑) ---
 def router(state: WorkflowState):

--- a/src/graph.py
+++ b/src/graph.py
@@ -1,0 +1,43 @@
+from langgraph.graph import StateGraph, START, END
+from src.state import WorkflowState
+from src.nodes.coder import coder_node
+from src.nodes.checker import checker_node
+
+# --- 定义路由逻辑 (大脑) ---
+def router(state: WorkflowState):
+    """
+    决定下一步去哪里的十字路口警察
+    """
+    # 1. 安全锁：如果重试了 3 次还是错，强制下班，防止破产
+    if state["error_count"] >= 3:
+        print("⚠️ 超过最大重试次数 (3次)，强制结束流转。")
+        return END
+        
+    # 2. 检查最后一条消息的内容
+    last_message = state["messages"][-1]
+    
+    # 如果is_valid 是 False，说明 Checker 打回了错误消息，那么就让它回去 coder 重写
+    # 那就打回给 coder 重新写
+    if state.get("is_valid") is False:
+        return "coder"
+        
+    # 如果顺利通过（没有报错产生新的 HumanMessage），就顺利结束
+    return END
+
+# 1. 实例化状态图，传入我们的 WorkflowState 笔记本
+builder = StateGraph(WorkflowState)
+
+# 2. 添加工作节点
+# 第一个参数是节点的内部名称（随便起），第二个参数是我们刚才写的处理函数
+builder.add_node("coder", coder_node)
+builder.add_node("checker", checker_node)
+
+# 3. 规划工作流向 (连线)
+# START -> coder -> checker -> END
+builder.add_edge(START, "coder")
+builder.add_edge("coder", "checker")
+builder.add_conditional_edges("checker", router)  # 根据 router 的判断，checker 可以去 coder 重试，或者直接去 END 结束
+# 4. 编译打包成最终的 Agent
+agent = builder.compile()
+
+print("✅ Agent 图纸编译完成！")

--- a/src/nl_planner.py
+++ b/src/nl_planner.py
@@ -1,6 +1,7 @@
 import json
 import os
 import re
+from dataclasses import dataclass
 from typing import Any, Protocol
 
 from langchain_deepseek import ChatDeepSeek
@@ -19,9 +20,28 @@ class NaturalLanguagePlanningError(ValueError):
     pass
 
 
+class PlannerJsonError(NaturalLanguagePlanningError):
+    pass
+
+
+class PlannerSchemaError(NaturalLanguagePlanningError):
+    pass
+
+
+class PlannerCatalogError(NaturalLanguagePlanningError):
+    pass
+
+
 class PlannerLlm(Protocol):
     def invoke(self, input: Any, *args: Any, **kwargs: Any) -> Any:
         ...
+
+
+@dataclass(frozen=True)
+class NaturalLanguagePlanResult:
+    plan: dict[str, Any]
+    planner_prompt: str
+    raw_response: str
 
 
 def plan_from_natural_language(
@@ -33,6 +53,24 @@ def plan_from_natural_language(
     recipe_catalog: RecipeCatalog | None = None,
 ) -> dict[str, Any]:
     """Convert a natural-language workflow request into a Recipe Tool Plan."""
+    return create_natural_language_plan(
+        request,
+        model=model,
+        llm=llm,
+        tool_catalog=tool_catalog,
+        recipe_catalog=recipe_catalog,
+    ).plan
+
+
+def create_natural_language_plan(
+    request: str,
+    *,
+    model: str = DEFAULT_PLANNER_MODEL,
+    llm: PlannerLlm | None = None,
+    tool_catalog: ToolCatalog | None = None,
+    recipe_catalog: RecipeCatalog | None = None,
+) -> NaturalLanguagePlanResult:
+    """Convert a natural-language request and retain planner observability details."""
     if not request.strip():
         raise NaturalLanguagePlanningError("natural language request is empty")
 
@@ -47,11 +85,19 @@ def plan_from_natural_language(
 
     try:
         ToolCallPlan.model_validate(plan)
+    except Exception as exc:
+        raise PlannerSchemaError(f"LLM planner plan schema validation failed: {exc}") from exc
+
+    try:
         resolve_tool_plan(plan, recipe_catalog, tool_catalog)
     except Exception as exc:
-        raise NaturalLanguagePlanningError(f"LLM planner produced an invalid Recipe Tool Plan: {exc}") from exc
+        raise PlannerCatalogError(f"LLM planner recipe/catalog validation failed: {exc}") from exc
 
-    return plan
+    return NaturalLanguagePlanResult(
+        plan=plan,
+        planner_prompt=prompt,
+        raw_response=raw_content,
+    )
 
 
 def build_planner_prompt(
@@ -134,15 +180,21 @@ def build_planner_prompt(
     )
 
 
+def build_default_planner_prompt(request: str) -> str:
+    tool_catalog = load_tool_catalog()
+    recipe_catalog = load_recipe_catalog(tool_catalog=tool_catalog)
+    return build_planner_prompt(request, tool_catalog, recipe_catalog)
+
+
 def parse_json_object(text: str) -> dict[str, Any]:
     candidate = _extract_json_candidate(text)
     try:
         parsed = json.loads(candidate)
     except json.JSONDecodeError as exc:
-        raise NaturalLanguagePlanningError(f"LLM planner did not return valid JSON: {exc}") from exc
+        raise PlannerJsonError(f"LLM planner JSON parsing failed: {exc}") from exc
 
     if not isinstance(parsed, dict):
-        raise NaturalLanguagePlanningError("LLM planner JSON must be an object")
+        raise PlannerJsonError("LLM planner JSON must be an object")
     return parsed
 
 
@@ -155,7 +207,7 @@ def _extract_json_candidate(text: str) -> str:
     start = stripped.find("{")
     end = stripped.rfind("}")
     if start == -1 or end == -1 or end < start:
-        raise NaturalLanguagePlanningError("LLM planner response does not contain a JSON object")
+        raise PlannerJsonError("LLM planner response does not contain a JSON object")
     return stripped[start : end + 1]
 
 

--- a/src/nl_planner.py
+++ b/src/nl_planner.py
@@ -1,0 +1,175 @@
+import json
+import os
+import re
+from typing import Any, Protocol
+
+from langchain_deepseek import ChatDeepSeek
+from pydantic import SecretStr
+
+from src.catalog.loader import ToolCatalog, load_tool_catalog
+from src.catalog.resolver import ToolCallPlan, resolve_tool_plan
+from src.recipes.loader import RecipeCatalog, load_recipe_catalog
+
+
+DEFAULT_PLANNER_MODEL = "deepseek-v4-pro"
+JSON_FENCE_PATTERN = re.compile(r"```(?:json)?\s*(.*?)\s*```", re.DOTALL | re.IGNORECASE)
+
+
+class NaturalLanguagePlanningError(ValueError):
+    pass
+
+
+class PlannerLlm(Protocol):
+    def invoke(self, input: Any, *args: Any, **kwargs: Any) -> Any:
+        ...
+
+
+def plan_from_natural_language(
+    request: str,
+    *,
+    model: str = DEFAULT_PLANNER_MODEL,
+    llm: PlannerLlm | None = None,
+    tool_catalog: ToolCatalog | None = None,
+    recipe_catalog: RecipeCatalog | None = None,
+) -> dict[str, Any]:
+    """Convert a natural-language workflow request into a Recipe Tool Plan."""
+    if not request.strip():
+        raise NaturalLanguagePlanningError("natural language request is empty")
+
+    tool_catalog = tool_catalog or load_tool_catalog()
+    recipe_catalog = recipe_catalog or load_recipe_catalog(tool_catalog=tool_catalog)
+    planner_llm = llm if llm is not None else _make_planner_llm(model)
+
+    prompt = build_planner_prompt(request, tool_catalog, recipe_catalog)
+    response = planner_llm.invoke(prompt)
+    raw_content = str(getattr(response, "content", response))
+    plan = parse_json_object(raw_content)
+
+    try:
+        ToolCallPlan.model_validate(plan)
+        resolve_tool_plan(plan, recipe_catalog, tool_catalog)
+    except Exception as exc:
+        raise NaturalLanguagePlanningError(f"LLM planner produced an invalid Recipe Tool Plan: {exc}") from exc
+
+    return plan
+
+
+def build_planner_prompt(
+    request: str,
+    tool_catalog: ToolCatalog,
+    recipe_catalog: RecipeCatalog,
+) -> str:
+    catalog_context = {
+        "recipes": [
+            {
+                "id": recipe.id,
+                "name": recipe.name,
+                "description": recipe.description,
+                "required_inputs": {
+                    input_name: spec.model_dump(exclude_none=True)
+                    for input_name, spec in recipe.required_inputs.items()
+                },
+                "steps": [
+                    {
+                        "id": step.id,
+                        "role": step.role,
+                        "optional": step.optional,
+                        "allowed_tools": step.allowed_tools,
+                    }
+                    for step in recipe.steps
+                ],
+            }
+            for recipe in recipe_catalog.all()
+        ],
+        "tools": [
+            {
+                "id": tool.id,
+                "version": tool.version,
+                "description": tool.description,
+                "inputs": {
+                    input_name: spec.model_dump(exclude_none=True)
+                    for input_name, spec in tool.inputs.items()
+                },
+                "params": {
+                    param_name: spec.model_dump(exclude_none=True)
+                    for param_name, spec in tool.params.items()
+                },
+                "outputs": {
+                    output_name: spec.model_dump(exclude_none=True)
+                    for output_name, spec in tool.outputs.items()
+                },
+            }
+            for tool in tool_catalog.all()
+        ],
+    }
+
+    return (
+        "You are a bioinformatics workflow planner. Convert the user's natural-language "
+        "request into a strict JSON Recipe Tool Plan for AI-bioworkflow.\n\n"
+        "Rules:\n"
+        "- Return JSON only. Do not include markdown or explanations.\n"
+        "- Prefer an existing recipe from the catalog.\n"
+        "- Use only tools and versions listed in the catalog.\n"
+        "- Use workflow input names from the recipe required_inputs when possible.\n"
+        "- Use call ids that are valid WDL identifiers.\n"
+        "- Connect upstream tool outputs with call_id.output_name expressions.\n"
+        "- Include explicit workflow outputs requested by the user, or the final useful output.\n\n"
+        "Output shape:\n"
+        "{\n"
+        '  "workflow": {\n'
+        '    "name": "ValidWorkflowName",\n'
+        '    "recipe": "recipe_id",\n'
+        '    "inputs": {"input_name": "WDLType"},\n'
+        '    "tool_calls": [\n'
+        '      {"id": "call_id", "step": "recipe_step_id", "tool": "tool_id", '
+        '"version": "tool_version", "inputs": {}, "params": {}}\n'
+        "    ],\n"
+        '    "outputs": {"output_name": "call_id.output_name"}\n'
+        "  }\n"
+        "}\n\n"
+        "Catalog:\n"
+        f"{json.dumps(catalog_context, indent=2, ensure_ascii=False)}\n\n"
+        "User request:\n"
+        f"{request.strip()}\n"
+    )
+
+
+def parse_json_object(text: str) -> dict[str, Any]:
+    candidate = _extract_json_candidate(text)
+    try:
+        parsed = json.loads(candidate)
+    except json.JSONDecodeError as exc:
+        raise NaturalLanguagePlanningError(f"LLM planner did not return valid JSON: {exc}") from exc
+
+    if not isinstance(parsed, dict):
+        raise NaturalLanguagePlanningError("LLM planner JSON must be an object")
+    return parsed
+
+
+def _extract_json_candidate(text: str) -> str:
+    stripped = text.strip()
+    fenced = JSON_FENCE_PATTERN.search(stripped)
+    if fenced:
+        return fenced.group(1).strip()
+
+    start = stripped.find("{")
+    end = stripped.rfind("}")
+    if start == -1 or end == -1 or end < start:
+        raise NaturalLanguagePlanningError("LLM planner response does not contain a JSON object")
+    return stripped[start : end + 1]
+
+
+def _make_planner_llm(model: str) -> PlannerLlm:
+    api_key_raw = os.environ.get("DEEPSEEK_API_KEY")
+    if not api_key_raw:
+        raise NaturalLanguagePlanningError(
+            "DEEPSEEK_API_KEY is required for natural language planning. "
+            "Set it in .env or use --input with a structured JSON/YAML plan."
+        )
+
+    return ChatDeepSeek(
+        model=model,
+        api_key=SecretStr(api_key_raw),
+        base_url="https://api.deepseek.com",
+        temperature=0,
+    )

--- a/src/nodes/analyzer.py
+++ b/src/nodes/analyzer.py
@@ -1,3 +1,5 @@
+import logging
+
 from langchain_core.messages import HumanMessage
 
 from src.analyzer import analyze_workflow_ir
@@ -5,11 +7,14 @@ from src.schema import WorkflowIR
 from src.state import WorkflowState
 
 
+logger = logging.getLogger(__name__)
+
+
 def analyzer_node(state: WorkflowState):
     """
     Validate WorkflowIR before rendering WDL.
     """
-    print("🧪 Analyzer 节点正在检查 Workflow IR...")
+    logger.info("Analyzer node is checking Workflow IR.")
 
     try:
         workflow_ir = WorkflowIR.model_validate(state.get("workflow_ir", {}))

--- a/src/nodes/analyzer.py
+++ b/src/nodes/analyzer.py
@@ -1,0 +1,35 @@
+from langchain_core.messages import HumanMessage
+
+from src.analyzer import analyze_workflow_ir
+from src.schema import WorkflowIR
+from src.state import WorkflowState
+
+
+def analyzer_node(state: WorkflowState):
+    """
+    Validate WorkflowIR before rendering WDL.
+    """
+    print("🧪 Analyzer 节点正在检查 Workflow IR...")
+
+    try:
+        workflow_ir = WorkflowIR.model_validate(state.get("workflow_ir", {}))
+    except Exception as exc:
+        message = f"Workflow IR 结构校验失败: {exc}"
+        return {
+            "analysis_errors": [message],
+            "analysis_warnings": [],
+            "is_valid": False,
+            "messages": [HumanMessage(content=message)],
+        }
+
+    report = analyze_workflow_ir(workflow_ir)
+    messages = []
+    if not report.is_valid:
+        messages.append(HumanMessage(content="\n".join(report.errors)))
+
+    return {
+        "analysis_errors": report.errors,
+        "analysis_warnings": report.warnings,
+        "is_valid": report.is_valid,
+        "messages": messages,
+    }

--- a/src/nodes/checker.py
+++ b/src/nodes/checker.py
@@ -1,0 +1,31 @@
+from langchain_core.messages import HumanMessage
+from src.state import WorkflowState
+from src.tools.validator import wdl_validator
+
+def checker_node(state: WorkflowState):
+    """
+    负责调用 miniwdl 工具校验代码的节点
+    """
+    print("🔍 Checker 节点正在运行 miniwdl 校验...")
+    
+    wdl_code = state.get("current_wdl", "")
+    current_error_count = state.get("error_count", 0)
+
+    # 1. 直接调用我们之前写好的工具
+    result = wdl_validator.invoke({"wdl_code": wdl_code})
+    
+    is_valid = result.get("is_valid", False) if isinstance(result, dict) else False
+    message = result.get("message", f"未知系统错误，返回内容为: {result}") if isinstance(result, dict) else str(result)
+
+    # 2. 判断结果并更新状态笔记本
+    if is_valid:
+        print("🎉 校验通过！")
+        return {"error_count": current_error_count, "is_valid": True} # 没报错，只更新状态，不增加消息
+    else:
+        print("❌ 校验失败！准备打回重写...")
+        # 报错了！伪造一个人类的消息，把报错糊在模型脸上，并记录失败次数
+        return {
+            "messages": [HumanMessage(content=message)],
+            "error_count": current_error_count + 1,
+            "is_valid": False
+        }

--- a/src/nodes/checker.py
+++ b/src/nodes/checker.py
@@ -1,14 +1,19 @@
+import logging
+
 from langchain_core.messages import HumanMessage
 
 from src.state import WorkflowState
 from src.tools.validator import wdl_validator
 
 
+logger = logging.getLogger(__name__)
+
+
 def checker_node(state: WorkflowState):
     """
     负责调用 miniwdl 工具校验代码的节点
     """
-    print("🔍 Checker 节点正在运行 miniwdl 校验...")
+    logger.info("Checker node is running miniwdl validation.")
     
     wdl_code = state.get("current_wdl", "")
     current_error_count = state.get("error_count", 0)
@@ -21,14 +26,14 @@ def checker_node(state: WorkflowState):
 
     # 2. 判断结果并更新状态笔记本
     if is_valid:
-        print("🎉 校验通过！")
+        logger.info("WDL validation passed.")
         return {
             "error_count": current_error_count,
             "is_valid": True,
             "validation_message": message,
         }
     else:
-        print("❌ 校验失败！")
+        logger.info("WDL validation failed.")
         # 报错了！把校验错误写入消息，后续 LLM repairer 可以基于它修复 IR
         return {
             "messages": [HumanMessage(content=message)],

--- a/src/nodes/checker.py
+++ b/src/nodes/checker.py
@@ -22,12 +22,17 @@ def checker_node(state: WorkflowState):
     # 2. 判断结果并更新状态笔记本
     if is_valid:
         print("🎉 校验通过！")
-        return {"error_count": current_error_count, "is_valid": True} # 没报错，只更新状态，不增加消息
+        return {
+            "error_count": current_error_count,
+            "is_valid": True,
+            "validation_message": message,
+        }
     else:
-        print("❌ 校验失败！准备打回重写...")
-        # 报错了！伪造一个人类的消息，把报错糊在模型脸上，并记录失败次数
+        print("❌ 校验失败！")
+        # 报错了！把校验错误写入消息，后续 LLM repairer 可以基于它修复 IR
         return {
             "messages": [HumanMessage(content=message)],
             "error_count": current_error_count + 1,
-            "is_valid": False
+            "is_valid": False,
+            "validation_message": message,
         }

--- a/src/nodes/checker.py
+++ b/src/nodes/checker.py
@@ -1,6 +1,8 @@
 from langchain_core.messages import HumanMessage
+
 from src.state import WorkflowState
 from src.tools.validator import wdl_validator
+
 
 def checker_node(state: WorkflowState):
     """

--- a/src/nodes/coder.py
+++ b/src/nodes/coder.py
@@ -1,0 +1,58 @@
+import os
+import json
+import re
+from langchain_deepseek import ChatDeepSeek
+from langchain_core.messages import SystemMessage, HumanMessage, AIMessage
+from src.state import WorkflowState
+from src.prompts import coder_prompt
+from pydantic import SecretStr
+
+# 初始化 DeepSeek (请确保在跑代码前 .env 里有真实的 DEEPSEEK_API_KEY)
+api_key_raw = os.environ.get("DEEPSEEK_API_KEY")
+if not api_key_raw:
+    raise ValueError("请设置 DEEPSEEK_API_KEY 环境变量")
+
+api_key = SecretStr(api_key_raw)
+llm = ChatDeepSeek(
+    model="deepseek-v4-pro", 
+    api_key=api_key, 
+    base_url="https://api.deepseek.com",
+    temperature=0
+)
+
+def coder_node(state: WorkflowState):
+    print("🤖 Coder 节点正在生成 WDL 代码...")
+    
+    # 1. 获取输入数据
+    user_json = state.get("parsed_json", {})
+    
+    # 小技巧：将 Python 字典转为带缩进的 JSON 字符串，大模型阅读起来准确率更高
+    formatted_json = json.dumps(user_json, indent=2, ensure_ascii=False)
+
+    # 2. 组装基础的 System Prompt (返回的是 PromptValue 对象)
+    prompt_value = coder_prompt.invoke({"json_data": formatted_json})
+    
+    # 3. 转换成标准的 Message 列表
+    base_messages = prompt_value.to_messages()
+    
+    # 4. 获取历史记录（包含之前的错误代码和 Checker 的打回报错）
+    history_messages = state.get("messages", [])
+    
+    # 5. 完美拼接：系统设定在前，历史记录在后
+    final_messages = base_messages + history_messages
+    
+    # 6. 调用模型
+    response = llm.invoke(final_messages)
+    raw_content = str(response.content)
+
+    # 【新增功能】：剥离 Markdown 代码块标记，提取纯 WDL 代码
+    clean_wdl = raw_content
+    match = re.search(r"```(?:wdl)?\s*(.*?)\s*```", raw_content, re.DOTALL | re.IGNORECASE)
+    if match:
+        clean_wdl = match.group(1).strip()
+    
+    # 7. 更新状态
+    return {
+        "current_wdl": clean_wdl,
+        "messages": [AIMessage(content="我已生成 WDL 代码。")]
+    }

--- a/src/nodes/coder.py
+++ b/src/nodes/coder.py
@@ -1,0 +1,38 @@
+import os
+from langchain_deepseek import ChatDeepSeek
+from langchain_core.messages import SystemMessage, HumanMessage, AIMessage
+from src.state import WorkflowState
+from src.prompts import CODER_SYSTEM_PROMPT
+
+# 初始化 DeepSeek (请确保在跑代码前 .env 里有真实的 DEEPSEEK_API_KEY)
+llm = ChatDeepSeek(
+    model="deepseek-chat", 
+    api_key=os.environ.get("DEEPSEEK_API_KEY"), 
+    base_url="https://api.deepseek.com",
+    temperature=0
+)
+
+def coder_node(state: WorkflowState):
+    """
+    负责将结构化 JSON 转化为 WDL 代码的节点
+    """
+    print("🤖 Coder 节点正在生成 WDL 代码...")
+    
+    # 1. 获取输入数据
+    user_json = state.get("parsed_json", {})
+    
+    # 2. 组装 Prompt
+    # 将 JSON 注入到提示词模板中
+    system_prompt = CODER_SYSTEM_PROMPT.replace("{json_data}", str(user_json))
+    
+    # 3. 调用模型
+    # 这里我们只传入 system_prompt，让模型专注于翻译代码
+    messages = [SystemMessage(content=system_prompt)]
+    response = llm.invoke(messages)
+    
+    # 4. 更新状态 (将生成的 WDL 存入 current_wdl，并把 AI 的回复追加到 messages)
+    # 注意这里必须返回一个字典，LangGraph 会根据键名自动更新 State
+    return {
+        "current_wdl": response.content,
+        "messages": [AIMessage(content="我已生成 WDL 代码。")]
+    }

--- a/src/nodes/coder.py
+++ b/src/nodes/coder.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import os
 import re
 
@@ -8,6 +9,9 @@ from pydantic import SecretStr
 
 from src.prompts import coder_prompt
 from src.state import WorkflowState
+
+
+logger = logging.getLogger(__name__)
 
 # 初始化 DeepSeek (请确保在跑代码前 .env 里有真实的 DEEPSEEK_API_KEY)
 api_key_raw = os.environ.get("DEEPSEEK_API_KEY")
@@ -23,7 +27,7 @@ llm = ChatDeepSeek(
 )
 
 def coder_node(state: WorkflowState):
-    print("🤖 Coder 节点正在生成 WDL 代码...")
+    logger.info("Coder node is generating WDL code.")
     
     # 1. 获取输入数据
     user_json = state.get("parsed_json", {})

--- a/src/nodes/coder.py
+++ b/src/nodes/coder.py
@@ -1,11 +1,13 @@
-import os
 import json
+import os
 import re
+
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
 from langchain_deepseek import ChatDeepSeek
-from langchain_core.messages import SystemMessage, HumanMessage, AIMessage
-from src.state import WorkflowState
-from src.prompts import coder_prompt
 from pydantic import SecretStr
+
+from src.prompts import coder_prompt
+from src.state import WorkflowState
 
 # 初始化 DeepSeek (请确保在跑代码前 .env 里有真实的 DEEPSEEK_API_KEY)
 api_key_raw = os.environ.get("DEEPSEEK_API_KEY")

--- a/src/nodes/coder.py
+++ b/src/nodes/coder.py
@@ -1,5 +1,6 @@
 import os
 import json
+import re
 from langchain_deepseek import ChatDeepSeek
 from langchain_core.messages import SystemMessage, HumanMessage, AIMessage
 from src.state import WorkflowState
@@ -28,14 +29,30 @@ def coder_node(state: WorkflowState):
     # 小技巧：将 Python 字典转为带缩进的 JSON 字符串，大模型阅读起来准确率更高
     formatted_json = json.dumps(user_json, indent=2, ensure_ascii=False)
 
-    # 2. 组装 Prompt (利用 LangChain 的 invoke 自动填充变量并生成 Message 列表)
-    messages = coder_prompt.invoke({"json_data": formatted_json})
+    # 2. 组装基础的 System Prompt (返回的是 PromptValue 对象)
+    prompt_value = coder_prompt.invoke({"json_data": formatted_json})
     
-    # 3. 调用模型
-    response = llm.invoke(messages)
+    # 3. 转换成标准的 Message 列表
+    base_messages = prompt_value.to_messages()
     
-    # 4. 更新状态
+    # 4. 获取历史记录（包含之前的错误代码和 Checker 的打回报错）
+    history_messages = state.get("messages", [])
+    
+    # 5. 完美拼接：系统设定在前，历史记录在后
+    final_messages = base_messages + history_messages
+    
+    # 6. 调用模型
+    response = llm.invoke(final_messages)
+    raw_content = str(response.content)
+
+    # 【新增功能】：剥离 Markdown 代码块标记，提取纯 WDL 代码
+    clean_wdl = raw_content
+    match = re.search(r"```(?:wdl)?\s*(.*?)\s*```", raw_content, re.DOTALL | re.IGNORECASE)
+    if match:
+        clean_wdl = match.group(1).strip()
+    
+    # 7. 更新状态
     return {
-        "current_wdl": response.content,
+        "current_wdl": clean_wdl,
         "messages": [AIMessage(content="我已生成 WDL 代码。")]
     }

--- a/src/nodes/coder.py
+++ b/src/nodes/coder.py
@@ -3,11 +3,17 @@ from langchain_deepseek import ChatDeepSeek
 from langchain_core.messages import SystemMessage, HumanMessage, AIMessage
 from src.state import WorkflowState
 from src.prompts import CODER_SYSTEM_PROMPT
+from pydantic import SecretStr
 
 # 初始化 DeepSeek (请确保在跑代码前 .env 里有真实的 DEEPSEEK_API_KEY)
+api_key_raw = os.environ.get("DEEPSEEK_API_KEY")
+if not api_key_raw:
+    raise ValueError("请设置 DEEPSEEK_API_KEY 环境变量")
+
+api_key = SecretStr(api_key_raw)
 llm = ChatDeepSeek(
     model="deepseek-chat", 
-    api_key=os.environ.get("DEEPSEEK_API_KEY"), 
+    api_key=api_key, 
     base_url="https://api.deepseek.com",
     temperature=0
 )

--- a/src/nodes/coder.py
+++ b/src/nodes/coder.py
@@ -12,7 +12,7 @@ if not api_key_raw:
 
 api_key = SecretStr(api_key_raw)
 llm = ChatDeepSeek(
-    model="deepseek-chat", 
+    model="deepseek-v4-pro", 
     api_key=api_key, 
     base_url="https://api.deepseek.com",
     temperature=0

--- a/src/nodes/coder.py
+++ b/src/nodes/coder.py
@@ -1,8 +1,9 @@
 import os
+import json
 from langchain_deepseek import ChatDeepSeek
 from langchain_core.messages import SystemMessage, HumanMessage, AIMessage
 from src.state import WorkflowState
-from src.prompts import CODER_SYSTEM_PROMPT
+from src.prompts import coder_prompt
 from pydantic import SecretStr
 
 # 初始化 DeepSeek (请确保在跑代码前 .env 里有真实的 DEEPSEEK_API_KEY)
@@ -19,25 +20,21 @@ llm = ChatDeepSeek(
 )
 
 def coder_node(state: WorkflowState):
-    """
-    负责将结构化 JSON 转化为 WDL 代码的节点
-    """
     print("🤖 Coder 节点正在生成 WDL 代码...")
     
     # 1. 获取输入数据
     user_json = state.get("parsed_json", {})
     
-    # 2. 组装 Prompt
-    # 将 JSON 注入到提示词模板中
-    system_prompt = CODER_SYSTEM_PROMPT.replace("{json_data}", str(user_json))
+    # 小技巧：将 Python 字典转为带缩进的 JSON 字符串，大模型阅读起来准确率更高
+    formatted_json = json.dumps(user_json, indent=2, ensure_ascii=False)
+
+    # 2. 组装 Prompt (利用 LangChain 的 invoke 自动填充变量并生成 Message 列表)
+    messages = coder_prompt.invoke({"json_data": formatted_json})
     
     # 3. 调用模型
-    # 这里我们只传入 system_prompt，让模型专注于翻译代码
-    messages = [SystemMessage(content=system_prompt)]
     response = llm.invoke(messages)
     
-    # 4. 更新状态 (将生成的 WDL 存入 current_wdl，并把 AI 的回复追加到 messages)
-    # 注意这里必须返回一个字典，LangGraph 会根据键名自动更新 State
+    # 4. 更新状态
     return {
         "current_wdl": response.content,
         "messages": [AIMessage(content="我已生成 WDL 代码。")]

--- a/src/nodes/planner.py
+++ b/src/nodes/planner.py
@@ -2,7 +2,7 @@ import logging
 
 from langchain_core.messages import AIMessage, HumanMessage
 
-from src.catalog import load_tool_catalog, resolve_tool_plan
+from src.catalog import load_tool_catalog, resolve_tool_plan, static_provider_from_image_map
 from src.recipes import load_recipe_catalog
 from src.schema import coerce_workflow_ir
 from src.state import WorkflowState
@@ -24,7 +24,7 @@ def planner_node(state: WorkflowState):
     raw_input = state.get("workflow_ir") or state.get("parsed_json", {})
 
     try:
-        workflow_ir, message = _normalize_planner_input(raw_input)
+        workflow_ir, message = _normalize_planner_input(raw_input, state)
     except Exception as exc:
         message = f"Workflow JSON 无法转换为标准 IR: {exc}"
         return {
@@ -42,15 +42,27 @@ def planner_node(state: WorkflowState):
     }
 
 
-def _normalize_planner_input(raw_input: dict):
+def _normalize_planner_input(raw_input: dict, state: WorkflowState):
     if _is_tool_call_plan(raw_input):
         tool_catalog = load_tool_catalog()
         recipe_catalog = load_recipe_catalog(tool_catalog=tool_catalog)
-        workflow_ir = resolve_tool_plan(raw_input, recipe_catalog, tool_catalog)
+        container_provider = _container_provider_from_state(state)
+        workflow_ir = resolve_tool_plan(
+            raw_input,
+            recipe_catalog,
+            tool_catalog,
+            container_provider=container_provider,
+        )
         return workflow_ir, "Recipe tool plan 已解析为 Workflow IR。"
 
     workflow_ir = coerce_workflow_ir(raw_input)
     return workflow_ir, "Workflow IR 已标准化。"
+
+
+def _container_provider_from_state(state: WorkflowState):
+    if not state.get("fill_containers"):
+        return None
+    return static_provider_from_image_map(state.get("container_image_candidates", {}))
 
 
 def _is_tool_call_plan(raw_input: dict) -> bool:

--- a/src/nodes/planner.py
+++ b/src/nodes/planner.py
@@ -1,0 +1,35 @@
+from langchain_core.messages import AIMessage, HumanMessage
+
+from src.schema import coerce_workflow_ir
+from src.state import WorkflowState
+
+
+def planner_node(state: WorkflowState):
+    """
+    Normalize user JSON into the internal WorkflowIR.
+
+    This node is intentionally deterministic for structured inputs. A future
+    LLM planner can sit before this step and produce the same IR schema from
+    natural language or incomplete forms.
+    """
+    print("🧭 Planner 节点正在标准化 Workflow IR...")
+
+    raw_input = state.get("workflow_ir") or state.get("parsed_json", {})
+
+    try:
+        workflow_ir = coerce_workflow_ir(raw_input)
+    except Exception as exc:
+        message = f"Workflow JSON 无法转换为标准 IR: {exc}"
+        return {
+            "analysis_errors": [message],
+            "analysis_warnings": [],
+            "is_valid": False,
+            "messages": [HumanMessage(content=message)],
+        }
+
+    return {
+        "workflow_ir": workflow_ir.model_dump(mode="json"),
+        "analysis_errors": [],
+        "analysis_warnings": [],
+        "messages": [AIMessage(content="Workflow IR 已标准化。")],
+    }

--- a/src/nodes/planner.py
+++ b/src/nodes/planner.py
@@ -1,9 +1,14 @@
+import logging
+
 from langchain_core.messages import AIMessage, HumanMessage
 
 from src.catalog import load_tool_catalog, resolve_tool_plan
 from src.recipes import load_recipe_catalog
 from src.schema import coerce_workflow_ir
 from src.state import WorkflowState
+
+
+logger = logging.getLogger(__name__)
 
 
 def planner_node(state: WorkflowState):
@@ -14,7 +19,7 @@ def planner_node(state: WorkflowState):
     LLM planner can sit before this step and produce the same IR schema from
     natural language or incomplete forms.
     """
-    print("🧭 Planner 节点正在标准化 Workflow IR...")
+    logger.info("Planner node is normalizing Workflow IR.")
 
     raw_input = state.get("workflow_ir") or state.get("parsed_json", {})
 

--- a/src/nodes/planner.py
+++ b/src/nodes/planner.py
@@ -1,5 +1,7 @@
 from langchain_core.messages import AIMessage, HumanMessage
 
+from src.catalog import load_tool_catalog, resolve_tool_plan
+from src.recipes import load_recipe_catalog
 from src.schema import coerce_workflow_ir
 from src.state import WorkflowState
 
@@ -17,7 +19,7 @@ def planner_node(state: WorkflowState):
     raw_input = state.get("workflow_ir") or state.get("parsed_json", {})
 
     try:
-        workflow_ir = coerce_workflow_ir(raw_input)
+        workflow_ir, message = _normalize_planner_input(raw_input)
     except Exception as exc:
         message = f"Workflow JSON 无法转换为标准 IR: {exc}"
         return {
@@ -31,5 +33,27 @@ def planner_node(state: WorkflowState):
         "workflow_ir": workflow_ir.model_dump(mode="json"),
         "analysis_errors": [],
         "analysis_warnings": [],
-        "messages": [AIMessage(content="Workflow IR 已标准化。")],
+        "messages": [AIMessage(content=message)],
     }
+
+
+def _normalize_planner_input(raw_input: dict):
+    if _is_tool_call_plan(raw_input):
+        tool_catalog = load_tool_catalog()
+        recipe_catalog = load_recipe_catalog(tool_catalog=tool_catalog)
+        workflow_ir = resolve_tool_plan(raw_input, recipe_catalog, tool_catalog)
+        return workflow_ir, "Recipe tool plan 已解析为 Workflow IR。"
+
+    workflow_ir = coerce_workflow_ir(raw_input)
+    return workflow_ir, "Workflow IR 已标准化。"
+
+
+def _is_tool_call_plan(raw_input: dict) -> bool:
+    if not isinstance(raw_input, dict):
+        return False
+
+    workflow = raw_input.get("workflow")
+    if not isinstance(workflow, dict):
+        return False
+
+    return "recipe" in workflow and "tool_calls" in workflow

--- a/src/nodes/renderer.py
+++ b/src/nodes/renderer.py
@@ -1,14 +1,19 @@
+import logging
+
 from langchain_core.messages import AIMessage
 
 from src.renderers import render_wdl
 from src.state import WorkflowState
 
 
+logger = logging.getLogger(__name__)
+
+
 def renderer_node(state: WorkflowState):
     """
     Deterministically compile WorkflowIR into WDL.
     """
-    print("🧱 Renderer 节点正在从 IR 编译 WDL...")
+    logger.info("Renderer node is compiling Workflow IR into WDL.")
 
     wdl_code = render_wdl(state.get("workflow_ir", {}))
     return {

--- a/src/nodes/renderer.py
+++ b/src/nodes/renderer.py
@@ -1,0 +1,17 @@
+from langchain_core.messages import AIMessage
+
+from src.renderers import render_wdl
+from src.state import WorkflowState
+
+
+def renderer_node(state: WorkflowState):
+    """
+    Deterministically compile WorkflowIR into WDL.
+    """
+    print("🧱 Renderer 节点正在从 IR 编译 WDL...")
+
+    wdl_code = render_wdl(state.get("workflow_ir", {}))
+    return {
+        "current_wdl": wdl_code,
+        "messages": [AIMessage(content="WDL 已由 Workflow IR 编译完成。")],
+    }

--- a/src/nodes/repairer.py
+++ b/src/nodes/repairer.py
@@ -1,14 +1,19 @@
+import logging
+
 from langchain_core.messages import AIMessage
 
 from src.repairer import repair_workflow_ir
 from src.state import WorkflowState
 
 
+logger = logging.getLogger(__name__)
+
+
 def repairer_node(state: WorkflowState):
     """
     Deterministically repair WorkflowIR when the analyzer/checker finds a safe fix.
     """
-    print("🩹 Repairer 节点正在尝试修复 Workflow IR...")
+    logger.info("Repairer node is attempting to repair Workflow IR.")
 
     try:
         report = repair_workflow_ir(state.get("workflow_ir", {}))

--- a/src/nodes/repairer.py
+++ b/src/nodes/repairer.py
@@ -1,0 +1,40 @@
+from langchain_core.messages import AIMessage
+
+from src.repairer import repair_workflow_ir
+from src.state import WorkflowState
+
+
+def repairer_node(state: WorkflowState):
+    """
+    Deterministically repair WorkflowIR when the analyzer/checker finds a safe fix.
+    """
+    print("🩹 Repairer 节点正在尝试修复 Workflow IR...")
+
+    try:
+        report = repair_workflow_ir(state.get("workflow_ir", {}))
+    except Exception as exc:
+        message = f"Workflow IR 修复失败: {exc}"
+        return {
+            "repair_actions": [],
+            "messages": [AIMessage(content=message)],
+        }
+
+    repair_count = state.get("repair_count", 0) + 1
+    if not report.changed:
+        return {
+            "repair_actions": [],
+            "repair_count": repair_count,
+            "messages": [AIMessage(content="Repairer 未找到可安全自动修复的 IR 问题。")],
+        }
+
+    action_summary = "\n".join(f"- {action}" for action in report.actions)
+    return {
+        "workflow_ir": report.workflow_ir.model_dump(mode="json"),
+        "analysis_errors": [],
+        "analysis_warnings": [],
+        "current_wdl": "",
+        "is_valid": False,
+        "repair_actions": report.actions,
+        "repair_count": repair_count,
+        "messages": [AIMessage(content=f"Workflow IR 已修复：\n{action_summary}")],
+    }

--- a/src/prompts.py
+++ b/src/prompts.py
@@ -1,0 +1,13 @@
+CODER_SYSTEM_PROMPT = """
+你是一个世界顶级的生物信息学工程师，精通 WDL (Workflow Description Language) 1.0 规范。
+你的任务是将用户提供的结构化 JSON 步骤说明，翻译成标准的、无语法错误的 WDL 代码。
+
+【约束条件】
+1. 必须包含一个 `workflow` 块和所有必需的 `task` 块。
+2. 变量传递必须严格使用 `~{variable}` 语法。
+3. 每个 task 必须包含 `command <<< >>>`、`runtime` 和 `output` 块。
+4. 你只需要输出 WDL 代码，不需要提供任何 markdown 格式或解释性的废话。直接输出纯文本代码。
+
+【用户的 JSON 描述如下】：
+{json_data}
+"""

--- a/src/prompts.py
+++ b/src/prompts.py
@@ -1,13 +1,27 @@
-CODER_SYSTEM_PROMPT = """
+from langchain_core.prompts import SystemMessagePromptTemplate, PromptTemplate, ChatPromptTemplate
+
+_CODER_SYSTEM_TEMPLATE = """
 你是一个世界顶级的生物信息学工程师，精通 WDL (Workflow Description Language) 1.0 规范。
 你的任务是将用户提供的结构化 JSON 步骤说明，翻译成标准的、无语法错误的 WDL 代码。
 
 【约束条件】
-1. 必须包含一个 `workflow` 块和所有必需的 `task` 块。
-2. 变量传递必须严格使用 `~{variable}` 语法。
-3. 每个 task 必须包含 `command <<< >>>`、`runtime` 和 `output` 块。
+1. 必须包含一个 workflow {} 块和所有必需的 task {} 块。
+2. 变量传递必须严格使用 ~{variable} 语法。
+3. 每个 task 必须包含 command <<< >>>、runtime 和 output 块。
 4. 你只需要输出 WDL 代码，不需要提供任何 markdown 格式或解释性的废话。直接输出纯文本代码。
 
 【用户的 JSON 描述如下】：
-{json_data}
+{{ json_data }}
 """
+
+# 明确指定 template_format="jinja2"
+jinja2_prompt = PromptTemplate(
+    template=_CODER_SYSTEM_TEMPLATE,
+    template_format="jinja2",
+    input_variables=["json_data"]
+)
+
+# 暴露出最终的 ChatPromptTemplate
+coder_prompt = ChatPromptTemplate.from_messages([
+    SystemMessagePromptTemplate(prompt=jinja2_prompt)
+])

--- a/src/prompts.py
+++ b/src/prompts.py
@@ -1,0 +1,27 @@
+from langchain_core.prompts import SystemMessagePromptTemplate, PromptTemplate, ChatPromptTemplate
+
+_CODER_SYSTEM_TEMPLATE = """
+你是一个世界顶级的生物信息学工程师，精通 WDL (Workflow Description Language) 1.0 规范。
+你的任务是将用户提供的结构化 JSON 步骤说明，翻译成标准的、无语法错误的 WDL 代码。
+
+【约束条件】
+1. 必须包含一个 workflow {} 块和所有必需的 task {} 块。
+2. 变量传递必须严格使用 ~{variable} 语法。
+3. 每个 task 必须包含 command <<< >>>、runtime 和 output 块。
+4. 你只需要输出 WDL 代码，不需要提供任何 markdown 格式或解释性的废话。直接输出纯文本代码。
+
+【用户的 JSON 描述如下】：
+{{ json_data }}
+"""
+
+# 明确指定 template_format="jinja2"
+jinja2_prompt = PromptTemplate(
+    template=_CODER_SYSTEM_TEMPLATE,
+    template_format="jinja2",
+    input_variables=["json_data"]
+)
+
+# 暴露出最终的 ChatPromptTemplate
+coder_prompt = ChatPromptTemplate.from_messages([
+    SystemMessagePromptTemplate(prompt=jinja2_prompt)
+])

--- a/src/prompts.py
+++ b/src/prompts.py
@@ -1,4 +1,5 @@
-from langchain_core.prompts import SystemMessagePromptTemplate, PromptTemplate, ChatPromptTemplate
+from langchain_core.prompts import (ChatPromptTemplate, PromptTemplate,
+                                    SystemMessagePromptTemplate)
 
 _CODER_SYSTEM_TEMPLATE = """
 你是一个世界顶级的生物信息学工程师，精通 WDL (Workflow Description Language) 1.0 规范。

--- a/src/recipes/__init__.py
+++ b/src/recipes/__init__.py
@@ -1,0 +1,5 @@
+from src.recipes.loader import RecipeCatalog, load_recipe_catalog
+from src.recipes.schema import RecipeSpec
+
+
+__all__ = ["RecipeCatalog", "RecipeSpec", "load_recipe_catalog"]

--- a/src/recipes/definitions/rnaseq_differential_expression.yaml
+++ b/src/recipes/definitions/rnaseq_differential_expression.yaml
@@ -1,0 +1,38 @@
+id: rnaseq_differential_expression
+name: RNA-seq differential expression
+description: Analyze bulk RNA-seq reads and identify differentially expressed genes.
+aliases:
+  - RNA-seq DEG
+  - bulk RNA-seq differential expression
+  - differential expression from RNA sequencing
+  - transcriptome differential expression
+
+required_inputs:
+  raw_r1:
+    type: File
+    description: First FASTQ read file.
+  raw_r2:
+    type: File
+    description: Second FASTQ read file.
+  transcriptome_index:
+    type: File
+    description: Salmon transcriptome index archive or directory.
+  sample_groups:
+    type: File
+    description: Sample metadata table with group labels.
+
+steps:
+  - id: qc
+    role: read_quality_control
+    allowed_tools:
+      - fastp
+
+  - id: quantify
+    role: expression_quantification
+    allowed_tools:
+      - salmon
+
+  - id: differential_expression
+    role: differential_expression
+    allowed_tools:
+      - deseq2

--- a/src/recipes/loader.py
+++ b/src/recipes/loader.py
@@ -1,0 +1,57 @@
+from pathlib import Path
+
+import yaml
+
+from src.catalog.loader import ToolCatalog, load_tool_catalog
+from src.recipes.schema import RecipeSpec
+
+
+DEFAULT_RECIPE_DIR = Path(__file__).parent / "definitions"
+
+
+class RecipeCatalog:
+    def __init__(self, recipes: dict[str, RecipeSpec]):
+        self._recipes = recipes
+
+    def get(self, recipe_id: str) -> RecipeSpec:
+        if recipe_id not in self._recipes:
+            raise KeyError(f"unknown recipe: {recipe_id}")
+        return self._recipes[recipe_id]
+
+    def all(self) -> list[RecipeSpec]:
+        return list(self._recipes.values())
+
+
+def load_recipe_catalog(
+    root: str | Path = DEFAULT_RECIPE_DIR,
+    tool_catalog: ToolCatalog | None = None,
+) -> RecipeCatalog:
+    root_path = Path(root)
+    tool_catalog = tool_catalog or load_tool_catalog()
+    recipes: dict[str, RecipeSpec] = {}
+
+    for yaml_path in sorted(root_path.rglob("*.yaml")):
+        spec = RecipeSpec.model_validate(_load_yaml(yaml_path))
+        if spec.id in recipes:
+            raise ValueError(f"duplicate recipe definition: {spec.id}")
+        _validate_recipe_tools(spec, tool_catalog)
+        recipes[spec.id] = spec
+
+    return RecipeCatalog(recipes)
+
+
+def _load_yaml(path: Path) -> dict:
+    with path.open("r", encoding="utf-8") as handle:
+        data = yaml.safe_load(handle)
+    if not isinstance(data, dict):
+        raise ValueError(f"YAML file must contain a mapping: {path}")
+    return data
+
+
+def _validate_recipe_tools(recipe: RecipeSpec, tool_catalog: ToolCatalog) -> None:
+    for step in recipe.steps:
+        for tool_id in step.allowed_tools:
+            if not tool_catalog.has_tool_id(tool_id):
+                raise ValueError(
+                    f"recipe '{recipe.id}' step '{step.id}' allows unknown tool '{tool_id}'"
+                )

--- a/src/recipes/schema.py
+++ b/src/recipes/schema.py
@@ -1,0 +1,77 @@
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from src.catalog.schema import validate_identifier, validate_mapping_keys
+
+
+class RequiredInputSpec(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    type: str
+    description: str | None = None
+
+
+class RecipeStepSpec(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    role: str
+    optional: bool = False
+    allowed_tools: list[str] = Field(default_factory=list)
+
+    @field_validator("id")
+    @classmethod
+    def validate_step_id(cls, value: str) -> str:
+        validate_identifier(value, "recipe step id")
+        return value
+
+    @field_validator("allowed_tools")
+    @classmethod
+    def validate_allowed_tools(cls, value: list[str]) -> list[str]:
+        for tool_id in value:
+            validate_identifier(tool_id, "allowed tool id")
+        return value
+
+
+class RecipeSpec(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    name: str
+    description: str = ""
+    aliases: list[str] = Field(default_factory=list)
+    required_inputs: dict[str, RequiredInputSpec] = Field(default_factory=dict)
+    steps: list[RecipeStepSpec] = Field(default_factory=list)
+
+    @field_validator("id")
+    @classmethod
+    def validate_recipe_id(cls, value: str) -> str:
+        validate_identifier(value, "recipe id")
+        return value
+
+    @field_validator("required_inputs")
+    @classmethod
+    def validate_required_input_names(
+        cls,
+        value: dict[str, RequiredInputSpec],
+    ) -> dict[str, RequiredInputSpec]:
+        validate_mapping_keys(value, "recipe required input")
+        return value
+
+    @model_validator(mode="after")
+    def validate_steps(self):
+        seen_steps = set()
+        for step in self.steps:
+            if step.id in seen_steps:
+                raise ValueError(f"duplicate recipe step id: {step.id}")
+            seen_steps.add(step.id)
+
+            if not step.allowed_tools:
+                raise ValueError(f"recipe step '{step.id}' must allow at least one tool")
+
+        return self
+
+    def step_by_id(self, step_id: str) -> RecipeStepSpec:
+        for step in self.steps:
+            if step.id == step_id:
+                return step
+        raise KeyError(f"unknown recipe step: {step_id}")

--- a/src/renderers/__init__.py
+++ b/src/renderers/__init__.py
@@ -1,0 +1,4 @@
+from src.renderers.wdl import render_wdl
+
+
+__all__ = ["render_wdl"]

--- a/src/renderers/templates/workflow.wdl.j2
+++ b/src/renderers/templates/workflow.wdl.j2
@@ -1,0 +1,69 @@
+version 1.0
+
+workflow {{ ir.workflow.name }} {
+{% if ir.workflow.inputs %}
+  input {
+{% for name, type in ir.workflow.inputs.items() %}
+    {{ type }} {{ name }}
+{% endfor %}
+  }
+
+{% endif %}
+{% for call in ir.workflow.calls %}
+  call {{ call.task }}{{ (" as " ~ call.id) if call.id != call.task else "" }} {
+{% if call.inputs %}
+    input:
+{% for input_name, expression in call.inputs.items() %}
+      {{ input_name }} = {{ expression }}{{ "," if not loop.last else "" }}
+{% endfor %}
+{% endif %}
+  }
+{% if not loop.last %}
+
+{% endif %}
+{% endfor %}
+{% if workflow_outputs %}
+
+  output {
+{% for output in workflow_outputs %}
+    {{ output.type }} {{ output.name }} = {{ output.expression }}
+{% endfor %}
+  }
+{% endif %}
+}
+
+{% for task_name, task in ir.tasks.items() %}
+task {{ task_name }} {
+{% if task.inputs %}
+  input {
+{% for input_name, type in task.inputs.items() %}
+    {{ type }} {{ input_name }}
+{% endfor %}
+  }
+
+{% endif %}
+  command <<<
+{{ task.command | indent_command(4) }}
+  >>>
+
+{% if task.outputs %}
+  output {
+{% for output_name, output in task.outputs.items() %}
+    {{ output.type }} {{ output_name }} = {{ output.value }}
+{% endfor %}
+  }
+
+{% endif %}
+{% set runtime_values = runtime_items(task.runtime) %}
+{% if runtime_values %}
+  runtime {
+{% for key, value in runtime_values %}
+    {{ key }}: {{ value | wdl_literal }}
+{% endfor %}
+  }
+{% endif %}
+}
+{% if not loop.last %}
+
+{% endif %}
+{% endfor %}

--- a/src/renderers/wdl.py
+++ b/src/renderers/wdl.py
@@ -1,0 +1,61 @@
+import json
+from pathlib import Path
+from typing import Any
+
+from jinja2 import Environment, FileSystemLoader, StrictUndefined
+
+from src.analyzer import resolve_workflow_output_type
+from src.schema import WorkflowIR, coerce_workflow_ir
+
+
+TEMPLATE_DIR = Path(__file__).parent / "templates"
+
+
+def render_wdl(workflow_ir: WorkflowIR | dict[str, Any]) -> str:
+    ir = coerce_workflow_ir(workflow_ir)
+    env = Environment(
+        loader=FileSystemLoader(TEMPLATE_DIR),
+        trim_blocks=True,
+        lstrip_blocks=True,
+        undefined=StrictUndefined,
+    )
+    env.filters["wdl_literal"] = _format_wdl_literal
+    env.filters["indent_command"] = _indent_command
+
+    template = env.get_template("workflow.wdl.j2")
+    return template.render(
+        ir=ir,
+        runtime_items=_runtime_items,
+        workflow_outputs=_workflow_outputs(ir),
+    ).strip() + "\n"
+
+
+def _workflow_outputs(ir: WorkflowIR) -> list[dict[str, str]]:
+    outputs = []
+    for name, expression in ir.workflow.outputs.items():
+        outputs.append(
+            {
+                "name": name,
+                "type": resolve_workflow_output_type(ir, expression) or "String",
+                "expression": expression,
+            }
+        )
+    return outputs
+
+
+def _runtime_items(runtime: Any) -> list[tuple[str, Any]]:
+    values = runtime.model_dump(exclude_none=True)
+    return sorted(values.items())
+
+
+def _format_wdl_literal(value: Any) -> str:
+    if isinstance(value, str):
+        return json.dumps(value)
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    return str(value)
+
+
+def _indent_command(command: str, spaces: int = 4) -> str:
+    prefix = " " * spaces
+    return "\n".join(f"{prefix}{line}" if line else "" for line in command.splitlines())

--- a/src/repairer.py
+++ b/src/repairer.py
@@ -1,0 +1,146 @@
+import json
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+from src.schema import IDENTIFIER_PATTERN, WorkflowIR, coerce_workflow_ir
+
+
+CALL_OUTPUT_PATTERN = re.compile(r"^([A-Za-z_][A-Za-z0-9_]*)\.([A-Za-z_][A-Za-z0-9_]*)$")
+SAFE_LITERAL_PATTERN = re.compile(r"^[A-Za-z0-9_./-]+$")
+
+
+@dataclass
+class RepairReport:
+    workflow_ir: WorkflowIR
+    actions: list[str] = field(default_factory=list)
+
+    @property
+    def changed(self) -> bool:
+        return bool(self.actions)
+
+
+def repair_workflow_ir(workflow_ir: WorkflowIR | dict[str, Any]) -> RepairReport:
+    """Apply conservative, deterministic repairs to Workflow IR."""
+    repaired = coerce_workflow_ir(workflow_ir).model_copy(deep=True)
+    actions: list[str] = []
+
+    _repair_call_order(repaired, actions)
+    _repair_output_literals(repaired, actions)
+
+    return RepairReport(workflow_ir=repaired, actions=actions)
+
+
+def _repair_call_order(ir: WorkflowIR, actions: list[str]) -> None:
+    calls = list(ir.workflow.calls)
+    if len(calls) < 2:
+        return
+
+    call_by_id = {call.id: call for call in calls}
+    original_order = [call.id for call in calls]
+    dependencies_by_call = {
+        call.id: _call_dependencies(call.inputs.values(), call_by_id)
+        for call in calls
+    }
+
+    ordered_calls = []
+    ordered_ids = set()
+    remaining_ids = list(original_order)
+
+    while remaining_ids:
+        ready_id = next(
+            (
+                call_id
+                for call_id in remaining_ids
+                if dependencies_by_call[call_id].issubset(ordered_ids)
+            ),
+            None,
+        )
+        if ready_id is None:
+            return
+
+        ordered_calls.append(call_by_id[ready_id])
+        ordered_ids.add(ready_id)
+        remaining_ids.remove(ready_id)
+
+    repaired_order = [call.id for call in ordered_calls]
+    if repaired_order != original_order:
+        ir.workflow.calls = ordered_calls
+        actions.append(
+            "Reordered workflow calls to satisfy upstream output dependencies: "
+            f"{' -> '.join(repaired_order)}"
+        )
+
+
+def _call_dependencies(expressions, call_by_id) -> set[str]:
+    dependencies = set()
+    for expression in expressions:
+        match = CALL_OUTPUT_PATTERN.match(expression.strip())
+        if match and match.group(1) in call_by_id:
+            dependencies.add(match.group(1))
+    return dependencies
+
+
+def _repair_output_literals(ir: WorkflowIR, actions: list[str]) -> None:
+    for task_name, task in ir.tasks.items():
+        task_input_names = set(task.inputs)
+
+        for output_name, output in task.outputs.items():
+            repaired_value = _repair_output_value(
+                output_name=output_name,
+                output_type=output.type,
+                value=output.value,
+                task_input_names=task_input_names,
+            )
+            if repaired_value != output.value:
+                output.value = repaired_value
+                actions.append(
+                    f"Repaired task '{task_name}' output '{output_name}' value to {repaired_value}"
+                )
+
+
+def _repair_output_value(
+    output_name: str,
+    output_type: str,
+    value: str,
+    task_input_names: set[str],
+) -> str:
+    stripped = value.strip()
+    base_type = output_type.strip().rstrip("?")
+
+    if not stripped:
+        return _default_output_value(output_name, base_type)
+
+    if base_type not in {"File", "String"}:
+        return stripped
+
+    if _is_quoted(stripped) or _is_expression_like(stripped):
+        return stripped
+
+    if IDENTIFIER_PATTERN.match(stripped) and stripped in task_input_names:
+        return stripped
+
+    if SAFE_LITERAL_PATTERN.match(stripped):
+        return json.dumps(stripped)
+
+    return stripped
+
+
+def _is_quoted(value: str) -> bool:
+    return len(value) >= 2 and value[0] == '"' and value[-1] == '"'
+
+
+def _is_expression_like(value: str) -> bool:
+    return any(char in value for char in "()[]{}~+*?:<>=!|&")
+
+
+def _default_output_value(output_name: str, base_type: str) -> str:
+    if base_type in {"File", "String"}:
+        return json.dumps(output_name)
+    if base_type == "Boolean":
+        return "false"
+    if base_type == "Float":
+        return "0.0"
+    if base_type == "Int":
+        return "0"
+    return output_name

--- a/src/schema.py
+++ b/src/schema.py
@@ -1,0 +1,275 @@
+import copy
+import re
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+IDENTIFIER_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+COMMAND_INPUT_PATTERN = re.compile(r"~\{\s*([A-Za-z_][A-Za-z0-9_]*)\s*\}")
+
+
+class RuntimeSpec(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    docker: str | None = None
+    cpu: int | None = None
+    memory: str | None = None
+    disks: str | None = None
+
+
+class OutputSpec(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    type: str
+    value: str
+
+
+class TaskSpec(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    inputs: dict[str, str] = Field(default_factory=dict)
+    command: str
+    outputs: dict[str, OutputSpec] = Field(default_factory=dict)
+    runtime: RuntimeSpec = Field(default_factory=RuntimeSpec)
+
+    @field_validator("inputs")
+    @classmethod
+    def validate_input_names(cls, value: dict[str, str]) -> dict[str, str]:
+        _validate_mapping_keys(value, "task input")
+        return value
+
+    @field_validator("outputs")
+    @classmethod
+    def validate_output_names(cls, value: dict[str, OutputSpec]) -> dict[str, OutputSpec]:
+        _validate_mapping_keys(value, "task output")
+        return value
+
+
+class CallSpec(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    task: str
+    inputs: dict[str, str] = Field(default_factory=dict)
+
+    @field_validator("id", "task")
+    @classmethod
+    def validate_call_identifiers(cls, value: str) -> str:
+        _validate_identifier(value, "call or task name")
+        return value
+
+    @field_validator("inputs")
+    @classmethod
+    def validate_call_input_names(cls, value: dict[str, str]) -> dict[str, str]:
+        _validate_mapping_keys(value, "call input")
+        return value
+
+
+class WorkflowSpec(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    inputs: dict[str, str] = Field(default_factory=dict)
+    calls: list[CallSpec] = Field(default_factory=list)
+    outputs: dict[str, str] = Field(default_factory=dict)
+
+    @field_validator("name")
+    @classmethod
+    def validate_workflow_name(cls, value: str) -> str:
+        _validate_identifier(value, "workflow name")
+        return value
+
+    @field_validator("inputs")
+    @classmethod
+    def validate_workflow_input_names(cls, value: dict[str, str]) -> dict[str, str]:
+        _validate_mapping_keys(value, "workflow input")
+        return value
+
+    @field_validator("outputs")
+    @classmethod
+    def validate_workflow_output_names(cls, value: dict[str, str]) -> dict[str, str]:
+        _validate_mapping_keys(value, "workflow output")
+        return value
+
+
+class WorkflowIR(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    version: str = "1.0"
+    workflow: WorkflowSpec
+    tasks: dict[str, TaskSpec]
+
+    @field_validator("tasks")
+    @classmethod
+    def validate_task_names(cls, value: dict[str, TaskSpec]) -> dict[str, TaskSpec]:
+        _validate_mapping_keys(value, "task")
+        return value
+
+
+def coerce_workflow_ir(data: WorkflowIR | dict[str, Any]) -> WorkflowIR:
+    """Normalize supported user JSON shapes into the internal WorkflowIR."""
+    if isinstance(data, WorkflowIR):
+        return data
+    if not isinstance(data, dict):
+        raise TypeError("workflow input must be a dictionary")
+
+    if "workflow" in data and "tasks" in data:
+        return WorkflowIR.model_validate(_normalize_ir_dict(data))
+
+    if "workflow_name" in data and "tasks" in data:
+        return WorkflowIR.model_validate(_legacy_to_ir_dict(data))
+
+    raise ValueError(
+        "unsupported workflow JSON: expected either {'workflow', 'tasks'} "
+        "or legacy {'workflow_name', 'tasks'}"
+    )
+
+
+def extract_command_inputs(command: str) -> set[str]:
+    return set(COMMAND_INPUT_PATTERN.findall(command or ""))
+
+
+def _normalize_ir_dict(data: dict[str, Any]) -> dict[str, Any]:
+    normalized = copy.deepcopy(data)
+    tasks = normalized.get("tasks", {})
+
+    if isinstance(tasks, list):
+        normalized["tasks"] = {
+            task["name"]: _normalize_task_dict(task)
+            for task in tasks
+        }
+    elif isinstance(tasks, dict):
+        normalized["tasks"] = {
+            task_name: _normalize_task_dict(task_data)
+            for task_name, task_data in tasks.items()
+        }
+
+    return normalized
+
+
+def _legacy_to_ir_dict(data: dict[str, Any]) -> dict[str, Any]:
+    workflow_inputs = dict(data.get("inputs", {}))
+    task_defs: dict[str, dict[str, Any]] = {}
+    calls: list[dict[str, Any]] = []
+    previous_task_outputs: dict[str, dict[str, str]] = {}
+
+    for raw_task in data.get("tasks", []):
+        task_name = raw_task["name"]
+        call_inputs = dict(raw_task.get("inputs", {}))
+        command = raw_task.get("command", "")
+
+        if not call_inputs:
+            call_inputs = {
+                input_name: input_name
+                for input_name in sorted(extract_command_inputs(command))
+            }
+
+        task_inputs = {
+            input_name: _infer_source_type(source, workflow_inputs, previous_task_outputs)
+            for input_name, source in call_inputs.items()
+        }
+
+        outputs = _normalize_outputs(raw_task.get("outputs", {}))
+        task_defs[task_name] = {
+            "inputs": task_inputs,
+            "command": command,
+            "outputs": outputs,
+            "runtime": _normalize_runtime(raw_task),
+        }
+        calls.append({"id": task_name, "task": task_name, "inputs": call_inputs})
+        previous_task_outputs[task_name] = {
+            output_name: output_spec["type"]
+            for output_name, output_spec in outputs.items()
+        }
+
+    workflow_outputs = dict(data.get("outputs", {}))
+    if not workflow_outputs and calls:
+        last_call_id = calls[-1]["id"]
+        workflow_outputs = {
+            output_name: f"{last_call_id}.{output_name}"
+            for output_name in task_defs[last_call_id]["outputs"]
+        }
+
+    return {
+        "version": "1.0",
+        "workflow": {
+            "name": data["workflow_name"],
+            "inputs": workflow_inputs,
+            "calls": calls,
+            "outputs": workflow_outputs,
+        },
+        "tasks": task_defs,
+    }
+
+
+def _normalize_task_dict(task_data: dict[str, Any]) -> dict[str, Any]:
+    normalized = copy.deepcopy(task_data)
+    normalized.pop("name", None)
+    normalized["outputs"] = _normalize_outputs(normalized.get("outputs", {}))
+    normalized["runtime"] = _normalize_runtime(normalized)
+    normalized.pop("docker", None)
+    return normalized
+
+
+def _normalize_outputs(outputs: dict[str, Any]) -> dict[str, dict[str, str]]:
+    normalized = {}
+    for output_name, output_spec in outputs.items():
+        if isinstance(output_spec, str):
+            normalized[output_name] = {
+                "type": output_spec,
+                "value": _default_output_value(output_name, output_spec),
+            }
+        else:
+            normalized[output_name] = output_spec
+    return normalized
+
+
+def _normalize_runtime(task_data: dict[str, Any]) -> dict[str, Any]:
+    runtime = dict(task_data.get("runtime", {}))
+    docker = task_data.get("docker")
+    if docker and "docker" not in runtime:
+        runtime["docker"] = docker
+    return runtime
+
+
+def _infer_source_type(
+    source: str,
+    workflow_inputs: dict[str, str],
+    previous_task_outputs: dict[str, dict[str, str]],
+) -> str:
+    if source in workflow_inputs:
+        return workflow_inputs[source]
+    if "." in source:
+        call_id, output_name = source.split(".", 1)
+        return previous_task_outputs.get(call_id, {}).get(output_name, "String")
+    if source.startswith('"') and source.endswith('"'):
+        return "String"
+    if source in {"true", "false"}:
+        return "Boolean"
+    if source.isdigit():
+        return "Int"
+    return "String"
+
+
+def _default_output_value(output_name: str, output_type: str) -> str:
+    base_type = output_type.rstrip("?")
+    if base_type in {"File", "String"}:
+        return f'"{output_name}"'
+    if base_type == "Boolean":
+        return "false"
+    if base_type == "Float":
+        return "0.0"
+    if base_type == "Int":
+        return "0"
+    return output_name
+
+
+def _validate_mapping_keys(value: dict[str, Any], label: str) -> None:
+    for key in value:
+        _validate_identifier(key, label)
+
+
+def _validate_identifier(value: str, label: str) -> None:
+    if not IDENTIFIER_PATTERN.match(value):
+        raise ValueError(f"invalid {label}: {value!r}")

--- a/src/state.py
+++ b/src/state.py
@@ -1,6 +1,8 @@
-from typing_extensions import TypedDict, Annotated
-from langchain_core.messages import AnyMessage
 import operator
+
+from langchain_core.messages import AnyMessage
+from typing_extensions import Annotated, TypedDict
+
 
 class WorkflowState(TypedDict):
     # 存放 LLM 的所有对话记录（必须用 operator.add 保证是追加模式）

--- a/src/state.py
+++ b/src/state.py
@@ -28,6 +28,12 @@ class WorkflowState(TypedDict):
     
     # 记录当前重试或循环的次数，防止死循环
     error_count: int
+
+    # 记录 IR repairer 已经尝试的次数，防止修复循环
+    repair_count: int
+
+    # 记录最近一次 IR repairer 执行的具体修复动作
+    repair_actions: list[str]
     
     # 用一个明确的布尔值来记录校验状态，True 代表校验通过，False 代表校验失败
     is_valid: bool

--- a/src/state.py
+++ b/src/state.py
@@ -14,3 +14,6 @@ class WorkflowState(TypedDict):
     
     # 记录当前重试或循环的次数，防止死循环
     error_count: int
+    
+    # 用一个明确的布尔值来记录校验状态，True 代表校验通过，False 代表校验失败
+    is_valid: bool

--- a/src/state.py
+++ b/src/state.py
@@ -1,0 +1,16 @@
+from typing_extensions import TypedDict, Annotated
+from langchain_core.messages import AnyMessage
+import operator
+
+class WorkflowState(TypedDict):
+    # 存放 LLM 的所有对话记录（必须用 operator.add 保证是追加模式）
+    messages: Annotated[list[AnyMessage], operator.add]
+    
+    # 存放用户从前端传来的结构化表单数据（JSON格式）
+    parsed_json: dict 
+    
+    # 存放模型生成的 WDL 代码（用于后续验证器检查）
+    current_wdl: str 
+    
+    # 记录当前重试或循环的次数，防止死循环
+    error_count: int

--- a/src/state.py
+++ b/src/state.py
@@ -1,0 +1,19 @@
+from typing_extensions import TypedDict, Annotated
+from langchain_core.messages import AnyMessage
+import operator
+
+class WorkflowState(TypedDict):
+    # 存放 LLM 的所有对话记录（必须用 operator.add 保证是追加模式）
+    messages: Annotated[list[AnyMessage], operator.add]
+    
+    # 存放用户从前端传来的结构化表单数据（JSON格式）
+    parsed_json: dict 
+    
+    # 存放模型生成的 WDL 代码（用于后续验证器检查）
+    current_wdl: str 
+    
+    # 记录当前重试或循环的次数，防止死循环
+    error_count: int
+    
+    # 用一个明确的布尔值来记录校验状态，True 代表校验通过，False 代表校验失败
+    is_valid: bool

--- a/src/state.py
+++ b/src/state.py
@@ -10,9 +10,21 @@ class WorkflowState(TypedDict):
     
     # 存放用户从前端传来的结构化表单数据（JSON格式）
     parsed_json: dict 
+
+    # 标准化后的内部工作流表示，后续节点只处理这个 IR
+    workflow_ir: dict
+
+    # IR 静态分析阶段产生的错误
+    analysis_errors: list[str]
+
+    # IR 静态分析阶段产生的警告
+    analysis_warnings: list[str]
     
     # 存放模型生成的 WDL 代码（用于后续验证器检查）
     current_wdl: str 
+
+    # miniwdl 或系统校验阶段返回的最后一条消息
+    validation_message: str
     
     # 记录当前重试或循环的次数，防止死循环
     error_count: int

--- a/src/state.py
+++ b/src/state.py
@@ -11,6 +11,12 @@ class WorkflowState(TypedDict):
     # 存放用户从前端传来的结构化表单数据（JSON格式）
     parsed_json: dict 
 
+    # 是否启用缺失 container 镜像补全
+    fill_containers: bool
+
+    # 离线 container 候选，格式为 {"tool@version": ["image", ...]}
+    container_image_candidates: dict[str, list[str]]
+
     # 标准化后的内部工作流表示，后续节点只处理这个 IR
     workflow_ir: dict
 

--- a/src/tools/validator.py
+++ b/src/tools/validator.py
@@ -1,8 +1,15 @@
 import os
+import shutil
 import subprocess
+import sys
 import tempfile
+from pathlib import Path
 
 from langchain_core.tools import tool
+
+
+def miniwdl_available() -> bool:
+    return _miniwdl_executable() is not None
 
 
 @tool
@@ -21,12 +28,19 @@ def wdl_validator(wdl_code: str) -> dict:
 
     try:
         # 2. 使用子进程在命令行中运行 `miniwdl check`
-        result = subprocess.run(
-            ["miniwdl", "check", temp_file_path],
-            capture_output=True,
-            text=True,
-            check=False  # 设置为 False，这样报错时 Python 不会崩溃，而是让我们自己处理
-        )
+        miniwdl_executable = _miniwdl_executable()
+        if miniwdl_executable is None:
+            return _missing_miniwdl_result()
+
+        try:
+            result = subprocess.run(
+                [miniwdl_executable, "check", temp_file_path],
+                capture_output=True,
+                text=True,
+                check=False  # 设置为 False，这样报错时 Python 不会崩溃，而是让我们自己处理
+            )
+        except FileNotFoundError:
+            return _missing_miniwdl_result()
 
         # 3. 解析执行结果
         if result.returncode == 0:
@@ -52,3 +66,22 @@ def wdl_validator(wdl_code: str) -> dict:
         # 4. 无论成功还是失败，都必须清理系统垃圾（删除临时文件）
         if os.path.exists(temp_file_path):
             os.remove(temp_file_path)
+
+
+def _miniwdl_executable() -> str | None:
+    executable = shutil.which("miniwdl")
+    if executable:
+        return executable
+
+    sibling = Path(sys.executable).with_name("miniwdl")
+    if sibling.exists():
+        return str(sibling)
+
+    return None
+
+
+def _missing_miniwdl_result() -> dict:
+    return {
+        "is_valid": False,
+        "message": "❌ 未找到 miniwdl 可执行文件，请先安装依赖或使用 `uv run` 执行。"
+    }

--- a/src/tools/validator.py
+++ b/src/tools/validator.py
@@ -1,7 +1,9 @@
+import os
 import subprocess
 import tempfile
-import os
+
 from langchain_core.tools import tool
+
 
 @tool
 def wdl_validator(wdl_code: str) -> dict:

--- a/src/tools/validator.py
+++ b/src/tools/validator.py
@@ -1,0 +1,52 @@
+import subprocess
+import tempfile
+import os
+from langchain_core.tools import tool
+
+@tool
+def wdl_validator(wdl_code: str) -> dict:
+    """
+    使用 miniwdl 校验 WDL 代码语法的合法性。
+    如果代码有错，会返回具体的错误行号和原因。
+    """
+    print("🛠️ Validator 工具正在校验代码语法...")
+    
+    # 1. 创建一个安全的临时文件来存放 WDL 代码
+    # delete=False 是因为 subprocess 需要在外部读取它，我们稍后手动删除
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.wdl', delete=False) as temp_file:
+        temp_file.write(wdl_code)
+        temp_file_path = temp_file.name
+
+    try:
+        # 2. 使用子进程在命令行中运行 `miniwdl check`
+        result = subprocess.run(
+            ["miniwdl", "check", temp_file_path],
+            capture_output=True,
+            text=True,
+            check=False  # 设置为 False，这样报错时 Python 不会崩溃，而是让我们自己处理
+        )
+
+        # 3. 解析执行结果
+        if result.returncode == 0:
+            return {
+                "is_valid": True,
+                "message": "✅ WDL 语法校验通过！没有发现任何错误。"
+            }
+        else:
+            # 提取报错信息（miniwdl 的主要报错通常在 stderr 中）
+            error_msg = result.stderr.strip() if result.stderr else result.stdout.strip()
+            
+            # 【高级工程技巧】
+            # 将系统生成的长串临时路径（如 /tmp/tmp_abc123.wdl）替换为干净的文件名
+            # 防止长串无意义的路径干扰大模型的注意力
+            clean_error_msg = error_msg.replace(temp_file_path, "generated.wdl")
+            
+            return {
+                "is_valid": False,
+                "message": f"❌ WDL 语法校验失败！请根据以下错误信息反思并重新输出修改后的完整代码：\n\n{clean_error_msg}"
+            }
+
+    finally:
+        # 4. 无论成功还是失败，都必须清理系统垃圾（删除临时文件）
+        if os.path.exists(temp_file_path):
+            os.remove(temp_file_path)

--- a/src/tools/validator.py
+++ b/src/tools/validator.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import shutil
 import subprocess
@@ -6,6 +7,9 @@ import tempfile
 from pathlib import Path
 
 from langchain_core.tools import tool
+
+
+logger = logging.getLogger(__name__)
 
 
 def miniwdl_available() -> bool:
@@ -18,7 +22,7 @@ def wdl_validator(wdl_code: str) -> dict:
     使用 miniwdl 校验 WDL 代码语法的合法性。
     如果代码有错，会返回具体的错误行号和原因。
     """
-    print("🛠️ Validator 工具正在校验代码语法...")
+    logger.info("Validator tool is checking WDL syntax.")
     
     # 1. 创建一个安全的临时文件来存放 WDL 代码
     # delete=False 是因为 subprocess 需要在外部读取它，我们稍后手动删除

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# Makes the test suite discoverable with `python -m unittest discover`.

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -94,6 +94,8 @@ class CatalogResolutionTests(unittest.TestCase):
         self.assertIn("File deg_table = deg.deg_table", wdl)
         self.assertIn("--contrast ~{contrast}", wdl)
         self.assertIn('contrast = "condition"', wdl)
+        self.assertIn("-I ~{r2}\n    -o clean_R1.fq.gz", wdl)
+        self.assertIn("-O clean_R2.fq.gz\n    --thread ~{thread}", wdl)
 
     def test_resolver_rejects_tool_not_allowed_for_recipe_step(self):
         plan = copy.deepcopy(sample_rnaseq_tool_plan())

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1,5 +1,6 @@
 import copy
 import unittest
+from typing import Any
 
 from src.analyzer import analyze_workflow_ir
 from src.catalog import load_tool_catalog, resolve_tool_plan
@@ -7,7 +8,7 @@ from src.recipes import load_recipe_catalog
 from src.renderers import render_wdl
 
 
-def sample_rnaseq_tool_plan():
+def sample_rnaseq_tool_plan() -> dict[str, Any]:
     return {
         "workflow": {
             "name": "RNASeqDEG",
@@ -95,11 +96,51 @@ class CatalogResolutionTests(unittest.TestCase):
         self.assertIn('contrast = "condition"', wdl)
 
     def test_resolver_rejects_tool_not_allowed_for_recipe_step(self):
-        plan = sample_rnaseq_tool_plan()
+        plan = copy.deepcopy(sample_rnaseq_tool_plan())
         plan["workflow"]["tool_calls"][0]["tool"] = "salmon"
         plan["workflow"]["tool_calls"][0]["version"] = "1.10.2"
 
         with self.assertRaisesRegex(ValueError, "not allowed for recipe step 'qc'"):
+            resolve_tool_plan(plan, self.recipe_catalog, self.tool_catalog)
+
+    def test_resolver_rejects_unknown_recipe_step(self):
+        plan = copy.deepcopy(sample_rnaseq_tool_plan())
+        plan["workflow"]["tool_calls"][0]["step"] = "magic"
+
+        with self.assertRaisesRegex(ValueError, "references unknown recipe step 'magic'"):
+            resolve_tool_plan(plan, self.recipe_catalog, self.tool_catalog)
+
+    def test_resolver_rejects_missing_required_recipe_step(self):
+        plan = copy.deepcopy(sample_rnaseq_tool_plan())
+        plan["workflow"]["tool_calls"] = plan["workflow"]["tool_calls"][:-1]
+
+        with self.assertRaisesRegex(ValueError, "missing required recipe step\\(s\\): differential_expression"):
+            resolve_tool_plan(plan, self.recipe_catalog, self.tool_catalog)
+
+    def test_resolver_rejects_duplicate_recipe_step(self):
+        plan = copy.deepcopy(sample_rnaseq_tool_plan())
+        duplicate_call = copy.deepcopy(plan["workflow"]["tool_calls"][0])
+        duplicate_call["id"] = "qc_again"
+        plan["workflow"]["tool_calls"].append(duplicate_call)
+
+        with self.assertRaisesRegex(ValueError, "duplicate tool calls for recipe step\\(s\\): qc"):
+            resolve_tool_plan(plan, self.recipe_catalog, self.tool_catalog)
+
+    def test_resolver_rejects_missing_required_workflow_input(self):
+        plan = copy.deepcopy(sample_rnaseq_tool_plan())
+        plan["workflow"]["inputs"].pop("sample_groups")
+
+        with self.assertRaisesRegex(ValueError, "missing required workflow input 'sample_groups'"):
+            resolve_tool_plan(plan, self.recipe_catalog, self.tool_catalog)
+
+    def test_resolver_rejects_required_workflow_input_type_mismatch(self):
+        plan = copy.deepcopy(sample_rnaseq_tool_plan())
+        plan["workflow"]["inputs"]["sample_groups"] = "String"
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "workflow input 'sample_groups' expects File but received String",
+        ):
             resolve_tool_plan(plan, self.recipe_catalog, self.tool_catalog)
 
     def test_resolver_rejects_unknown_param(self):

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -3,7 +3,7 @@ import unittest
 from typing import Any
 
 from src.analyzer import analyze_workflow_ir
-from src.catalog import load_tool_catalog, resolve_tool_plan
+from src.catalog import StaticContainerImageProvider, ToolCatalog, load_tool_catalog, resolve_tool_plan
 from src.recipes import load_recipe_catalog
 from src.renderers import render_wdl
 
@@ -96,6 +96,36 @@ class CatalogResolutionTests(unittest.TestCase):
         self.assertIn('contrast = "condition"', wdl)
         self.assertIn("-I ~{r2}\n    -o clean_R1.fq.gz", wdl)
         self.assertIn("-O clean_R2.fq.gz\n    --thread ~{thread}", wdl)
+
+    def test_resolver_fills_missing_container_when_provider_is_supplied(self):
+        tools = {
+            (tool.id, tool.version): tool
+            for tool in self.tool_catalog.all()
+        }
+        fastp = tools[("fastp", "0.23.2")]
+        runtime_without_docker = fastp.runtime.model_copy(update={"docker": None})
+        tools[("fastp", "0.23.2")] = fastp.model_copy(update={"runtime": runtime_without_docker})
+        tool_catalog = ToolCatalog(tools)
+        recipe_catalog = load_recipe_catalog(tool_catalog=tool_catalog)
+        container_provider = StaticContainerImageProvider(
+            {
+                ("fastp", "0.23.2"): [
+                    "quay.io/biocontainers/fastp:0.23.2--h5f740d0_0",
+                ]
+            }
+        )
+
+        workflow_ir = resolve_tool_plan(
+            sample_rnaseq_tool_plan(),
+            recipe_catalog,
+            tool_catalog,
+            container_provider=container_provider,
+        )
+
+        self.assertEqual(
+            workflow_ir.tasks["fastp_qc"].runtime.docker,
+            "quay.io/biocontainers/fastp:0.23.2--h5f740d0_0",
+        )
 
     def test_resolver_rejects_tool_not_allowed_for_recipe_step(self):
         plan = copy.deepcopy(sample_rnaseq_tool_plan())

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1,0 +1,114 @@
+import copy
+import unittest
+
+from src.analyzer import analyze_workflow_ir
+from src.catalog import load_tool_catalog, resolve_tool_plan
+from src.recipes import load_recipe_catalog
+from src.renderers import render_wdl
+
+
+def sample_rnaseq_tool_plan():
+    return {
+        "workflow": {
+            "name": "RNASeqDEG",
+            "recipe": "rnaseq_differential_expression",
+            "inputs": {
+                "raw_r1": "File",
+                "raw_r2": "File",
+                "transcriptome_index": "File",
+                "sample_groups": "File",
+            },
+            "tool_calls": [
+                {
+                    "id": "qc",
+                    "step": "qc",
+                    "tool": "fastp",
+                    "version": "0.23.2",
+                    "inputs": {
+                        "r1": "raw_r1",
+                        "r2": "raw_r2",
+                    },
+                    "params": {
+                        "thread": 4,
+                    },
+                },
+                {
+                    "id": "quantify",
+                    "step": "quantify",
+                    "tool": "salmon",
+                    "version": "1.10.2",
+                    "inputs": {
+                        "r1": "qc.clean_r1",
+                        "r2": "qc.clean_r2",
+                        "index": "transcriptome_index",
+                    },
+                    "params": {
+                        "thread": 8,
+                    },
+                },
+                {
+                    "id": "deg",
+                    "step": "differential_expression",
+                    "tool": "deseq2",
+                    "version": "1.42.0",
+                    "inputs": {
+                        "counts": "quantify.gene_counts",
+                        "sample_groups": "sample_groups",
+                    },
+                    "params": {
+                        "contrast": "condition",
+                    },
+                },
+            ],
+            "outputs": {
+                "deg_table": "deg.deg_table",
+            },
+        }
+    }
+
+
+class CatalogResolutionTests(unittest.TestCase):
+    def setUp(self):
+        self.tool_catalog = load_tool_catalog()
+        self.recipe_catalog = load_recipe_catalog(tool_catalog=self.tool_catalog)
+
+    def test_catalog_plan_resolves_to_valid_renderable_ir(self):
+        workflow_ir = resolve_tool_plan(
+            sample_rnaseq_tool_plan(),
+            self.recipe_catalog,
+            self.tool_catalog,
+        )
+        report = analyze_workflow_ir(workflow_ir)
+
+        self.assertTrue(report.is_valid, report.errors)
+        self.assertEqual(workflow_ir.workflow.name, "RNASeqDEG")
+        self.assertIn("fastp_qc", workflow_ir.tasks)
+        self.assertIn("salmon_quantify", workflow_ir.tasks)
+        self.assertIn("deseq2_deg", workflow_ir.tasks)
+
+        wdl = render_wdl(workflow_ir)
+        self.assertIn("call fastp_qc as qc", wdl)
+        self.assertIn("call salmon_quantify as quantify", wdl)
+        self.assertIn("call deseq2_deg as deg", wdl)
+        self.assertIn("File deg_table = deg.deg_table", wdl)
+        self.assertIn("--contrast ~{contrast}", wdl)
+        self.assertIn('contrast = "condition"', wdl)
+
+    def test_resolver_rejects_tool_not_allowed_for_recipe_step(self):
+        plan = sample_rnaseq_tool_plan()
+        plan["workflow"]["tool_calls"][0]["tool"] = "salmon"
+        plan["workflow"]["tool_calls"][0]["version"] = "1.10.2"
+
+        with self.assertRaisesRegex(ValueError, "not allowed for recipe step 'qc'"):
+            resolve_tool_plan(plan, self.recipe_catalog, self.tool_catalog)
+
+    def test_resolver_rejects_unknown_param(self):
+        plan = copy.deepcopy(sample_rnaseq_tool_plan())
+        plan["workflow"]["tool_calls"][0]["params"]["magic"] = 1
+
+        with self.assertRaisesRegex(ValueError, "unknown param 'magic'"):
+            resolve_tool_plan(plan, self.recipe_catalog, self.tool_catalog)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,100 @@
+import io
+import json
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+
+import main as cli
+
+
+EXAMPLES_DIR = Path(__file__).parents[1] / "examples"
+
+
+class CliTests(unittest.TestCase):
+    def test_load_workflow_input_reads_recipe_plan_example(self):
+        data = cli.load_workflow_input(EXAMPLES_DIR / "rnaseq_deg_recipe_plan.json")
+
+        self.assertEqual(data["workflow"]["name"], "RNASeqDEG")
+        self.assertEqual(data["workflow"]["recipe"], "rnaseq_differential_expression")
+
+    def test_cli_writes_wdl_output_from_recipe_plan_without_check(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "rnaseq_deg.wdl"
+            stdout = io.StringIO()
+            stderr = io.StringIO()
+
+            with redirect_stdout(stdout), redirect_stderr(stderr):
+                exit_code = cli.main(
+                    [
+                        "--input",
+                        str(EXAMPLES_DIR / "rnaseq_deg_recipe_plan.json"),
+                        "--output",
+                        str(output_path),
+                        "--print-ir",
+                        "--no-check",
+                    ]
+                )
+
+            self.assertEqual(exit_code, 0, stderr.getvalue())
+            self.assertTrue(output_path.exists())
+            self.assertIn("workflow RNASeqDEG", output_path.read_text(encoding="utf-8"))
+            self.assertIn('"workflow"', stdout.getvalue())
+            self.assertIn("WDL written to", stderr.getvalue())
+
+    def test_cli_returns_failure_for_invalid_recipe_plan(self):
+        plan = cli.load_workflow_input(EXAMPLES_DIR / "rnaseq_deg_recipe_plan.json")
+        plan["workflow"]["inputs"].pop("sample_groups")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            input_path = Path(tmpdir) / "invalid_plan.json"
+            input_path.write_text(json.dumps(plan), encoding="utf-8")
+            stdout = io.StringIO()
+            stderr = io.StringIO()
+
+            with redirect_stdout(stdout), redirect_stderr(stderr):
+                exit_code = cli.main(["--input", str(input_path), "--no-check"])
+
+            self.assertEqual(exit_code, 1)
+            self.assertEqual(stdout.getvalue(), "")
+            self.assertIn("missing required workflow input 'sample_groups'", stderr.getvalue())
+
+    def test_cli_stdout_is_pure_wdl_without_output_path(self):
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+
+        with redirect_stdout(stdout), redirect_stderr(stderr):
+            exit_code = cli.main(
+                [
+                    "--input",
+                    str(EXAMPLES_DIR / "rnaseq_workflow_ir.json"),
+                    "--no-check",
+                ]
+            )
+
+        self.assertEqual(exit_code, 0, stderr.getvalue())
+        self.assertTrue(stdout.getvalue().startswith("version 1.0\n"))
+        self.assertNotIn("Planner node", stdout.getvalue())
+        self.assertIn("WDL syntax validation skipped", stderr.getvalue())
+
+    def test_cli_verbose_logs_stay_on_stderr(self):
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+
+        with redirect_stdout(stdout), redirect_stderr(stderr):
+            exit_code = cli.main(
+                [
+                    "--input",
+                    str(EXAMPLES_DIR / "rnaseq_workflow_ir.json"),
+                    "--no-check",
+                    "--verbose",
+                ]
+            )
+
+        self.assertEqual(exit_code, 0, stderr.getvalue())
+        self.assertTrue(stdout.getvalue().startswith("version 1.0\n"))
+        self.assertIn("Planner node is normalizing Workflow IR.", stderr.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 import main as cli
+from src.nl_planner import NaturalLanguagePlanningError, NaturalLanguagePlanResult
 
 
 EXAMPLES_DIR = Path(__file__).parents[1] / "examples"
@@ -26,13 +27,18 @@ class CliTests(unittest.TestCase):
 
     def test_cli_compiles_natural_language_prompt_with_mock_planner(self):
         planned = cli.load_workflow_input(EXAMPLES_DIR / "rnaseq_deg_recipe_plan.json")
+        plan_result = NaturalLanguagePlanResult(
+            plan=planned,
+            planner_prompt="planner prompt",
+            raw_response=json.dumps(planned),
+        )
 
         with tempfile.TemporaryDirectory() as tmpdir:
             output_path = Path(tmpdir) / "rnaseq_deg.wdl"
             stdout = io.StringIO()
             stderr = io.StringIO()
 
-            with patch("main.plan_from_natural_language", return_value=planned) as planner:
+            with patch("main.create_natural_language_plan", return_value=plan_result) as planner:
                 with redirect_stdout(stdout), redirect_stderr(stderr):
                     exit_code = cli.main(
                         [
@@ -49,6 +55,84 @@ class CliTests(unittest.TestCase):
             planner.assert_called_once()
             self.assertIn('"recipe": "rnaseq_differential_expression"', stdout.getvalue())
             self.assertIn("workflow RNASeqDEG", output_path.read_text(encoding="utf-8"))
+
+    def test_cli_saves_natural_language_plan_and_planner_prompt(self):
+        planned = cli.load_workflow_input(EXAMPLES_DIR / "rnaseq_deg_recipe_plan.json")
+        plan_result = NaturalLanguagePlanResult(
+            plan=planned,
+            planner_prompt="planner prompt",
+            raw_response=json.dumps(planned),
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "rnaseq_deg.wdl"
+            plan_path = Path(tmpdir) / "plan.json"
+            prompt_path = Path(tmpdir) / "planner_prompt.txt"
+            stdout = io.StringIO()
+            stderr = io.StringIO()
+
+            with patch("main.build_default_planner_prompt", return_value="planner prompt"):
+                with patch("main.create_natural_language_plan", return_value=plan_result):
+                    with redirect_stdout(stdout), redirect_stderr(stderr):
+                        exit_code = cli.main(
+                            [
+                                "--prompt",
+                                "Run bulk RNA-seq differential expression.",
+                                "--output",
+                                str(output_path),
+                                "--save-plan",
+                                str(plan_path),
+                                "--save-planner-prompt",
+                                str(prompt_path),
+                                "--no-check",
+                            ]
+                        )
+
+            self.assertEqual(exit_code, 0, stderr.getvalue())
+            self.assertEqual(json.loads(plan_path.read_text(encoding="utf-8")), planned)
+            self.assertEqual(prompt_path.read_text(encoding="utf-8"), "planner prompt")
+            self.assertIn("Planner plan written to", stderr.getvalue())
+            self.assertIn("Planner prompt written to", stderr.getvalue())
+
+    def test_cli_reports_natural_language_planning_failure(self):
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+
+        with patch(
+            "main.create_natural_language_plan",
+            side_effect=NaturalLanguagePlanningError("LLM planner JSON parsing failed: bad json"),
+        ):
+            with redirect_stdout(stdout), redirect_stderr(stderr):
+                exit_code = cli.main(["--prompt", "Run RNA-seq differential expression."])
+
+        self.assertEqual(exit_code, 1)
+        self.assertEqual(stdout.getvalue(), "")
+        self.assertIn("Natural language planning failed", stderr.getvalue())
+        self.assertIn("JSON parsing failed", stderr.getvalue())
+
+    def test_cli_saves_planner_prompt_even_when_planning_fails(self):
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            prompt_path = Path(tmpdir) / "planner_prompt.txt"
+            with patch("main.build_default_planner_prompt", return_value="planner prompt"):
+                with patch(
+                    "main.create_natural_language_plan",
+                    side_effect=NaturalLanguagePlanningError("LLM planner JSON parsing failed: bad json"),
+                ):
+                    with redirect_stdout(stdout), redirect_stderr(stderr):
+                        exit_code = cli.main(
+                            [
+                                "--prompt",
+                                "Run RNA-seq differential expression.",
+                                "--save-planner-prompt",
+                                str(prompt_path),
+                            ]
+                        )
+
+            self.assertEqual(exit_code, 1)
+            self.assertEqual(prompt_path.read_text(encoding="utf-8"), "planner prompt")
 
     def test_cli_writes_wdl_output_from_recipe_plan_without_check(self):
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,6 +4,7 @@ import tempfile
 import unittest
 from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
+from unittest.mock import patch
 
 import main as cli
 
@@ -17,6 +18,37 @@ class CliTests(unittest.TestCase):
 
         self.assertEqual(data["workflow"]["name"], "RNASeqDEG")
         self.assertEqual(data["workflow"]["recipe"], "rnaseq_differential_expression")
+
+    def test_load_prompt_reads_prompt_file(self):
+        prompt = cli.load_prompt(prompt_file=EXAMPLES_DIR / "rnaseq_deg_request.txt")
+
+        self.assertIn("bulk RNA-seq differential expression", prompt)
+
+    def test_cli_compiles_natural_language_prompt_with_mock_planner(self):
+        planned = cli.load_workflow_input(EXAMPLES_DIR / "rnaseq_deg_recipe_plan.json")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "rnaseq_deg.wdl"
+            stdout = io.StringIO()
+            stderr = io.StringIO()
+
+            with patch("main.plan_from_natural_language", return_value=planned) as planner:
+                with redirect_stdout(stdout), redirect_stderr(stderr):
+                    exit_code = cli.main(
+                        [
+                            "--prompt",
+                            "Run bulk RNA-seq differential expression.",
+                            "--output",
+                            str(output_path),
+                            "--print-plan",
+                            "--no-check",
+                        ]
+                    )
+
+            self.assertEqual(exit_code, 0, stderr.getvalue())
+            planner.assert_called_once()
+            self.assertIn('"recipe": "rnaseq_differential_expression"', stdout.getvalue())
+            self.assertIn("workflow RNASeqDEG", output_path.read_text(encoding="utf-8"))
 
     def test_cli_writes_wdl_output_from_recipe_plan_without_check(self):
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,10 +7,23 @@ from pathlib import Path
 from unittest.mock import patch
 
 import main as cli
+from src.catalog import ToolCatalog, load_tool_catalog
 from src.nl_planner import NaturalLanguagePlanningError, NaturalLanguagePlanResult
+from src.recipes import load_recipe_catalog
 
 
 EXAMPLES_DIR = Path(__file__).parents[1] / "examples"
+
+
+def tool_catalog_without_fastp_docker() -> ToolCatalog:
+    tools = {
+        (tool.id, tool.version): tool
+        for tool in load_tool_catalog().all()
+    }
+    fastp = tools[("fastp", "0.23.2")]
+    runtime_without_docker = fastp.runtime.model_copy(update={"docker": None})
+    tools[("fastp", "0.23.2")] = fastp.model_copy(update={"runtime": runtime_without_docker})
+    return ToolCatalog(tools)
 
 
 class CliTests(unittest.TestCase):
@@ -24,6 +37,72 @@ class CliTests(unittest.TestCase):
         prompt = cli.load_prompt(prompt_file=EXAMPLES_DIR / "rnaseq_deg_request.txt")
 
         self.assertIn("bulk RNA-seq differential expression", prompt)
+
+    def test_load_container_image_candidates_reads_json_mapping(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "containers.json"
+            path.write_text(
+                json.dumps(
+                    {
+                        "fastp@0.23.2": "quay.io/biocontainers/fastp:0.23.2",
+                        "salmon@1.10.2": [
+                            "quay.io/biocontainers/salmon:1.10.2--h6dccd9a_2",
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            candidates = cli.load_container_image_candidates(path)
+
+        self.assertEqual(
+            candidates,
+            {
+                "fastp@0.23.2": ["quay.io/biocontainers/fastp:0.23.2"],
+                "salmon@1.10.2": [
+                    "quay.io/biocontainers/salmon:1.10.2--h6dccd9a_2",
+                ],
+            },
+        )
+
+    def test_cli_container_images_implies_fill_containers(self):
+        tool_catalog = tool_catalog_without_fastp_docker()
+        recipe_catalog = load_recipe_catalog(tool_catalog=tool_catalog)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "rnaseq_deg.wdl"
+            container_path = Path(tmpdir) / "containers.json"
+            container_path.write_text(
+                json.dumps(
+                    {
+                        "fastp@0.23.2": "quay.io/biocontainers/fastp:0.23.2--h5f740d0_0",
+                    }
+                ),
+                encoding="utf-8",
+            )
+            stdout = io.StringIO()
+            stderr = io.StringIO()
+
+            with patch("src.nodes.planner.load_tool_catalog", return_value=tool_catalog):
+                with patch("src.nodes.planner.load_recipe_catalog", return_value=recipe_catalog):
+                    with redirect_stdout(stdout), redirect_stderr(stderr):
+                        exit_code = cli.main(
+                            [
+                                "--input",
+                                str(EXAMPLES_DIR / "rnaseq_deg_recipe_plan.json"),
+                                "--container-images",
+                                str(container_path),
+                                "--output",
+                                str(output_path),
+                                "--no-check",
+                            ]
+                        )
+
+            self.assertEqual(exit_code, 0, stderr.getvalue())
+            self.assertIn(
+                "quay.io/biocontainers/fastp:0.23.2--h5f740d0_0",
+                output_path.read_text(encoding="utf-8"),
+            )
 
     def test_cli_compiles_natural_language_prompt_with_mock_planner(self):
         planned = cli.load_workflow_input(EXAMPLES_DIR / "rnaseq_deg_recipe_plan.json")

--- a/tests/test_container_resolver.py
+++ b/tests/test_container_resolver.py
@@ -8,7 +8,9 @@ from src.catalog import (
     StaticContainerImageProvider,
     ToolSpec,
     fill_missing_tool_container,
+    parse_tool_version_key,
     resolve_tool_container,
+    static_provider_from_image_map,
 )
 
 
@@ -114,6 +116,22 @@ class ContainerResolverTests(unittest.TestCase):
             provider.calls,
             [("fastp", "0.23.2", ("fastq qc", "adapter trimming"))],
         )
+
+    def test_static_provider_from_image_map_parses_tool_version_keys(self):
+        provider = static_provider_from_image_map(
+            {
+                "fastp@0.23.2": "quay.io/biocontainers/fastp:0.23.2",
+            }
+        )
+
+        self.assertEqual(
+            resolve_tool_container(make_tool(), provider),
+            "quay.io/biocontainers/fastp:0.23.2",
+        )
+
+    def test_parse_tool_version_key_rejects_malformed_key(self):
+        with self.assertRaisesRegex(ValueError, "<tool>@<version>"):
+            parse_tool_version_key("fastp")
 
     def test_missing_image_reports_tool_version(self):
         tool = make_tool()

--- a/tests/test_container_resolver.py
+++ b/tests/test_container_resolver.py
@@ -1,0 +1,144 @@
+import unittest
+from collections.abc import Sequence
+
+from src.catalog import (
+    AmbiguousContainerImageError,
+    ContainerImageCandidate,
+    ContainerImageNotFoundError,
+    StaticContainerImageProvider,
+    ToolSpec,
+    fill_missing_tool_container,
+    resolve_tool_container,
+)
+
+
+def make_tool(*, docker: str | None = None, aliases: list[str] | None = None) -> ToolSpec:
+    data = {
+        "id": "fastp",
+        "version": "0.23.2",
+        "aliases": aliases or ["fastq qc"],
+        "description": "FASTQ quality control.",
+        "inputs": {
+            "r1": {
+                "type": "File",
+                "required": True,
+            }
+        },
+        "params": {
+            "thread": {
+                "type": "Int",
+                "default": 4,
+                "min": 1,
+            }
+        },
+        "outputs": {
+            "clean_r1": {
+                "type": "File",
+                "value": '"clean_R1.fq.gz"',
+            }
+        },
+        "command_template": "fastp -i ~{r1} --thread ~{thread}",
+        "runtime": {
+            "cpu": 4,
+            "memory": "8G",
+        },
+    }
+    if docker:
+        data["runtime"]["docker"] = docker
+    return ToolSpec.model_validate(data)
+
+
+class FailingProvider:
+    def search(
+        self,
+        tool_id: str,
+        version: str,
+        aliases: Sequence[str] = (),
+    ) -> Sequence[ContainerImageCandidate]:
+        raise AssertionError("provider should not be called")
+
+
+class RecordingProvider:
+    def __init__(self):
+        self.calls: list[tuple[str, str, tuple[str, ...]]] = []
+
+    def search(
+        self,
+        tool_id: str,
+        version: str,
+        aliases: Sequence[str] = (),
+    ) -> Sequence[ContainerImageCandidate]:
+        self.calls.append((tool_id, version, tuple(aliases)))
+        return [ContainerImageCandidate("quay.io/biocontainers/fastp:0.23.2")]
+
+
+class ContainerResolverTests(unittest.TestCase):
+    def test_resolve_container_keeps_existing_docker_without_provider_lookup(self):
+        tool = make_tool(docker="quay.io/biocontainers/fastp:0.23.2")
+
+        self.assertEqual(
+            resolve_tool_container(tool, FailingProvider()),
+            "quay.io/biocontainers/fastp:0.23.2",
+        )
+        self.assertIs(fill_missing_tool_container(tool, FailingProvider()), tool)
+
+    def test_static_provider_fills_missing_docker_and_preserves_runtime(self):
+        tool = make_tool()
+        provider = StaticContainerImageProvider(
+            {
+                ("fastp", "0.23.2"): [
+                    "quay.io/biocontainers/fastp:0.23.2--h5f740d0_0",
+                ]
+            }
+        )
+
+        filled = fill_missing_tool_container(tool, provider)
+
+        self.assertIsNone(tool.runtime.docker)
+        self.assertEqual(filled.runtime.cpu, 4)
+        self.assertEqual(filled.runtime.memory, "8G")
+        self.assertEqual(
+            filled.runtime.docker,
+            "quay.io/biocontainers/fastp:0.23.2--h5f740d0_0",
+        )
+
+    def test_provider_receives_tool_identity_and_aliases(self):
+        tool = make_tool(aliases=["fastq qc", "adapter trimming"])
+        provider = RecordingProvider()
+
+        self.assertEqual(
+            resolve_tool_container(tool, provider),
+            "quay.io/biocontainers/fastp:0.23.2",
+        )
+        self.assertEqual(
+            provider.calls,
+            [("fastp", "0.23.2", ("fastq qc", "adapter trimming"))],
+        )
+
+    def test_missing_image_reports_tool_version(self):
+        tool = make_tool()
+        provider = StaticContainerImageProvider({})
+
+        with self.assertRaisesRegex(ContainerImageNotFoundError, "fastp@0.23.2"):
+            resolve_tool_container(tool, provider)
+
+    def test_ambiguous_image_requires_manual_selection(self):
+        tool = make_tool()
+        provider = StaticContainerImageProvider(
+            {
+                ("fastp", "0.23.2"): [
+                    "quay.io/biocontainers/fastp:0.23.2--h5f740d0_0",
+                    "quay.io/biocontainers/fastp:0.23.2--h79da9fb_1",
+                ]
+            }
+        )
+
+        with self.assertRaisesRegex(
+            AmbiguousContainerImageError,
+            "multiple container images found.*h5f740d0_0.*h79da9fb_1",
+        ):
+            resolve_tool_container(tool, provider)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -149,6 +149,8 @@ def sample_rnaseq_tool_plan() -> dict[str, Any]:
 def initial_state(parsed_json: dict[str, Any]) -> WorkflowState:
     state: WorkflowState = {
         "parsed_json": parsed_json,
+        "fill_containers": False,
+        "container_image_candidates": {},
         "workflow_ir": {},
         "analysis_errors": [],
         "analysis_warnings": [],

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,12 +1,14 @@
 import unittest
+from typing import Any
 
 from src.analyzer import analyze_workflow_ir
 from src.graph import agent
 from src.renderers import render_wdl
 from src.schema import coerce_workflow_ir
+from src.state import WorkflowState
 
 
-def sample_multi_task_ir():
+def sample_multi_task_ir() -> dict[str, Any]:
     return {
         "workflow": {
             "name": "RNASeqPipeline",
@@ -84,7 +86,7 @@ def sample_multi_task_ir():
     }
 
 
-def sample_rnaseq_tool_plan():
+def sample_rnaseq_tool_plan() -> dict[str, Any]:
     return {
         "workflow": {
             "name": "RNASeqDEG",
@@ -144,8 +146,8 @@ def sample_rnaseq_tool_plan():
     }
 
 
-def initial_state(parsed_json: dict):
-    return {
+def initial_state(parsed_json: dict[str, Any]) -> WorkflowState:
+    state: WorkflowState = {
         "parsed_json": parsed_json,
         "workflow_ir": {},
         "analysis_errors": [],
@@ -154,8 +156,11 @@ def initial_state(parsed_json: dict):
         "current_wdl": "",
         "validation_message": "",
         "error_count": 0,
+        "repair_count": 0,
+        "repair_actions": [],
         "is_valid": False,
     }
+    return state
 
 
 class WorkflowCompilationTests(unittest.TestCase):
@@ -183,6 +188,19 @@ class WorkflowCompilationTests(unittest.TestCase):
 
         self.assertFalse(report.is_valid)
         self.assertIn("references unavailable output 'qc.clean_r1'", "\n".join(report.errors))
+
+    def test_agent_repairs_forward_output_reference_order(self):
+        raw_ir = sample_multi_task_ir()
+        raw_ir["workflow"]["calls"].reverse()
+
+        final_state = agent.invoke(initial_state(raw_ir))
+
+        self.assertTrue(final_state["is_valid"], final_state["validation_message"])
+        self.assertEqual(
+            [call["id"] for call in final_state["workflow_ir"]["workflow"]["calls"]],
+            ["qc", "align"],
+        )
+        self.assertTrue(final_state["repair_actions"])
 
     def test_analyzer_allows_omitted_optional_call_inputs(self):
         raw_ir = sample_multi_task_ir()
@@ -217,6 +235,28 @@ class WorkflowCompilationTests(unittest.TestCase):
         self.assertEqual(workflow_ir.workflow.name, "SimpleQC")
         self.assertEqual(workflow_ir.workflow.calls[0].id, "fastp_qc")
         self.assertEqual(workflow_ir.tasks["fastp_qc"].runtime.docker, "quay.io/biocontainers/fastp:0.23.2")
+
+    def test_agent_repairs_bare_file_output_literals(self):
+        raw_ir = sample_multi_task_ir()
+        raw_ir["tasks"]["fastp"]["outputs"]["clean_r1"]["value"] = "clean_R1.fq.gz"
+        raw_ir["tasks"]["fastp"]["outputs"]["clean_r2"]["value"] = "clean_R2.fq.gz"
+
+        final_state = agent.invoke(initial_state(raw_ir))
+
+        self.assertTrue(final_state["is_valid"], final_state["validation_message"])
+        self.assertIn('File clean_r1 = "clean_R1.fq.gz"', final_state["current_wdl"])
+        self.assertIn('File clean_r2 = "clean_R2.fq.gz"', final_state["current_wdl"])
+        self.assertTrue(final_state["repair_actions"])
+
+    def test_agent_stops_when_repairer_has_no_safe_action(self):
+        raw_ir = sample_multi_task_ir()
+        raw_ir["workflow"]["calls"][0]["inputs"]["r1"] = "missing_input"
+
+        final_state = agent.invoke(initial_state(raw_ir))
+
+        self.assertFalse(final_state["is_valid"])
+        self.assertIn("references unknown value 'missing_input'", "\n".join(final_state["analysis_errors"]))
+        self.assertEqual(final_state["repair_actions"], [])
 
     def test_agent_compiles_recipe_tool_plan(self):
         final_state = agent.invoke(initial_state(sample_rnaseq_tool_plan()))

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,6 +1,7 @@
 import unittest
 
 from src.analyzer import analyze_workflow_ir
+from src.graph import agent
 from src.renderers import render_wdl
 from src.schema import coerce_workflow_ir
 
@@ -83,6 +84,80 @@ def sample_multi_task_ir():
     }
 
 
+def sample_rnaseq_tool_plan():
+    return {
+        "workflow": {
+            "name": "RNASeqDEG",
+            "recipe": "rnaseq_differential_expression",
+            "inputs": {
+                "raw_r1": "File",
+                "raw_r2": "File",
+                "transcriptome_index": "File",
+                "sample_groups": "File",
+            },
+            "tool_calls": [
+                {
+                    "id": "qc",
+                    "step": "qc",
+                    "tool": "fastp",
+                    "version": "0.23.2",
+                    "inputs": {
+                        "r1": "raw_r1",
+                        "r2": "raw_r2",
+                    },
+                    "params": {
+                        "thread": 4,
+                    },
+                },
+                {
+                    "id": "quantify",
+                    "step": "quantify",
+                    "tool": "salmon",
+                    "version": "1.10.2",
+                    "inputs": {
+                        "r1": "qc.clean_r1",
+                        "r2": "qc.clean_r2",
+                        "index": "transcriptome_index",
+                    },
+                    "params": {
+                        "thread": 8,
+                    },
+                },
+                {
+                    "id": "deg",
+                    "step": "differential_expression",
+                    "tool": "deseq2",
+                    "version": "1.42.0",
+                    "inputs": {
+                        "counts": "quantify.gene_counts",
+                        "sample_groups": "sample_groups",
+                    },
+                    "params": {
+                        "contrast": "condition",
+                    },
+                },
+            ],
+            "outputs": {
+                "deg_table": "deg.deg_table",
+            },
+        }
+    }
+
+
+def initial_state(parsed_json: dict):
+    return {
+        "parsed_json": parsed_json,
+        "workflow_ir": {},
+        "analysis_errors": [],
+        "analysis_warnings": [],
+        "messages": [],
+        "current_wdl": "",
+        "validation_message": "",
+        "error_count": 0,
+        "is_valid": False,
+    }
+
+
 class WorkflowCompilationTests(unittest.TestCase):
     def test_multi_task_ir_analyzes_and_renders(self):
         workflow_ir = coerce_workflow_ir(sample_multi_task_ir())
@@ -142,6 +217,16 @@ class WorkflowCompilationTests(unittest.TestCase):
         self.assertEqual(workflow_ir.workflow.name, "SimpleQC")
         self.assertEqual(workflow_ir.workflow.calls[0].id, "fastp_qc")
         self.assertEqual(workflow_ir.tasks["fastp_qc"].runtime.docker, "quay.io/biocontainers/fastp:0.23.2")
+
+    def test_agent_compiles_recipe_tool_plan(self):
+        final_state = agent.invoke(initial_state(sample_rnaseq_tool_plan()))
+
+        self.assertTrue(final_state["is_valid"], final_state["validation_message"])
+        self.assertEqual(final_state["analysis_errors"], [])
+        self.assertIn("call fastp_qc as qc", final_state["current_wdl"])
+        self.assertIn("call salmon_quantify as quantify", final_state["current_wdl"])
+        self.assertIn("call deseq2_deg as deg", final_state["current_wdl"])
+        self.assertIn("File deg_table = deg.deg_table", final_state["current_wdl"])
 
 
 if __name__ == "__main__":

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,0 +1,138 @@
+import unittest
+
+from src.analyzer import analyze_workflow_ir
+from src.renderers import render_wdl
+from src.schema import coerce_workflow_ir
+
+
+def sample_multi_task_ir():
+    return {
+        "workflow": {
+            "name": "RNASeqPipeline",
+            "inputs": {
+                "raw_r1": "File",
+                "raw_r2": "File",
+                "reference": "File",
+            },
+            "calls": [
+                {
+                    "id": "qc",
+                    "task": "fastp",
+                    "inputs": {
+                        "r1": "raw_r1",
+                        "r2": "raw_r2",
+                    },
+                },
+                {
+                    "id": "align",
+                    "task": "bwa_mem",
+                    "inputs": {
+                        "r1": "qc.clean_r1",
+                        "r2": "qc.clean_r2",
+                        "ref": "reference",
+                    },
+                },
+            ],
+            "outputs": {
+                "bam": "align.bam",
+            },
+        },
+        "tasks": {
+            "fastp": {
+                "inputs": {
+                    "r1": "File",
+                    "r2": "File",
+                },
+                "command": "fastp -i ~{r1} -I ~{r2} -o clean_R1.fq.gz -O clean_R2.fq.gz",
+                "outputs": {
+                    "clean_r1": {
+                        "type": "File",
+                        "value": "\"clean_R1.fq.gz\"",
+                    },
+                    "clean_r2": {
+                        "type": "File",
+                        "value": "\"clean_R2.fq.gz\"",
+                    },
+                },
+                "runtime": {
+                    "docker": "quay.io/biocontainers/fastp:0.23.2",
+                    "cpu": 4,
+                    "memory": "8G",
+                },
+            },
+            "bwa_mem": {
+                "inputs": {
+                    "r1": "File",
+                    "r2": "File",
+                    "ref": "File",
+                },
+                "command": "bwa mem ~{ref} ~{r1} ~{r2} > aligned.sam",
+                "outputs": {
+                    "bam": {
+                        "type": "File",
+                        "value": "\"aligned.sam\"",
+                    },
+                },
+                "runtime": {
+                    "docker": "quay.io/biocontainers/bwa:0.7.17--hed695b0_7",
+                    "cpu": 8,
+                    "memory": "32G",
+                },
+            },
+        },
+    }
+
+
+class WorkflowCompilationTests(unittest.TestCase):
+    def test_multi_task_ir_analyzes_and_renders(self):
+        workflow_ir = coerce_workflow_ir(sample_multi_task_ir())
+        report = analyze_workflow_ir(workflow_ir)
+
+        self.assertTrue(report.is_valid, report.errors)
+
+        wdl = render_wdl(workflow_ir)
+        self.assertIn("workflow RNASeqPipeline", wdl)
+        self.assertIn("call fastp as qc", wdl)
+        self.assertIn("call bwa_mem as align", wdl)
+        self.assertIn("r1 = qc.clean_r1", wdl)
+        self.assertIn("File bam = align.bam", wdl)
+        self.assertIn("task fastp", wdl)
+        self.assertIn("task bwa_mem", wdl)
+
+    def test_analyzer_rejects_forward_output_reference(self):
+        raw_ir = sample_multi_task_ir()
+        raw_ir["workflow"]["calls"].reverse()
+
+        workflow_ir = coerce_workflow_ir(raw_ir)
+        report = analyze_workflow_ir(workflow_ir)
+
+        self.assertFalse(report.is_valid)
+        self.assertIn("references unavailable output 'qc.clean_r1'", "\n".join(report.errors))
+
+    def test_legacy_json_is_normalized_to_ir(self):
+        legacy_json = {
+            "workflow_name": "SimpleQC",
+            "inputs": {
+                "raw_fastq": "File",
+            },
+            "tasks": [
+                {
+                    "name": "fastp_qc",
+                    "docker": "quay.io/biocontainers/fastp:0.23.2",
+                    "command": "fastp -i ~{raw_fastq} -o out.fq",
+                    "outputs": {
+                        "clean_fastq": "File",
+                    },
+                },
+            ],
+        }
+
+        workflow_ir = coerce_workflow_ir(legacy_json)
+
+        self.assertEqual(workflow_ir.workflow.name, "SimpleQC")
+        self.assertEqual(workflow_ir.workflow.calls[0].id, "fastp_qc")
+        self.assertEqual(workflow_ir.tasks["fastp_qc"].runtime.docker, "quay.io/biocontainers/fastp:0.23.2")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -109,6 +109,16 @@ class WorkflowCompilationTests(unittest.TestCase):
         self.assertFalse(report.is_valid)
         self.assertIn("references unavailable output 'qc.clean_r1'", "\n".join(report.errors))
 
+    def test_analyzer_allows_omitted_optional_call_inputs(self):
+        raw_ir = sample_multi_task_ir()
+        raw_ir["tasks"]["fastp"]["inputs"]["r2"] = "File?"
+        raw_ir["workflow"]["calls"][0]["inputs"].pop("r2")
+
+        workflow_ir = coerce_workflow_ir(raw_ir)
+        report = analyze_workflow_ir(workflow_ir)
+
+        self.assertTrue(report.is_valid, report.errors)
+
     def test_legacy_json_is_normalized_to_ir(self):
         legacy_json = {
             "workflow_name": "SimpleQC",

--- a/tests/test_nl_planner.py
+++ b/tests/test_nl_planner.py
@@ -4,8 +4,12 @@ from types import SimpleNamespace
 
 from src.catalog import load_tool_catalog
 from src.nl_planner import (
-    NaturalLanguagePlanningError,
+    PlannerCatalogError,
+    PlannerJsonError,
+    PlannerSchemaError,
+    build_default_planner_prompt,
     build_planner_prompt,
+    create_natural_language_plan,
     parse_json_object,
     plan_from_natural_language,
 )
@@ -89,7 +93,7 @@ class NaturalLanguagePlannerTests(unittest.TestCase):
         self.assertEqual(parsed["workflow"]["name"], "Demo")
 
     def test_parse_json_object_rejects_non_json(self):
-        with self.assertRaisesRegex(NaturalLanguagePlanningError, "does not contain a JSON object"):
+        with self.assertRaisesRegex(PlannerJsonError, "does not contain a JSON object"):
             parse_json_object("I would run fastp first.")
 
     def test_build_planner_prompt_includes_catalog_and_request(self):
@@ -116,6 +120,44 @@ class NaturalLanguagePlannerTests(unittest.TestCase):
 
         self.assertEqual(plan["workflow"]["recipe"], "rnaseq_differential_expression")
         self.assertIn("Run RNA-seq differential expression.", fake_llm.prompts[0])
+
+    def test_create_natural_language_plan_returns_observability_details(self):
+        fake_llm = FakePlannerLlm(json.dumps(sample_rnaseq_tool_plan()))
+
+        result = create_natural_language_plan(
+            "Run RNA-seq differential expression.",
+            llm=fake_llm,
+        )
+
+        self.assertEqual(result.plan["workflow"]["recipe"], "rnaseq_differential_expression")
+        self.assertIn("Catalog:", result.planner_prompt)
+        self.assertIn("RNASeqDEG", result.raw_response)
+
+    def test_plan_from_natural_language_reports_schema_error(self):
+        fake_llm = FakePlannerLlm(json.dumps({"workflow": {"name": "RNASeqDEG"}}))
+
+        with self.assertRaisesRegex(PlannerSchemaError, "plan schema validation failed"):
+            plan_from_natural_language(
+                "Run RNA-seq differential expression.",
+                llm=fake_llm,
+            )
+
+    def test_plan_from_natural_language_reports_catalog_error(self):
+        plan = sample_rnaseq_tool_plan()
+        plan["workflow"]["tool_calls"] = plan["workflow"]["tool_calls"][:-1]
+        fake_llm = FakePlannerLlm(json.dumps(plan))
+
+        with self.assertRaisesRegex(PlannerCatalogError, "recipe/catalog validation failed"):
+            plan_from_natural_language(
+                "Run RNA-seq differential expression.",
+                llm=fake_llm,
+            )
+
+    def test_build_default_planner_prompt_loads_catalog(self):
+        prompt = build_default_planner_prompt("Run RNA-seq differential expression.")
+
+        self.assertIn("rnaseq_differential_expression", prompt)
+        self.assertIn("Run RNA-seq differential expression.", prompt)
 
 
 if __name__ == "__main__":

--- a/tests/test_nl_planner.py
+++ b/tests/test_nl_planner.py
@@ -1,0 +1,122 @@
+import json
+import unittest
+from types import SimpleNamespace
+
+from src.catalog import load_tool_catalog
+from src.nl_planner import (
+    NaturalLanguagePlanningError,
+    build_planner_prompt,
+    parse_json_object,
+    plan_from_natural_language,
+)
+from src.recipes import load_recipe_catalog
+
+
+def sample_rnaseq_tool_plan():
+    return {
+        "workflow": {
+            "name": "RNASeqDEG",
+            "recipe": "rnaseq_differential_expression",
+            "inputs": {
+                "raw_r1": "File",
+                "raw_r2": "File",
+                "transcriptome_index": "File",
+                "sample_groups": "File",
+            },
+            "tool_calls": [
+                {
+                    "id": "qc",
+                    "step": "qc",
+                    "tool": "fastp",
+                    "version": "0.23.2",
+                    "inputs": {
+                        "r1": "raw_r1",
+                        "r2": "raw_r2",
+                    },
+                    "params": {
+                        "thread": 4,
+                    },
+                },
+                {
+                    "id": "quantify",
+                    "step": "quantify",
+                    "tool": "salmon",
+                    "version": "1.10.2",
+                    "inputs": {
+                        "r1": "qc.clean_r1",
+                        "r2": "qc.clean_r2",
+                        "index": "transcriptome_index",
+                    },
+                    "params": {
+                        "thread": 8,
+                    },
+                },
+                {
+                    "id": "deg",
+                    "step": "differential_expression",
+                    "tool": "deseq2",
+                    "version": "1.42.0",
+                    "inputs": {
+                        "counts": "quantify.gene_counts",
+                        "sample_groups": "sample_groups",
+                    },
+                    "params": {
+                        "contrast": "condition",
+                    },
+                },
+            ],
+            "outputs": {
+                "deg_table": "deg.deg_table",
+            },
+        }
+    }
+
+
+class FakePlannerLlm:
+    def __init__(self, response: str):
+        self.response = response
+        self.prompts = []
+
+    def invoke(self, prompt: str):
+        self.prompts.append(prompt)
+        return SimpleNamespace(content=self.response)
+
+
+class NaturalLanguagePlannerTests(unittest.TestCase):
+    def test_parse_json_object_accepts_fenced_json(self):
+        parsed = parse_json_object('```json\n{"workflow": {"name": "Demo"}}\n```')
+
+        self.assertEqual(parsed["workflow"]["name"], "Demo")
+
+    def test_parse_json_object_rejects_non_json(self):
+        with self.assertRaisesRegex(NaturalLanguagePlanningError, "does not contain a JSON object"):
+            parse_json_object("I would run fastp first.")
+
+    def test_build_planner_prompt_includes_catalog_and_request(self):
+        tool_catalog = load_tool_catalog()
+        recipe_catalog = load_recipe_catalog(tool_catalog=tool_catalog)
+
+        prompt = build_planner_prompt(
+            "Run RNA-seq differential expression.",
+            tool_catalog,
+            recipe_catalog,
+        )
+
+        self.assertIn("rnaseq_differential_expression", prompt)
+        self.assertIn("fastp", prompt)
+        self.assertIn("Run RNA-seq differential expression.", prompt)
+
+    def test_plan_from_natural_language_validates_llm_plan(self):
+        fake_llm = FakePlannerLlm(json.dumps(sample_rnaseq_tool_plan()))
+
+        plan = plan_from_natural_language(
+            "Run RNA-seq differential expression.",
+            llm=fake_llm,
+        )
+
+        self.assertEqual(plan["workflow"]["recipe"], "rnaseq_differential_expression")
+        self.assertIn("Run RNA-seq differential expression.", fake_llm.prompts[0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,0 +1,60 @@
+import unittest
+
+from src.tools.validator import miniwdl_available, wdl_validator
+
+
+VALID_WDL = """
+version 1.0
+
+workflow SimpleWorkflow {
+  input {
+    File raw_fastq
+  }
+
+  call fastp_qc {
+    input:
+      raw_fastq = raw_fastq
+  }
+
+  output {
+    File clean_fastq = fastp_qc.clean_fastq
+  }
+}
+
+task fastp_qc {
+  input {
+    File raw_fastq
+  }
+
+  command <<<
+    cp ~{raw_fastq} clean.fq
+  >>>
+
+  output {
+    File clean_fastq = "clean.fq"
+  }
+
+  runtime {
+    docker: "ubuntu:22.04"
+  }
+}
+"""
+
+
+class ValidatorTests(unittest.TestCase):
+    @unittest.skipIf(not miniwdl_available(), "miniwdl is not installed")
+    def test_validator_accepts_valid_wdl(self):
+        result = wdl_validator.invoke({"wdl_code": VALID_WDL})
+
+        self.assertTrue(result["is_valid"], result["message"])
+
+    @unittest.skipIf(not miniwdl_available(), "miniwdl is not installed")
+    def test_validator_rejects_invalid_wdl(self):
+        result = wdl_validator.invoke({"wdl_code": "workflow Bad {"})
+
+        self.assertFalse(result["is_valid"])
+        self.assertIn("WDL 语法校验失败", result["message"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/uv.lock
+++ b/uv.lock
@@ -15,6 +15,7 @@ dependencies = [
     { name = "langgraph" },
     { name = "miniwdl" },
     { name = "python-dotenv" },
+    { name = "pyyaml" },
 ]
 
 [package.dev-dependencies]
@@ -32,6 +33,7 @@ requires-dist = [
     { name = "langgraph", specifier = ">=1.1.10" },
     { name = "miniwdl", specifier = ">=1.14.2" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
+    { name = "pyyaml", specifier = ">=6.0.3" },
 ]
 
 [package.metadata.requires-dev]

--- a/uv.lock
+++ b/uv.lock
@@ -7,11 +7,27 @@ name = "ai-bioworkflow"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "jinja2" },
+    { name = "langchain" },
+    { name = "langchain-anthropic" },
+    { name = "langchain-deepseek" },
+    { name = "langchain-openai" },
     { name = "langgraph" },
+    { name = "miniwdl" },
+    { name = "python-dotenv" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "langgraph", specifier = ">=1.1.10" }]
+requires-dist = [
+    { name = "jinja2", specifier = ">=3.1.6" },
+    { name = "langchain", specifier = ">=1.2.18" },
+    { name = "langchain-anthropic", specifier = ">=1.4.3" },
+    { name = "langchain-deepseek", specifier = ">=1.0.1" },
+    { name = "langchain-openai", specifier = ">=1.2.1" },
+    { name = "langgraph", specifier = ">=1.1.10" },
+    { name = "miniwdl", specifier = ">=1.14.2" },
+    { name = "python-dotenv", specifier = ">=1.2.2" },
+]
 
 [[package]]
 name = "annotated-types"
@@ -20,6 +36,25 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "anthropic"
+version = "0.100.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "docstring-parser" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9c/2d/24caf0ff727cba2ed863925017c8f93463a2ea6224a0efe5626e672bc3d2/anthropic-0.100.0.tar.gz", hash = "sha256:650dee9e023afb16395939ee4104bbc21f966b380210119fb91122c12099c79a", size = 758255, upload-time = "2026-05-06T15:07:13.578Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/a0/c775c59ab9445ecabb57ef3d5c24027de060139189a9e312ef9ef889a665/anthropic-0.100.0-py3-none-any.whl", hash = "sha256:1c15769efa15d8fd5c1ebf900e25c57e3ee540f8554a29aa56e4edefffe2951d", size = 753596, upload-time = "2026-05-06T15:07:12.106Z" },
 ]
 
 [[package]]
@@ -32,6 +67,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
+name = "argcomplete"
+version = "3.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/38/61/0b9ae6399dd4a58d8c1b1dc5a27d6f2808023d0b5dd3104bb99f45a33ff6/argcomplete-3.6.3.tar.gz", hash = "sha256:62e8ed4fd6a45864acc8235409461b72c9a28ee785a2011cc5eb78318786c89c", size = 73754, upload-time = "2025-10-20T03:33:34.741Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/f5/9373290775639cb67a2fce7f629a1c240dce9f12fe927bc32b2736e16dfc/argcomplete-3.6.3-py3-none-any.whl", hash = "sha256:f5007b3a600ccac5d25bbce33089211dfd49eab4a7718da3f10e3082525a92ce", size = 43846, upload-time = "2025-10-20T03:33:33.021Z" },
 ]
 
 [[package]]
@@ -101,6 +145,59 @@ wheels = [
 ]
 
 [[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "coloredlogs"
+version = "15.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "humanfriendly" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cc/c7/eed8f27100517e8c0e6b923d5f0845d0cb99763da6fdee00478f91db7325/coloredlogs-15.0.1.tar.gz", hash = "sha256:7c991aa71a4577af2f82600d8f8f3a89f936baeaf9b50a9c197da014e5bf16b0", size = 278520, upload-time = "2021-06-11T10:22:45.202Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/06/3d6badcf13db419e25b07041d9c7b4a2c331d3f4e7134445ec5df57714cd/coloredlogs-15.0.1-py2.py3-none-any.whl", hash = "sha256:612ee75c546f53e92e70049c9dbfcc18c935a2b9a53b66085ce9ef6a6e5c0934", size = 46018, upload-time = "2021-06-11T10:22:42.561Z" },
+]
+
+[[package]]
+name = "distro"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
+name = "docker"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "requests" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/91/9b/4a2ea29aeba62471211598dac5d96825bb49348fa07e906ea930394a83ce/docker-7.1.0.tar.gz", hash = "sha256:ad8c70e6e3f8926cb8a92619b832b4ea5299e2831c14284663184e200546fa6c", size = 117834, upload-time = "2024-05-23T11:13:57.216Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/26/57c6fb270950d476074c087527a558ccb6f4436657314bfb6cdf484114c4/docker-7.1.0-py3-none-any.whl", hash = "sha256:c96b93b7f0a746f9e77d325bcfb87422a3d8bd4f03136ae8a85b37f1898d5fc0", size = 147774, upload-time = "2024-05-23T11:13:55.01Z" },
+]
+
+[[package]]
+name = "docstring-parser"
+version = "0.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -138,12 +235,102 @@ wheels = [
 ]
 
 [[package]]
+name = "humanfriendly"
+version = "10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyreadline3", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cc/3f/2c29224acb2e2df4d2046e4c73ee2662023c58ff5b113c4c1adac0886c43/humanfriendly-10.0.tar.gz", hash = "sha256:6b0b831ce8f15f7300721aa49829fc4e83921a9a301cc7f606be6686a2288ddc", size = 360702, upload-time = "2021-09-17T21:40:43.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/0f/310fb31e39e2d734ccaa2c0fb981ee41f7bd5056ce9bc29b2248bd569169/humanfriendly-10.0-py2.py3-none-any.whl", hash = "sha256:1697e1a8a8f550fd43c2865cd84542fc175a61dcb779b6fee18cf6b6ccba1477", size = 86794, upload-time = "2021-09-17T21:40:39.897Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.13"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
+]
+
+[[package]]
+name = "importlib-metadata"
+version = "9.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "zipp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/3d/2d244233ac4f76e38533cfcb2991c9eb4c7bf688ae0a036d30725b8faafe/importlib_metadata-9.0.0-py3-none-any.whl", hash = "sha256:2d21d1cc5a017bd0559e36150c21c830ab1dc304dedd1b7ea85d20f45ef3edd7", size = 27789, upload-time = "2026-03-20T06:42:55.665Z" },
+]
+
+[[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "jiter"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/c1/0cddc6eb17d4c53a99840953f95dd3accdc5cfc7a337b0e9b26476276be9/jiter-0.14.0.tar.gz", hash = "sha256:e8a39e66dac7153cf3f964a12aad515afa8d74938ec5cc0018adcdae5367c79e", size = 165725, upload-time = "2026-04-10T14:28:42.01Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/97/2a/09f70020898507a89279659a1afe3364d57fc1b2c89949081975d135f6f5/jiter-0.14.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:af72f204cf4d44258e5b4c1745130ac45ddab0e71a06333b01de660ab4187a94", size = 315502, upload-time = "2026-04-10T14:26:47.697Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/be/080c96a45cd74f9fce5db4fd68510b88087fb37ffe2541ff73c12db92535/jiter-0.14.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4b77da71f6e819be5fbcec11a453fde5b1d0267ef6ed487e2a392fd8e14e4e3a", size = 314870, upload-time = "2026-04-10T14:26:49.149Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/5e/2d0fee155826a968a832cc32438de5e2a193292c8721ca70d0b53e58245b/jiter-0.14.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:77f4ea612fe8b84b8b04e51d0e78029ecf3466348e25973f953de6e6a59aa4c1", size = 343406, upload-time = "2026-04-10T14:26:50.762Z" },
+    { url = "https://files.pythonhosted.org/packages/70/af/bf9ee0d3a4f8dc0d679fc1337f874fe60cdbf841ebbb304b374e1c9aaceb/jiter-0.14.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:62fe2451f8fcc0240261e6a4df18ecbcd58327857e61e625b2393ea3b468aac9", size = 369415, upload-time = "2026-04-10T14:26:52.188Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/83/8e8561eadba31f4d3948a5b712fb0447ec71c3560b57a855449e7b8ddc98/jiter-0.14.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6112f26f5afc75bcb475787d29da3aa92f9d09c7858f632f4be6ffe607be82e9", size = 461456, upload-time = "2026-04-10T14:26:53.611Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/c9/c5299e826a5fe6108d172b344033f61c69b1bb979dd8d9ddd4278a160971/jiter-0.14.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:215a6cb8fb7dc702aa35d475cc00ddc7f970e5c0b1417fb4b4ac5d82fa2a29db", size = 378488, upload-time = "2026-04-10T14:26:55.211Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/37/c16d9d15c0a471b8644b1abe3c82668092a707d9bedcf076f24ff2e380cd/jiter-0.14.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fc4ab96a30fb3cb2c7e0cd33f7616c8860da5f5674438988a54ac717caccdbaa", size = 353242, upload-time = "2026-04-10T14:26:56.705Z" },
+    { url = "https://files.pythonhosted.org/packages/58/ea/8050cb0dc654e728e1bfacbc0c640772f2181af5dedd13ae70145743a439/jiter-0.14.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:3a99c1387b1f2928f799a9de899193484d66206a50e98233b6b088a7f0c1edb2", size = 356823, upload-time = "2026-04-10T14:26:58.281Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/3b/cf71506d270e5f84d97326bf220e47aed9b95e9a4a060758fb07772170ab/jiter-0.14.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ab18d11074485438695f8d34a1b6da61db9754248f96d51341956607a8f39985", size = 392564, upload-time = "2026-04-10T14:27:00.018Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/cc/8c6c74a3efb5bd671bfd14f51e8a73375464ca914b1551bc3b40e26ac2c9/jiter-0.14.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:801028dcfc26ac0895e4964cbc0fd62c73be9fd4a7d7b1aaf6e5790033a719b7", size = 520322, upload-time = "2026-04-10T14:27:01.664Z" },
+    { url = "https://files.pythonhosted.org/packages/41/24/68d7b883ec959884ddf00d019b2e0e82ba81b167e1253684fa90519ce33c/jiter-0.14.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:ad425b087aafb4a1c7e1e98a279200743b9aaf30c3e0ba723aec93f061bd9bc8", size = 552619, upload-time = "2026-04-10T14:27:03.316Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/89/b1a0985223bbf3150ff9e8f46f98fc9360c1de94f48abe271bbe1b465682/jiter-0.14.0-cp313-cp313-win32.whl", hash = "sha256:882bcb9b334318e233950b8be366fe5f92c86b66a7e449e76975dfd6d776a01f", size = 205699, upload-time = "2026-04-10T14:27:04.662Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/19/3f339a5a7f14a11730e67f6be34f9d5105751d547b615ef593fa122a5ded/jiter-0.14.0-cp313-cp313-win_amd64.whl", hash = "sha256:9b8c571a5dba09b98bd3462b5a53f27209a5cbbe85670391692ede71974e979f", size = 201323, upload-time = "2026-04-10T14:27:06.139Z" },
+    { url = "https://files.pythonhosted.org/packages/50/56/752dd89c84be0e022a8ea3720bcfa0a8431db79a962578544812ce061739/jiter-0.14.0-cp313-cp313-win_arm64.whl", hash = "sha256:34f19dcc35cb1abe7c369b3756babf8c7f04595c0807a848df8f26ef8298ef92", size = 191099, upload-time = "2026-04-10T14:27:07.564Z" },
+    { url = "https://files.pythonhosted.org/packages/91/28/292916f354f25a1fe8cf2c918d1415c699a4a659ae00be0430e1c5d9ffea/jiter-0.14.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e89bcd7d426a75bb4952c696b267075790d854a07aad4c9894551a82c5b574ab", size = 320880, upload-time = "2026-04-10T14:27:09.326Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/c7/b002a7d8b8957ac3d469bd59c18ef4b1595a5216ae0de639a287b9816023/jiter-0.14.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7b25beaa0d4447ea8c7ae0c18c688905d34840d7d0b937f2f7bdd52162c98a40", size = 346563, upload-time = "2026-04-10T14:27:11.287Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/3b/f8d07580d8706021d255a6356b8fab13ee4c869412995550ce6ed4ddf97d/jiter-0.14.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:651a8758dd413c51e3b7f6557cdc6921faf70b14106f45f969f091f5cda990ea", size = 357928, upload-time = "2026-04-10T14:27:12.729Z" },
+    { url = "https://files.pythonhosted.org/packages/47/5b/ac1a974da29e35507230383110ffec59998b290a8732585d04e19a9eb5ba/jiter-0.14.0-cp313-cp313t-win_amd64.whl", hash = "sha256:e1a7eead856a5038a8d291f1447176ab0b525c77a279a058121b5fccee257f6f", size = 203519, upload-time = "2026-04-10T14:27:14.125Z" },
+    { url = "https://files.pythonhosted.org/packages/96/6d/9fc8433d667d2454271378a79747d8c76c10b51b482b454e6190e511f244/jiter-0.14.0-cp313-cp313t-win_arm64.whl", hash = "sha256:2e692633a12cda97e352fdcd1c4acc971b1c28707e1e33aeef782b0cbf051975", size = 190113, upload-time = "2026-04-10T14:27:16.638Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/1e/354ed92461b165bd581f9ef5150971a572c873ec3b68a916d5aa91da3cc2/jiter-0.14.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:6f396837fc7577871ca8c12edaf239ed9ccef3bbe39904ae9b8b63ce0a48b140", size = 315277, upload-time = "2026-04-10T14:27:18.109Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/95/8c7c7028aa8636ac21b7a55faef3e34215e6ed0cbf5ae58258427f621aa3/jiter-0.14.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a4d50ea3d8ba4176f79754333bd35f1bbcd28e91adc13eb9b7ca91bc52a6cef9", size = 315923, upload-time = "2026-04-10T14:27:19.603Z" },
+    { url = "https://files.pythonhosted.org/packages/47/40/e2a852a44c4a089f2681a16611b7ce113224a80fd8504c46d78491b47220/jiter-0.14.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce17f8a050447d1b4153bda4fb7d26e6a9e74eb4f4a41913f30934c5075bf615", size = 344943, upload-time = "2026-04-10T14:27:21.262Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/1f/670f92adee1e9895eac41e8a4d623b6da68c4d46249d8b556b60b63f949e/jiter-0.14.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f4f1c4b125e1652aefbc2e2c1617b60a160ab789d180e3d423c41439e5f32850", size = 369725, upload-time = "2026-04-10T14:27:22.766Z" },
+    { url = "https://files.pythonhosted.org/packages/01/2f/541c9ba567d05de1c4874a0f8f8c5e3fd78e2b874266623da9a775cf46e0/jiter-0.14.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:be808176a6a3a14321d18c603f2d40741858a7c4fc982f83232842689fe86dd9", size = 461210, upload-time = "2026-04-10T14:27:24.315Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/a9/c31cbec09627e0d5de7aeaec7690dba03e090caa808fefd8133137cf45bc/jiter-0.14.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:26679d58ba816f88c3849306dd58cb863a90a1cf352cdd4ef67e30ccf8a77994", size = 380002, upload-time = "2026-04-10T14:27:26.155Z" },
+    { url = "https://files.pythonhosted.org/packages/50/02/3c05c1666c41904a2f607475a73e7a4763d1cbde2d18229c4f85b22dc253/jiter-0.14.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:80381f5a19af8fa9aef743f080e34f6b25ebd89656475f8cf0470ec6157052aa", size = 354678, upload-time = "2026-04-10T14:27:27.701Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/97/e15b33545c2b13518f560d695f974b9891b311641bdcf178d63177e8801e/jiter-0.14.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:004df5fdb8ecbd6d99f3227df18ba1a259254c4359736a2e6f036c944e02d7c5", size = 358920, upload-time = "2026-04-10T14:27:29.256Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/d2/8b1461def6b96ba44530df20d07ef7a1c7da22f3f9bf1727e2d611077bf1/jiter-0.14.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:cff5708f7ed0fa098f2b53446c6fa74c48469118e5cd7497b4f1cd569ab06928", size = 394512, upload-time = "2026-04-10T14:27:31.344Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/88/837566dd6ed6e452e8d3205355afd484ce44b2533edfa4ed73a298ea893e/jiter-0.14.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:2492e5f06c36a976d25c7cc347a60e26d5470178d44cde1b9b75e60b4e519f28", size = 521120, upload-time = "2026-04-10T14:27:33.299Z" },
+    { url = "https://files.pythonhosted.org/packages/89/6b/b00b45c4d1b4c031777fe161d620b755b5b02cdade1e316dcb46e4471d63/jiter-0.14.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:7609cfbe3a03d37bfdbf5052012d5a879e72b83168a363deae7b3a26564d57de", size = 553668, upload-time = "2026-04-10T14:27:34.868Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/d8/6fe5b42011d19397433d345716eac16728ac241862a2aac9c91923c7509a/jiter-0.14.0-cp314-cp314-win32.whl", hash = "sha256:7282342d32e357543565286b6450378c3cd402eea333fc1ebe146f1fabb306fc", size = 207001, upload-time = "2026-04-10T14:27:36.455Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/43/5c2e08da1efad5e410f0eaaabeadd954812612c33fbbd8fd5328b489139d/jiter-0.14.0-cp314-cp314-win_amd64.whl", hash = "sha256:bd77945f38866a448e73b0b7637366afa814d4617790ecd88a18ca74377e6c02", size = 202187, upload-time = "2026-04-10T14:27:38Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/1f/6e39ac0b4cdfa23e606af5b245df5f9adaa76f35e0c5096790da430ca506/jiter-0.14.0-cp314-cp314-win_arm64.whl", hash = "sha256:f2d4c61da0821ee42e0cdf5489da60a6d074306313a377c2b35af464955a3611", size = 192257, upload-time = "2026-04-10T14:27:39.504Z" },
+    { url = "https://files.pythonhosted.org/packages/05/57/7dbc0ffbbb5176a27e3518716608aa464aee2e2887dc938f0b900a120449/jiter-0.14.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1bf7ff85517dd2f20a5750081d2b75083c1b269cf75afc7511bdf1f9548beb3b", size = 323441, upload-time = "2026-04-10T14:27:41.039Z" },
+    { url = "https://files.pythonhosted.org/packages/83/6e/7b3314398d8983f06b557aa21b670511ec72d3b79a68ee5e4d9bff972286/jiter-0.14.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c8ef8791c3e78d6c6b157c6d360fbb5c715bebb8113bc6a9303c5caff012754a", size = 348109, upload-time = "2026-04-10T14:27:42.552Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/4f/8dc674bcd7db6dba566de73c08c763c337058baff1dbeb34567045b27cdc/jiter-0.14.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e74663b8b10da1fe0f4e4703fd7980d24ad17174b6bb35d8498d6e3ebce2ae6a", size = 368328, upload-time = "2026-04-10T14:27:44.574Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/5f/188e09a1f20906f98bbdec44ed820e19f4e8eb8aff88b9d1a5a497587ff3/jiter-0.14.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1aca29ba52913f78362ec9c2da62f22cdc4c3083313403f90c15460979b84d9b", size = 463301, upload-time = "2026-04-10T14:27:46.717Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/f0/19046ef965ed8f349e8554775bb12ff4352f443fbe12b95d31f575891256/jiter-0.14.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8b39b7d87a952b79949af5fef44d2544e58c21a28da7f1bae3ef166455c61746", size = 378891, upload-time = "2026-04-10T14:27:48.32Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/c3/da43bd8431ee175695777ee78cf0e93eacbb47393ff493f18c45231b427d/jiter-0.14.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:78d918a68b26e9fab068c2b5453577ef04943ab2807b9a6275df2a812599a310", size = 360749, upload-time = "2026-04-10T14:27:49.88Z" },
+    { url = "https://files.pythonhosted.org/packages/72/26/e054771be889707c6161dbdec9c23d33a9ec70945395d70f07cfea1e9a6f/jiter-0.14.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:b08997c35aee1201c1a5361466a8fb9162d03ae7bf6568df70b6c859f1e654a4", size = 358526, upload-time = "2026-04-10T14:27:51.504Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/0f/7bea65ea2a6d91f2bf989ff11a18136644392bf2b0497a1fa50934c30a9c/jiter-0.14.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:260bf7ca20704d58d41f669e5e9fe7fe2fa72901a6b324e79056f5d52e9c9be2", size = 393926, upload-time = "2026-04-10T14:27:53.368Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a1/b1ff7d70deef61ac0b7c6c2f12d2ace950cdeecb4fdc94500a0926802857/jiter-0.14.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:37826e3df29e60f30a382f9294348d0238ef127f4b5d7f5f8da78b5b9e050560", size = 521052, upload-time = "2026-04-10T14:27:55.058Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/7b/3b0649983cbaf15eda26a414b5b1982e910c67bd6f7b1b490f3cfc76896a/jiter-0.14.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:645be49c46f2900937ba0eaf871ad5183c96858c0af74b6becc7f4e367e36e06", size = 553716, upload-time = "2026-04-10T14:27:57.269Z" },
+    { url = "https://files.pythonhosted.org/packages/97/f8/33d78c83bd93ae0c0af05293a6660f88a1977caef39a6d72a84afab94ce0/jiter-0.14.0-cp314-cp314t-win32.whl", hash = "sha256:2f7877ed45118de283786178eceaf877110abacd04fde31efff3940ae9672674", size = 207957, upload-time = "2026-04-10T14:27:59.285Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/ac/2b760516c03e2227826d1f7025d89bf6bf6357a28fe75c2a2800873c50bf/jiter-0.14.0-cp314-cp314t-win_amd64.whl", hash = "sha256:14c0cb10337c49f5eafe8e7364daca5e29a020ea03580b8f8e6c597fed4e1588", size = 204690, upload-time = "2026-04-10T14:28:00.962Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/2e/a44c20c58aeed0355f2d326969a181696aeb551a25195f47563908a815be/jiter-0.14.0-cp314-cp314t-win_arm64.whl", hash = "sha256:5419d4aa2024961da9fe12a9cfe7484996735dca99e8e090b5c88595ef1951ff", size = 191338, upload-time = "2026-04-10T14:28:02.853Z" },
 ]
 
 [[package]]
@@ -168,6 +355,34 @@ wheels = [
 ]
 
 [[package]]
+name = "langchain"
+version = "1.2.18"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langchain-core" },
+    { name = "langgraph" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/4e/b651ecac63af474b28519384f7011294493d139937b1a9591581291eef34/langchain-1.2.18.tar.gz", hash = "sha256:7e829dbf117affadfd2067a0e97b4af20222f535f30fb812a28472d842c1074c", size = 582882, upload-time = "2026-05-08T13:59:19.895Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/20/959f6098c79158afe5aedce7de05c3700f10d293890ef9e5dace6c3ad94b/langchain-1.2.18-py3-none-any.whl", hash = "sha256:8432d43a65540845ed6f1a783d38d869c4659a6b9405f9a510169ad40d2f7bae", size = 113643, upload-time = "2026-05-08T13:59:18.461Z" },
+]
+
+[[package]]
+name = "langchain-anthropic"
+version = "1.4.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anthropic" },
+    { name = "langchain-core" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fa/e3/d2f9dec95602524b1cfb4be2747ba5bc38d32501b2a56cb4bcb76e80bb45/langchain_anthropic-1.4.3.tar.gz", hash = "sha256:f8a2442463c0629b1b3110eaeaa56fdbdc87df2a802f8c7f5ecf611eb4874ec8", size = 685219, upload-time = "2026-05-03T17:33:27.118Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d3/55/482a1968c95275e8be6d8c1e53b54f0f7be0b8b155ce1608c947a95cf543/langchain_anthropic-1.4.3-py3-none-any.whl", hash = "sha256:65466e0f2f95909a009708f2958e917dfdbfab79c612b4484a30866a85e1f291", size = 50389, upload-time = "2026-05-03T17:33:25.671Z" },
+]
+
+[[package]]
 name = "langchain-core"
 version = "1.3.3"
 source = { registry = "https://pypi.org/simple" }
@@ -185,6 +400,33 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d3/ae/8b74458fc3850ec3d150eb9f45e857db129dafa801fb5cf173dfc9f8bbf3/langchain_core-1.3.3.tar.gz", hash = "sha256:fa510a5db8efdc0c6ff41c0939fb5c00a0183c11f6b84233e892e3227ff69182", size = 915041, upload-time = "2026-05-05T19:02:36.612Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/01/4771b7ab2af1d1aba5b710bd8f13d9225c609425214b357590a17b01be77/langchain_core-1.3.3-py3-none-any.whl", hash = "sha256:18aae8506f37da7f74398492279a7d6efcee4f8e23c4c41c7af080eeb7ef7bd1", size = 543857, upload-time = "2026-05-05T19:02:34.52Z" },
+]
+
+[[package]]
+name = "langchain-deepseek"
+version = "1.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langchain-core" },
+    { name = "langchain-openai" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4e/c4/de579ea21e22777959f214af165761c6cd101248222bcc0886d020d67185/langchain_deepseek-1.0.1.tar.gz", hash = "sha256:e7a0238f2c14e928e1562641b2df639c19cdf867287a7f2293ffb1372daf83ae", size = 147216, upload-time = "2025-11-13T16:29:13.445Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cd/dd/a803dfbf64273232f3fc82f859487331abb717671bbcdf266fd80de6ef78/langchain_deepseek-1.0.1-py3-none-any.whl", hash = "sha256:0a9862f335f1873370bb0fe1928ac19b8b9292b014ef5412da462ded8bb82c5a", size = 8325, upload-time = "2025-11-13T16:29:12.385Z" },
+]
+
+[[package]]
+name = "langchain-openai"
+version = "1.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langchain-core" },
+    { name = "openai" },
+    { name = "tiktoken" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9a/0e/d8e16c28aa67106d285e63b8ffc04c5af68341e345ce24a0751dbf2e167e/langchain_openai-1.2.1.tar.gz", hash = "sha256:ee4480b787706361b7125fad46930589a624df87aa158c6986ef1fad10d10675", size = 1146092, upload-time = "2026-04-24T19:46:43.328Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/55/2865b18ee3a3dd11160b8c4b2cf37e75bf2a4a8d1d38868ffffc7b7cc180/langchain_openai-1.2.1-py3-none-any.whl", hash = "sha256:a80732185030d4f453dda6c25feef46f645f665423fdffe38ae3edf1ac3c6c4d", size = 98626, upload-time = "2026-04-24T19:46:41.971Z" },
 ]
 
 [[package]]
@@ -276,6 +518,109 @@ wheels = [
 ]
 
 [[package]]
+name = "lark"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/34/28fff3ab31ccff1fd4f6c7c7b0ceb2b6968d8ea4950663eadcb5720591a0/lark-1.3.1.tar.gz", hash = "sha256:b426a7a6d6d53189d318f2b6236ab5d6429eaf09259f1ca33eb716eed10d2905", size = 382732, upload-time = "2025-10-27T18:25:56.653Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3d/14ce75ef66813643812f3093ab17e46d3a206942ce7376d31ec2d36229e7/lark-1.3.1-py3-none-any.whl", hash = "sha256:c629b661023a014c37da873b4ff58a817398d12635d3bbb2c5a03be7fe5d1e12", size = 113151, upload-time = "2025-10-27T18:25:54.882Z" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622, upload-time = "2025-09-27T18:36:41.777Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029, upload-time = "2025-09-27T18:36:43.257Z" },
+    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374, upload-time = "2025-09-27T18:36:44.508Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980, upload-time = "2025-09-27T18:36:45.385Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990, upload-time = "2025-09-27T18:36:46.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784, upload-time = "2025-09-27T18:36:47.884Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588, upload-time = "2025-09-27T18:36:48.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041, upload-time = "2025-09-27T18:36:49.797Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543, upload-time = "2025-09-27T18:36:51.584Z" },
+    { url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113, upload-time = "2025-09-27T18:36:52.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911, upload-time = "2025-09-27T18:36:53.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658, upload-time = "2025-09-27T18:36:54.819Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066, upload-time = "2025-09-27T18:36:55.714Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639, upload-time = "2025-09-27T18:36:56.908Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569, upload-time = "2025-09-27T18:36:57.913Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284, upload-time = "2025-09-27T18:36:58.833Z" },
+    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801, upload-time = "2025-09-27T18:36:59.739Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769, upload-time = "2025-09-27T18:37:00.719Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642, upload-time = "2025-09-27T18:37:01.673Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
+    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619, upload-time = "2025-09-27T18:37:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload-time = "2025-09-27T18:37:07.213Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408, upload-time = "2025-09-27T18:37:09.572Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005, upload-time = "2025-09-27T18:37:10.58Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048, upload-time = "2025-09-27T18:37:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821, upload-time = "2025-09-27T18:37:12.48Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606, upload-time = "2025-09-27T18:37:13.485Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload-time = "2025-09-27T18:37:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747, upload-time = "2025-09-27T18:37:15.36Z" },
+    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341, upload-time = "2025-09-27T18:37:16.496Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073, upload-time = "2025-09-27T18:37:17.476Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661, upload-time = "2025-09-27T18:37:18.453Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670, upload-time = "2025-09-27T18:37:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598, upload-time = "2025-09-27T18:37:21.177Z" },
+    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261, upload-time = "2025-09-27T18:37:22.167Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835, upload-time = "2025-09-27T18:37:23.296Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733, upload-time = "2025-09-27T18:37:24.237Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload-time = "2025-09-27T18:37:25.271Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
+name = "miniwdl"
+version = "1.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "argcomplete" },
+    { name = "coloredlogs" },
+    { name = "docker" },
+    { name = "importlib-metadata" },
+    { name = "lark" },
+    { name = "psutil" },
+    { name = "pygtail" },
+    { name = "python-json-logger" },
+    { name = "questionary" },
+    { name = "regex" },
+    { name = "ruamel-yaml" },
+    { name = "xdg" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/85/05/3314988f43cc7eab978eef05463eb7876eae4396a4f1fc30ea4bf79fb3ac/miniwdl-1.14.2.tar.gz", hash = "sha256:5272ab56beeefb403770841a7486d9d00f8e687f363f3dd4467844e799495ecf", size = 487061, upload-time = "2026-04-26T21:52:58.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/4b/d69af3f83138751ee894fe9c5b39d99a50f608f2ac4fe06ee11a024b963b/miniwdl-1.14.2-py3-none-any.whl", hash = "sha256:aa0e6dc0cd6626fa0b11601ade154456ec0be98ca46ecb4da7315c6c2d1ed6d9", size = 200188, upload-time = "2026-04-26T21:52:56.49Z" },
+]
+
+[[package]]
+name = "openai"
+version = "2.36.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f4/a1/4d5e84cf51720fc1526cc49e10ac1961abcccb55b0efb3d970db1e9a2728/openai-2.36.0.tar.gz", hash = "sha256:139dea0edd2f1b30c33d46ae1a6929e03906254140318e4608e98fe8c566f2e7", size = 753003, upload-time = "2026-05-07T17:33:17.075Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/1c/5d43735b2553baae2a5e899dcbcd0670a86930d993184d72ca909bf11c9b/openai-2.36.0-py3-none-any.whl", hash = "sha256:143f6194b548dbc2c921af1f1b03b9f14c85fed8a75b5b516f5bcc11a2a50c63", size = 1302361, upload-time = "2026-05-07T17:33:15.063Z" },
+]
+
+[[package]]
 name = "orjson"
 version = "3.11.9"
 source = { registry = "https://pypi.org/simple" }
@@ -353,6 +698,46 @@ wheels = [
 ]
 
 [[package]]
+name = "prompt-toolkit"
+version = "3.0.52"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/96/06e01a7b38dce6fe1db213e061a4602dd6032a8a97ef6c1a862537732421/prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855", size = 434198, upload-time = "2025-08-27T15:24:02.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955", size = 391431, upload-time = "2025-08-27T15:23:59.498Z" },
+]
+
+[[package]]
+name = "psutil"
+version = "7.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c6/d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372", size = 493740, upload-time = "2026-01-28T18:14:54.428Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/08/510cbdb69c25a96f4ae523f733cdc963ae654904e8db864c07585ef99875/psutil-7.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:2edccc433cbfa046b980b0df0171cd25bcaeb3a68fe9022db0979e7aa74a826b", size = 130595, upload-time = "2026-01-28T18:14:57.293Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/f5/97baea3fe7a5a9af7436301f85490905379b1c6f2dd51fe3ecf24b4c5fbf/psutil-7.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78c8603dcd9a04c7364f1a3e670cea95d51ee865e4efb3556a3a63adef958ea", size = 131082, upload-time = "2026-01-28T18:14:59.732Z" },
+    { url = "https://files.pythonhosted.org/packages/37/d6/246513fbf9fa174af531f28412297dd05241d97a75911ac8febefa1a53c6/psutil-7.2.2-cp313-cp313t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1a571f2330c966c62aeda00dd24620425d4b0cc86881c89861fbc04549e5dc63", size = 181476, upload-time = "2026-01-28T18:15:01.884Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/b5/9182c9af3836cca61696dabe4fd1304e17bc56cb62f17439e1154f225dd3/psutil-7.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:917e891983ca3c1887b4ef36447b1e0873e70c933afc831c6b6da078ba474312", size = 184062, upload-time = "2026-01-28T18:15:04.436Z" },
+    { url = "https://files.pythonhosted.org/packages/16/ba/0756dca669f5a9300d0cbcbfae9a4c30e446dfc7440ffe43ded5724bfd93/psutil-7.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:ab486563df44c17f5173621c7b198955bd6b613fb87c71c161f827d3fb149a9b", size = 139893, upload-time = "2026-01-28T18:15:06.378Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/61/8fa0e26f33623b49949346de05ec1ddaad02ed8ba64af45f40a147dbfa97/psutil-7.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:ae0aefdd8796a7737eccea863f80f81e468a1e4cf14d926bd9b6f5f2d5f90ca9", size = 135589, upload-time = "2026-01-28T18:15:08.03Z" },
+    { url = "https://files.pythonhosted.org/packages/81/69/ef179ab5ca24f32acc1dac0c247fd6a13b501fd5534dbae0e05a1c48b66d/psutil-7.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:eed63d3b4d62449571547b60578c5b2c4bcccc5387148db46e0c2313dad0ee00", size = 130664, upload-time = "2026-01-28T18:15:09.469Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/64/665248b557a236d3fa9efc378d60d95ef56dd0a490c2cd37dafc7660d4a9/psutil-7.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7b6d09433a10592ce39b13d7be5a54fbac1d1228ed29abc880fb23df7cb694c9", size = 131087, upload-time = "2026-01-28T18:15:11.724Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2e/e6782744700d6759ebce3043dcfa661fb61e2fb752b91cdeae9af12c2178/psutil-7.2.2-cp314-cp314t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fa4ecf83bcdf6e6c8f4449aff98eefb5d0604bf88cb883d7da3d8d2d909546a", size = 182383, upload-time = "2026-01-28T18:15:13.445Z" },
+    { url = "https://files.pythonhosted.org/packages/57/49/0a41cefd10cb7505cdc04dab3eacf24c0c2cb158a998b8c7b1d27ee2c1f5/psutil-7.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e452c464a02e7dc7822a05d25db4cde564444a67e58539a00f929c51eddda0cf", size = 185210, upload-time = "2026-01-28T18:15:16.002Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/2c/ff9bfb544f283ba5f83ba725a3c5fec6d6b10b8f27ac1dc641c473dc390d/psutil-7.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:c7663d4e37f13e884d13994247449e9f8f574bc4655d509c3b95e9ec9e2b9dc1", size = 141228, upload-time = "2026-01-28T18:15:18.385Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/fc/f8d9c31db14fcec13748d373e668bc3bed94d9077dbc17fb0eebc073233c/psutil-7.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:11fe5a4f613759764e79c65cf11ebdf26e33d6dd34336f8a337aa2996d71c841", size = 136284, upload-time = "2026-01-28T18:15:19.912Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/36/5ee6e05c9bd427237b11b3937ad82bb8ad2752d72c6969314590dd0c2f6e/psutil-7.2.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ed0cace939114f62738d808fdcecd4c869222507e266e574799e9c0faa17d486", size = 129090, upload-time = "2026-01-28T18:15:22.168Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c4/f5af4c1ca8c1eeb2e92ccca14ce8effdeec651d5ab6053c589b074eda6e1/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a7b04c10f32cc88ab39cbf606e117fd74721c831c98a27dc04578deb0c16979", size = 129859, upload-time = "2026-01-28T18:15:23.795Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9", size = 155560, upload-time = "2026-01-28T18:15:25.976Z" },
+    { url = "https://files.pythonhosted.org/packages/63/65/37648c0c158dc222aba51c089eb3bdfa238e621674dc42d48706e639204f/psutil-7.2.2-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b0726cecd84f9474419d67252add4ac0cd9811b04d61123054b9fb6f57df6e9e", size = 156997, upload-time = "2026-01-28T18:15:27.794Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/13/125093eadae863ce03c6ffdbae9929430d116a246ef69866dad94da3bfbc/psutil-7.2.2-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd04ef36b4a6d599bbdb225dd1d3f51e00105f6d48a28f006da7f9822f2606d8", size = 148972, upload-time = "2026-01-28T18:15:29.342Z" },
+    { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
+]
+
+[[package]]
 name = "pydantic"
 version = "2.13.4"
 source = { registry = "https://pypi.org/simple" }
@@ -424,6 +809,55 @@ wheels = [
 ]
 
 [[package]]
+name = "pygtail"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/89/437120e303d5d2c81107ed3415d5f3c9975f7dfdeef9e4440cef364e3bf9/pygtail-0.14.0.tar.gz", hash = "sha256:55616d31a081eaaeb069d0946f2bc7e530ebf505d4c3c050f8e941786a3449d3", size = 13509, upload-time = "2022-11-06T14:54:28.816Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/77/5558c3904229d2e320722ec58d38b82f9ff3063b7eeda49a8821b5595de1/pygtail-0.14.0-py3-none-any.whl", hash = "sha256:3d8e847d4d5c56e3cece1f65577562e63f8b75af7b93bf21b71c3213d369c2a9", size = 14319, upload-time = "2022-11-06T14:54:26.714Z" },
+]
+
+[[package]]
+name = "pyreadline3"
+version = "3.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/49/4cea918a08f02817aabae639e3d0ac046fef9f9180518a3ad394e22da148/pyreadline3-3.5.4.tar.gz", hash = "sha256:8d57d53039a1c75adba8e50dd3d992b28143480816187ea5efbd5c78e6c885b7", size = 99839, upload-time = "2024-09-19T02:40:10.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/dc/491b7661614ab97483abf2056be1deee4dc2490ecbf7bff9ab5cdbac86e1/pyreadline3-3.5.4-py3-none-any.whl", hash = "sha256:eaf8e6cc3c49bcccf145fc6067ba8643d1df34d604a1ec0eccbf7a18e6d3fae6", size = 83178, upload-time = "2024-09-19T02:40:08.598Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "python-json-logger"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f7/ff/3cc9165fd44106973cd7ac9facb674a65ed853494592541d339bdc9a30eb/python_json_logger-4.1.0.tar.gz", hash = "sha256:b396b9e3ed782b09ff9d6e4f1683d46c83ad0d35d2e407c09a9ebbf038f88195", size = 17573, upload-time = "2026-03-29T04:39:56.805Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/be/0631a861af4d1c875f096c07d34e9a63639560a717130e7a87cbc82b7e3f/python_json_logger-4.1.0-py3-none-any.whl", hash = "sha256:132994765cf75bf44554be9aa49b06ef2345d23661a96720262716438141b6b2", size = 15021, upload-time = "2026-03-29T04:39:55.266Z" },
+]
+
+[[package]]
+name = "pywin32"
+version = "311"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/be/3fd5de0979fcb3994bfee0d65ed8ca9506a8a1260651b86174f6a86f52b3/pywin32-311-cp313-cp313-win32.whl", hash = "sha256:f95ba5a847cba10dd8c4d8fefa9f2a6cf283b8b88ed6178fa8a6c1ab16054d0d", size = 8705700, upload-time = "2025-07-14T20:13:26.471Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/28/e0a1909523c6890208295a29e05c2adb2126364e289826c0a8bc7297bd5c/pywin32-311-cp313-cp313-win_amd64.whl", hash = "sha256:718a38f7e5b058e76aee1c56ddd06908116d35147e133427e59a3983f703a20d", size = 9494700, upload-time = "2025-07-14T20:13:28.243Z" },
+    { url = "https://files.pythonhosted.org/packages/04/bf/90339ac0f55726dce7d794e6d79a18a91265bdf3aa70b6b9ca52f35e022a/pywin32-311-cp313-cp313-win_arm64.whl", hash = "sha256:7b4075d959648406202d92a2310cb990fea19b535c7f4a78d3f5e10b926eeb8a", size = 8709318, upload-time = "2025-07-14T20:13:30.348Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/31/097f2e132c4f16d99a22bfb777e0fd88bd8e1c634304e102f313af69ace5/pywin32-311-cp314-cp314-win32.whl", hash = "sha256:b7a2c10b93f8986666d0c803ee19b5990885872a7de910fc460f9b0c2fbf92ee", size = 8840714, upload-time = "2025-07-14T20:13:32.449Z" },
+    { url = "https://files.pythonhosted.org/packages/90/4b/07c77d8ba0e01349358082713400435347df8426208171ce297da32c313d/pywin32-311-cp314-cp314-win_amd64.whl", hash = "sha256:3aca44c046bd2ed8c90de9cb8427f581c479e594e99b5c0bb19b29c10fd6cb87", size = 9656800, upload-time = "2025-07-14T20:13:34.312Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/d2/21af5c535501a7233e734b8af901574572da66fcc254cb35d0609c9080dd/pywin32-311-cp314-cp314-win_arm64.whl", hash = "sha256:a508e2d9025764a8270f93111a970e1d0fbfc33f4153b388bb649b7eec4f9b42", size = 8932540, upload-time = "2025-07-14T20:13:36.379Z" },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -460,6 +894,90 @@ wheels = [
 ]
 
 [[package]]
+name = "questionary"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "prompt-toolkit" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f6/45/eafb0bba0f9988f6a2520f9ca2df2c82ddfa8d67c95d6625452e97b204a5/questionary-2.1.1.tar.gz", hash = "sha256:3d7e980292bb0107abaa79c68dd3eee3c561b83a0f89ae482860b181c8bd412d", size = 25845, upload-time = "2025-08-28T19:00:20.851Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3c/26/1062c7ec1b053db9e499b4d2d5bc231743201b74051c973dadeac80a8f43/questionary-2.1.1-py3-none-any.whl", hash = "sha256:a51af13f345f1cdea62347589fbb6df3b290306ab8930713bfae4d475a7d4a59", size = 36753, upload-time = "2025-08-28T19:00:19.56Z" },
+]
+
+[[package]]
+name = "regex"
+version = "2026.5.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/0e/49aee608ad09480e7fd276898c99ec6192985fa331abe4eb3a986094490b/regex-2026.5.9.tar.gz", hash = "sha256:a8234aa23ec39894bfe4a3f1b85616a7032481964a13ac6fc9f10de4f6fca270", size = 416074, upload-time = "2026-05-09T23:15:19.37Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/aa/da/797e91ecec6f84135da778ddce78c20e0af5d2a15c26f87a81bc3eadb6db/regex-2026.5.9-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d626b84406444b165fc0ba981604edea39f0588ff1f92baa23fe50799ea9afdb", size = 490303, upload-time = "2026-05-09T23:13:04.382Z" },
+    { url = "https://files.pythonhosted.org/packages/44/da/bf30abaaa737b58f4a4b8c4a03659e02fd92092c822e0197ed9e0daab917/regex-2026.5.9-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:d7bdc0ab8f3dd7e1b4f9ab88634e13374669db86bb3c72e8292f07ae313f539f", size = 292019, upload-time = "2026-05-09T23:13:06.022Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/e7/d0eaf5713828417b9e5648cf81fa9bacd4961f6ab98c380c2034f8716e35/regex-2026.5.9-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a8820737949116ffff55fe18f9fc644530063ba6ebfcb8314239416e78f1347c", size = 289468, upload-time = "2026-05-09T23:13:08.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/9b/b3fdd62b003baa1a9b593cd8c8699c9651c2e80cc21a5c715707983c42d7/regex-2026.5.9-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aa0fbdbac82cb3e4450d0ccde7d7a35607f4cb2dd9fba4b8b69bfaf8c9fa6aed", size = 796749, upload-time = "2026-05-09T23:13:10.573Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/30/66ab84588765f5b4b271a9ca09ef7ce2b87caa95176ec3d2ad65d7bc4902/regex-2026.5.9-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:57e8915c7986aa33d25e4d3629cef711cd2863f2961b10409f0c04cb8b7d9020", size = 865445, upload-time = "2026-05-09T23:13:12.523Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/89/f05169e8588aac365f35ffc7f3bc3184f095ef4cfded7cfaa3c7fd5dbd89/regex-2026.5.9-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:508f56a89ba9cb26e4168cbc37dbd60a28d82430a9e18ad1d25fe0883c314ca2", size = 912322, upload-time = "2026-05-09T23:13:14.281Z" },
+    { url = "https://files.pythonhosted.org/packages/30/e1/c93444052cf41581f3c884ab3fb5823daf0992f11cd4388d4275ca610558/regex-2026.5.9-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b6d189041f15691cfa2b6c4290448ec221244d225b3f5fe9e7771b34ffcdf6e2", size = 801269, upload-time = "2026-05-09T23:13:16.569Z" },
+    { url = "https://files.pythonhosted.org/packages/50/fe/0cf96b882f540e62e8b9956599798203d599c44cf4c77917ca27400ff69b/regex-2026.5.9-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e82db382b44d0111b22601c509c89f64434816c9e0eef9d1989cda8cc6ff1c04", size = 777085, upload-time = "2026-05-09T23:13:18.675Z" },
+    { url = "https://files.pythonhosted.org/packages/23/5c/d78d4924e7fc875557b9e9b768423925fdfaac5549d06da7810019a9bd26/regex-2026.5.9-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:2acfb48634f64996b57f90f39afa692ff362162722581921fe92239a59960f3c", size = 785153, upload-time = "2026-05-09T23:13:20.525Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/e0/5214774090e7b4524dcea3e3c4aa74141d43043f8beb49c1599db1c8b53a/regex-2026.5.9-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:d29eebfc9525db68cad3c97eedd7f754fa265aa5cd0cf4f863b2421e1b48fc9f", size = 860164, upload-time = "2026-05-09T23:13:22.263Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/e1/4a57a83350319b1271f0d7a249b8672513ed928b237a741631270de6caea/regex-2026.5.9-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:debb893095e944091c16e641a6e33c1b0f4cb61ab945ec5afbf53ce7068834d8", size = 765731, upload-time = "2026-05-09T23:13:24.277Z" },
+    { url = "https://files.pythonhosted.org/packages/12/f4/499e74a20c156fc75836ee04a72a38d1a063978f600937f9760467beb1b0/regex-2026.5.9-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:d659eee77986549c9ea45b861c7567e44d6287c3dc9a4565478853f7b9fe2ff6", size = 852062, upload-time = "2026-05-09T23:13:26.125Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/92/7eebc0d0a01e78629695f342ba17e0deaff8fb45e79cc0d7b98287da6e3e/regex-2026.5.9-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:2efa205e6d98b24d1f3ab395c11aa15cdf10935bca283d0285e0499c284fba21", size = 789577, upload-time = "2026-05-09T23:13:27.814Z" },
+    { url = "https://files.pythonhosted.org/packages/05/a4/018e71f7d2ad48c1ebe6d3ae0026f9b7cb4802fd15c7cc02fdf724355102/regex-2026.5.9-cp313-cp313-win32.whl", hash = "sha256:f3844f134e834076677dd369976e9f5068679fcb8e50102fdf6b7ac96a3ec127", size = 266691, upload-time = "2026-05-09T23:13:29.549Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/1d/861a93719fb9ee7dbfc3761b3797b7a3e112a5d42c6129459d2d741be9b5/regex-2026.5.9-cp313-cp313-win_amd64.whl", hash = "sha256:3527bb4942d2c14552155406cdedd906567456821848aed1cb4933a391bf5eca", size = 277747, upload-time = "2026-05-09T23:13:31.859Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/c6/0a2436ae4da1ba76e51cb98943c6838a9a721faa40ebe2dce07694ae34e3/regex-2026.5.9-cp313-cp313-win_arm64.whl", hash = "sha256:56a33f191f17d8c417f99945ebdc1e691d3af9605d86ec68c7e54a57e3e17af6", size = 270500, upload-time = "2026-05-09T23:13:33.525Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e9/d21346f7b60ed58789371358ed66b09d00f832e1bd7c06e55d9da5679882/regex-2026.5.9-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:01f28d868834624c934b8d2e0aa1c8341337e37831f4a012f18a5afcba4cbaf3", size = 494172, upload-time = "2026-05-09T23:13:35.935Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/43/fd1177a2032037c681baecdb3422ee4e1424aec4e4f470ef47793d325274/regex-2026.5.9-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:48036f6374aaa79eb3b754ec29c61d1c6b1606749d705a13f8854fa2539671f6", size = 293952, upload-time = "2026-05-09T23:13:38.307Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7d/9fbf919768368d3f8a4f6c692cf2aa61e482b2b81ec6a298ace4cbf02480/regex-2026.5.9-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:b96350aa424e79d4fd6b567b344dcbe2b2d6bfc48dfe7717587e1fa6d43da6ff", size = 292314, upload-time = "2026-05-09T23:13:40.353Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/6c/e41bfeecb589716843e7c4df09ba46ff2a42961457afece19059d85caeef/regex-2026.5.9-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8f3af7a4903c5c04a11a196a5aa75cdd7dd3f8508132f9fb3259d9f5908e3b88", size = 811681, upload-time = "2026-05-09T23:13:42.543Z" },
+    { url = "https://files.pythonhosted.org/packages/87/83/a5c1c525fba0aa656e88ad0face0b1829788ef4c2fb6b26df58aa1151b84/regex-2026.5.9-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7e87577720152d2caae19fe2baaf1f8d5ca12091e9e229f03915c37d1e4b9178", size = 871135, upload-time = "2026-05-09T23:13:44.326Z" },
+    { url = "https://files.pythonhosted.org/packages/18/d4/80882e799e440dd878b0979cbebf8fa4d54624a332c83037c7a701649e3f/regex-2026.5.9-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c8b9b9d294cfea3cd19c718ade7cc93492b2c4991abd9a68d0b3477ae6d8e100", size = 917265, upload-time = "2026-05-09T23:13:47.295Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/ff/8db60211e2286e396aad7dc7725356c502bff0901ea05bd6cdc2e1a042b9/regex-2026.5.9-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:728d8bfd28a8845c8b6bc5dc7ce010453d206396786c0765c2740cb65f37791e", size = 816311, upload-time = "2026-05-09T23:13:49.885Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/47/742ef579c61730f8d268e5cf1f9ce0e37e2ea041ad0f5644724f2378e463/regex-2026.5.9-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7e30b874d341fac767d7df5a0870540541c2c054b80cfaac116e8d367a8a7ff2", size = 785498, upload-time = "2026-05-09T23:13:52.25Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/ab/cb0999802dcb0fb95b1ab005e8d4163d8afdd67efc2cb6b6630ac13f8cb1/regex-2026.5.9-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:fd190e88a895a8901325fad284a3f74ea52b1da8525b76cc811fa9b1edf0ce2b", size = 801348, upload-time = "2026-05-09T23:13:54.127Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/62/8ca59a24c55bc34d166eefaf3717bd77772f329fdbf984d86581e0a3571c/regex-2026.5.9-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:8e76e8161ad00694cfce6767d5dea860c6391ac5b83e5c3a39661e696f11fc7e", size = 866493, upload-time = "2026-05-09T23:13:56.067Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/3d/30f2ae62cef3278bb5bb821f467277a55fb73f01032cf85997e15e8289a8/regex-2026.5.9-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:ddda5340e6c01a293027dd46232fa79eaff1b48058ce7a98f572b6445b088041", size = 772811, upload-time = "2026-05-09T23:13:57.867Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/ae/7d2089bcd78ad0c0161bc684339df50032acb438a7bd3305e7ddb1193cec/regex-2026.5.9-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:205109e96b3cf5adf8f4cd62bedde9487feb282b9497a3535451e5a24cd706a0", size = 856584, upload-time = "2026-05-09T23:13:59.679Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/29/92ff47f75990131ea4f24ba17819e5a9d141e10819807e09addd73409af6/regex-2026.5.9-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:dfbe4579b9f08036aa7d101d1835437a20783574ac66327e6b29b4018a138081", size = 803453, upload-time = "2026-05-09T23:14:01.978Z" },
+    { url = "https://files.pythonhosted.org/packages/04/99/eff29f1037dcab36702c9ee5d6858cf1ce2336ea8ea2987f64245b99ea5e/regex-2026.5.9-cp313-cp313t-win32.whl", hash = "sha256:ed2c9e8068b614c574d8d30e543d617cf5379b0535d46f97ef00e904745a08b5", size = 269951, upload-time = "2026-05-09T23:14:03.661Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/9d/8870b8981d27b22cda77bb26a5ac7ebfa9c7d9e0dea195a834a82380e748/regex-2026.5.9-cp313-cp313t-win_amd64.whl", hash = "sha256:b46b0f094dc1d3b90356c85a0bd2c9bafc4a6a190b9d6f8ddd5a033b6e088ed4", size = 281240, upload-time = "2026-05-09T23:14:05.56Z" },
+    { url = "https://files.pythonhosted.org/packages/72/b1/3379415e8f135c13ac551353397cc4fe97b4978f3cac73c5fcbcded548b8/regex-2026.5.9-cp313-cp313t-win_arm64.whl", hash = "sha256:872acc074bd29ffc9913ecdfedf6ea77502312ca44a4aa0d3779089c6069d8de", size = 272383, upload-time = "2026-05-09T23:14:07.843Z" },
+    { url = "https://files.pythonhosted.org/packages/13/3e/9c3cd292d8808b3645a2ce517e200179b6d0e903f176300bd8b542e14de5/regex-2026.5.9-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:1bd7587a2948b4085195d5a3374eaf4a425dc3e55784c038175355ecf3bbbf8a", size = 490376, upload-time = "2026-05-09T23:14:09.64Z" },
+    { url = "https://files.pythonhosted.org/packages/60/70/d43ee8a2ca0a8b68d167f21658b85520ac0574617c7f320367c5047f7556/regex-2026.5.9-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:dea2e88e1cce4522496cce630e11e67b98b7076620bc4336c3f674bc21a375f4", size = 291964, upload-time = "2026-05-09T23:14:11.424Z" },
+    { url = "https://files.pythonhosted.org/packages/21/91/9d50b433828d8e74196904e168a43abf1e6e88b2a15d47ed742456720c37/regex-2026.5.9-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:2099f7e7ff7b6aa3192312650a56e91cc091e49d50b04e4f6f8b6e28b3b27f1c", size = 289682, upload-time = "2026-05-09T23:14:13.123Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/d2/b835e3cafbb9d977736912436259ff551d60919f7d7b3d37d46659c63564/regex-2026.5.9-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ecd353045824e4477562a2ac718c25799cdaaa41f7aa925a806a8a3e6848a5b9", size = 796996, upload-time = "2026-05-09T23:14:14.923Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/a6/9f992d00019166b9de01c546dd4549bc679f2a68df11b877740b0760b7c2/regex-2026.5.9-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:65c8c8c37377794bd5b2f3ebe51919042bf17aec802e23c833d89782ed0c78af", size = 866089, upload-time = "2026-05-09T23:14:17.757Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/08/4d32af657e049b19cb62b02e46e38fe1518797bfb2203ee93a510b21b0dc/regex-2026.5.9-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5b73ab8afcf66c622db143d1c6fda4e58e4d537ee4f125229ad47b1ab80f34c0", size = 911530, upload-time = "2026-05-09T23:14:20.353Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/27/2af43dd1dc201d1fecefda64a45f4ad0995855b92724f795a777b402ee69/regex-2026.5.9-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0de5cf193997384ed2ca6f1cd4f78055b255d93d82d5a8cd6ba0d11c10b167e4", size = 800643, upload-time = "2026-05-09T23:14:22.265Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/dd/23a249047013b5321d4a60c4d2437462086f601b061776a525e5fba2a59f/regex-2026.5.9-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d641a8c9a61618047796d572a39a79b26167b0411d2c3031937b2fe2d081e2cf", size = 777223, upload-time = "2026-05-09T23:14:24.179Z" },
+    { url = "https://files.pythonhosted.org/packages/94/6a/e85ed9538cd19586d0465076a4578a12e093ce776d15f3f8ce92733a8dd6/regex-2026.5.9-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:24b2355ef5cc9aa5b8f07d17704face1c166fdcc2290fa7bd6e6c925655a8346", size = 785760, upload-time = "2026-05-09T23:14:26.065Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/c4/f25473209438638e947c55f9156fd8f236f74169229028cc99116380868e/regex-2026.5.9-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:a24852d3c29ad9e47593593d8a247c44ccc3d0548ef12c822d6ed0810affe676", size = 860891, upload-time = "2026-05-09T23:14:28.17Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/f7/f4f86e3c74419c37370e91f150ae0c2ef7d34b2e0e4cdd5da046a02e4022/regex-2026.5.9-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:916714069da19329ef7de197dcbc77bb3104145c7c2c864dbfbe318f46b88b14", size = 765891, upload-time = "2026-05-09T23:14:30.06Z" },
+    { url = "https://files.pythonhosted.org/packages/26/70/704d8e13765939146b1cd0ef4e2feb71d7929727d2290f026eed10095955/regex-2026.5.9-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:fa411799ca8da32a8d38d020a88faa5b6f91657d284761352940ecf9f7c3bbdd", size = 851380, upload-time = "2026-05-09T23:14:32.123Z" },
+    { url = "https://files.pythonhosted.org/packages/26/29/1a13582a8460038edc38e49f64ceb0dd7c60f5caba77571f4bf6601965d9/regex-2026.5.9-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:1e6da47d679b7010ef27556b6e0f99771b744936db1792a10ceac6547ae1503e", size = 789350, upload-time = "2026-05-09T23:14:34.799Z" },
+    { url = "https://files.pythonhosted.org/packages/73/56/3dcafe34fc72e271d62ad9a291801e88a1457bb251c132f15fcc2e5aad1a/regex-2026.5.9-cp314-cp314-win32.whl", hash = "sha256:98bd73080e8756255137e1bd3f3f00295bbc5aa383c0e0f973920e9134d7c4ad", size = 272130, upload-time = "2026-05-09T23:14:36.729Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/9c/02eebf0be95efe416c664db7fb8b6b05b7a0b06a7544f2884f2558b0526f/regex-2026.5.9-cp314-cp314-win_amd64.whl", hash = "sha256:ff8d372ac2acdc048d1c19916f27ee61bc5722728458ba6ca5052f2c72d51763", size = 280999, upload-time = "2026-05-09T23:14:39.126Z" },
+    { url = "https://files.pythonhosted.org/packages/70/5a/1dd1abee76cb7a846a0bcf42fdc87e5720c3c33c24f3e37814310a513d9f/regex-2026.5.9-cp314-cp314-win_arm64.whl", hash = "sha256:e1d93bf647916292e8edcec150c07ddf3dc50179ccaf770c04a7f9e452155372", size = 273500, upload-time = "2026-05-09T23:14:41.059Z" },
+    { url = "https://files.pythonhosted.org/packages/86/c1/c5f619b0057a7965cb78ec559c1d7a45ce8c99a35bea95483d64959a93d9/regex-2026.5.9-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:83d0ee4a57d1c87cb549e195ec300b8f0ec3a82eba66d835e4e2ed8634fe4499", size = 494269, upload-time = "2026-05-09T23:14:42.869Z" },
+    { url = "https://files.pythonhosted.org/packages/05/2c/5d01f1aee33de4bbe60c8452945bfc8477ca7c5ae4450f6bfe711036cb36/regex-2026.5.9-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:d3d7eb5c9a7f6df82ed3cfac9beb93882a5cbcb5b8b157b56cb2b3b276574ac1", size = 293954, upload-time = "2026-05-09T23:14:44.822Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/fe/e8988b2ae2108c6ef71bd4aa8d87fbe257976dd0810e826cd75f701c68b6/regex-2026.5.9-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:075160bf16658e16d35233300b8453aac25de4cbea808d22348b6979668e924d", size = 292405, upload-time = "2026-05-09T23:14:47.211Z" },
+    { url = "https://files.pythonhosted.org/packages/79/34/d2b0937faa7859263f7f0a3c6b103a1296306be6952dc173d0154e9a2f49/regex-2026.5.9-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:45375819235558a4ff1c4971dc32881f022613abdb180128f5cb4768c1765a1c", size = 811855, upload-time = "2026-05-09T23:14:49.21Z" },
+    { url = "https://files.pythonhosted.org/packages/80/fe/daf53a47457a8486db66c66c01ceb9c2303eecee3f87197f1e77eb1a736d/regex-2026.5.9-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ead4b163ac30a29574510cd4b3e2e985ac5290c05fc7095557d6a5f403fc31b5", size = 871189, upload-time = "2026-05-09T23:14:51.555Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/75/058fc4470cbfbf57d800aff1a0022b929a3f9fa553ee10a0cdf2070eb31f/regex-2026.5.9-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8c6e4218fbdfbcd4f6c19efca40930d24a621bf4b48cb76bc6640543bd28ef20", size = 917485, upload-time = "2026-05-09T23:14:53.633Z" },
+    { url = "https://files.pythonhosted.org/packages/88/e7/179cfda3a28bc843b5c6cfe7f79f23489c791ed95f151083803660878432/regex-2026.5.9-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6351571c8a42b505eb555c0dc47d740d0fb66977dc142919eea6f4325b7c56a0", size = 816369, upload-time = "2026-05-09T23:14:56.198Z" },
+    { url = "https://files.pythonhosted.org/packages/41/90/6f0cc422071688266d344fca8462d787cba0a2c144acb25721f9a61ec265/regex-2026.5.9-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:002205cafd2a9e78c6290c7d1df277bf3277b3b7a30e0b4bb0dac2e2e3f7cb2d", size = 785869, upload-time = "2026-05-09T23:14:58.602Z" },
+    { url = "https://files.pythonhosted.org/packages/02/67/a31f1760f09c27b251ef39e9beb541f462cf977381d067faa764c2c0e393/regex-2026.5.9-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8abd33fef90b2a9efac5557d6033ca82d1195ed3a15fea5af15ba7b463c6a63b", size = 801427, upload-time = "2026-05-09T23:15:00.642Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/c4/1a80654597b6bc1e1ea0494824c31200e8a956abe290afae9b19a166a148/regex-2026.5.9-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:31037c82eccb44b7ea2e9e221d7c01429430e989a1f4b91ea5a855f6017b509a", size = 866482, upload-time = "2026-05-09T23:15:03.384Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/960724e06482c08466ff5611e242e86f80062949cdf6b4b9cc317b9dd93d/regex-2026.5.9-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:5604dfd046dc37eca90250fc3be938b076c8059fa772ac0ed6f499b0f0fb0415", size = 773022, upload-time = "2026-05-09T23:15:05.625Z" },
+    { url = "https://files.pythonhosted.org/packages/50/a8/a9979c3e7918280e93159ebcab5ef1a65116dd4f3bd6091be0eae4a126e8/regex-2026.5.9-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:0e1b1b4e496afbb24f4a62aba855ee4f88f25578927697b340702e48c9ee6bc2", size = 856642, upload-time = "2026-05-09T23:15:07.966Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/d4/a9b732f2f0072c0ab12227483abb24fffcb9f73f8a2b203df0a6d0434735/regex-2026.5.9-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:be3372b9df6ddecff6486d37e19095a7b4973137caf5512407a89f4455361f41", size = 803552, upload-time = "2026-05-09T23:15:10.215Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/fe/1b3113817447a1d4155e4ac76d2e072f42c0bcba2f43fa8a0e756ea2cd91/regex-2026.5.9-cp314-cp314t-win32.whl", hash = "sha256:3ddd90103f9e5c471c49c7852ecc1fe27c7e45eb99e977aefe7caa4e779f4f58", size = 275746, upload-time = "2026-05-09T23:15:12.609Z" },
+    { url = "https://files.pythonhosted.org/packages/92/73/93d42045302636c91f2e5ef588b65b84b01428f28ec77de256b1dfdfbe5c/regex-2026.5.9-cp314-cp314t-win_amd64.whl", hash = "sha256:ca518ed29c46eecba6010b15f1b9a479314d2de409536e71b6a13aa04e3b8a77", size = 285685, upload-time = "2026-05-09T23:15:15.086Z" },
+    { url = "https://files.pythonhosted.org/packages/da/80/35b4c33c804a165a7f55289afda3ea9e3eb6d15800341a2d66455c0f1f30/regex-2026.5.9-cp314-cp314t-win_arm64.whl", hash = "sha256:5e41809d2683fcde7d5a8c87a6567ba1fb1ce0de9f31bff578de00a4b2d76daa", size = 275713, upload-time = "2026-05-09T23:15:16.98Z" },
+]
+
+[[package]]
 name = "requests"
 version = "2.33.1"
 source = { registry = "https://pypi.org/simple" }
@@ -487,12 +1005,82 @@ wheels = [
 ]
 
 [[package]]
+name = "ruamel-yaml"
+version = "0.19.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/3b/ebda527b56beb90cb7652cb1c7e4f91f48649fbcd8d2eb2fb6e77cd3329b/ruamel_yaml-0.19.1.tar.gz", hash = "sha256:53eb66cd27849eff968ebf8f0bf61f46cdac2da1d1f3576dd4ccee9b25c31993", size = 142709, upload-time = "2026-01-02T16:50:31.84Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/0c/51f6841f1d84f404f92463fc2b1ba0da357ca1e3db6b7fbda26956c3b82a/ruamel_yaml-0.19.1-py3-none-any.whl", hash = "sha256:27592957fedf6e0b62f281e96effd28043345e0e66001f97683aa9a40c667c93", size = 118102, upload-time = "2026-01-02T16:50:29.201Z" },
+]
+
+[[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
 name = "tenacity"
 version = "9.1.4"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
+]
+
+[[package]]
+name = "tiktoken"
+version = "0.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "regex" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/ab/4d017d0f76ec3171d469d80fc03dfbb4e48a4bcaddaa831b31d526f05edc/tiktoken-0.12.0.tar.gz", hash = "sha256:b18ba7ee2b093863978fcb14f74b3707cdc8d4d4d3836853ce7ec60772139931", size = 37806, upload-time = "2025-10-06T20:22:45.419Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/61/441588ee21e6b5cdf59d6870f86beb9789e532ee9718c251b391b70c68d6/tiktoken-0.12.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:775c2c55de2310cc1bc9a3ad8826761cbdc87770e586fd7b6da7d4589e13dab3", size = 1050802, upload-time = "2025-10-06T20:22:00.96Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/05/dcf94486d5c5c8d34496abe271ac76c5b785507c8eae71b3708f1ad9b45a/tiktoken-0.12.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a01b12f69052fbe4b080a2cfb867c4de12c704b56178edf1d1d7b273561db160", size = 993995, upload-time = "2025-10-06T20:22:02.788Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/70/5163fe5359b943f8db9946b62f19be2305de8c3d78a16f629d4165e2f40e/tiktoken-0.12.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:01d99484dc93b129cd0964f9d34eee953f2737301f18b3c7257bf368d7615baa", size = 1128948, upload-time = "2025-10-06T20:22:03.814Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/da/c028aa0babf77315e1cef357d4d768800c5f8a6de04d0eac0f377cb619fa/tiktoken-0.12.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:4a1a4fcd021f022bfc81904a911d3df0f6543b9e7627b51411da75ff2fe7a1be", size = 1151986, upload-time = "2025-10-06T20:22:05.173Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/5a/886b108b766aa53e295f7216b509be95eb7d60b166049ce2c58416b25f2a/tiktoken-0.12.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:981a81e39812d57031efdc9ec59fa32b2a5a5524d20d4776574c4b4bd2e9014a", size = 1194222, upload-time = "2025-10-06T20:22:06.265Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f8/4db272048397636ac7a078d22773dd2795b1becee7bc4922fe6207288d57/tiktoken-0.12.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9baf52f84a3f42eef3ff4e754a0db79a13a27921b457ca9832cf944c6be4f8f3", size = 1255097, upload-time = "2025-10-06T20:22:07.403Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/32/45d02e2e0ea2be3a9ed22afc47d93741247e75018aac967b713b2941f8ea/tiktoken-0.12.0-cp313-cp313-win_amd64.whl", hash = "sha256:b8a0cd0c789a61f31bf44851defbd609e8dd1e2c8589c614cc1060940ef1f697", size = 879117, upload-time = "2025-10-06T20:22:08.418Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/76/994fc868f88e016e6d05b0da5ac24582a14c47893f4474c3e9744283f1d5/tiktoken-0.12.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:d5f89ea5680066b68bcb797ae85219c72916c922ef0fcdd3480c7d2315ffff16", size = 1050309, upload-time = "2025-10-06T20:22:10.939Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/b8/57ef1456504c43a849821920d582a738a461b76a047f352f18c0b26c6516/tiktoken-0.12.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:b4e7ed1c6a7a8a60a3230965bdedba8cc58f68926b835e519341413370e0399a", size = 993712, upload-time = "2025-10-06T20:22:12.115Z" },
+    { url = "https://files.pythonhosted.org/packages/72/90/13da56f664286ffbae9dbcfadcc625439142675845baa62715e49b87b68b/tiktoken-0.12.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:fc530a28591a2d74bce821d10b418b26a094bf33839e69042a6e86ddb7a7fb27", size = 1128725, upload-time = "2025-10-06T20:22:13.541Z" },
+    { url = "https://files.pythonhosted.org/packages/05/df/4f80030d44682235bdaecd7346c90f67ae87ec8f3df4a3442cb53834f7e4/tiktoken-0.12.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:06a9f4f49884139013b138920a4c393aa6556b2f8f536345f11819389c703ebb", size = 1151875, upload-time = "2025-10-06T20:22:14.559Z" },
+    { url = "https://files.pythonhosted.org/packages/22/1f/ae535223a8c4ef4c0c1192e3f9b82da660be9eb66b9279e95c99288e9dab/tiktoken-0.12.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:04f0e6a985d95913cabc96a741c5ffec525a2c72e9df086ff17ebe35985c800e", size = 1194451, upload-time = "2025-10-06T20:22:15.545Z" },
+    { url = "https://files.pythonhosted.org/packages/78/a7/f8ead382fce0243cb625c4f266e66c27f65ae65ee9e77f59ea1653b6d730/tiktoken-0.12.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:0ee8f9ae00c41770b5f9b0bb1235474768884ae157de3beb5439ca0fd70f3e25", size = 1253794, upload-time = "2025-10-06T20:22:16.624Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e0/6cc82a562bc6365785a3ff0af27a2a092d57c47d7a81d9e2295d8c36f011/tiktoken-0.12.0-cp313-cp313t-win_amd64.whl", hash = "sha256:dc2dd125a62cb2b3d858484d6c614d136b5b848976794edfb63688d539b8b93f", size = 878777, upload-time = "2025-10-06T20:22:18.036Z" },
+    { url = "https://files.pythonhosted.org/packages/72/05/3abc1db5d2c9aadc4d2c76fa5640134e475e58d9fbb82b5c535dc0de9b01/tiktoken-0.12.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:a90388128df3b3abeb2bfd1895b0681412a8d7dc644142519e6f0a97c2111646", size = 1050188, upload-time = "2025-10-06T20:22:19.563Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7b/50c2f060412202d6c95f32b20755c7a6273543b125c0985d6fa9465105af/tiktoken-0.12.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:da900aa0ad52247d8794e307d6446bd3cdea8e192769b56276695d34d2c9aa88", size = 993978, upload-time = "2025-10-06T20:22:20.702Z" },
+    { url = "https://files.pythonhosted.org/packages/14/27/bf795595a2b897e271771cd31cb847d479073497344c637966bdf2853da1/tiktoken-0.12.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:285ba9d73ea0d6171e7f9407039a290ca77efcdb026be7769dccc01d2c8d7fff", size = 1129271, upload-time = "2025-10-06T20:22:22.06Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/de/9341a6d7a8f1b448573bbf3425fa57669ac58258a667eb48a25dfe916d70/tiktoken-0.12.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:d186a5c60c6a0213f04a7a802264083dea1bbde92a2d4c7069e1a56630aef830", size = 1151216, upload-time = "2025-10-06T20:22:23.085Z" },
+    { url = "https://files.pythonhosted.org/packages/75/0d/881866647b8d1be4d67cb24e50d0c26f9f807f994aa1510cb9ba2fe5f612/tiktoken-0.12.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:604831189bd05480f2b885ecd2d1986dc7686f609de48208ebbbddeea071fc0b", size = 1194860, upload-time = "2025-10-06T20:22:24.602Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/1e/b651ec3059474dab649b8d5b69f5c65cd8fcd8918568c1935bd4136c9392/tiktoken-0.12.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:8f317e8530bb3a222547b85a58583238c8f74fd7a7408305f9f63246d1a0958b", size = 1254567, upload-time = "2025-10-06T20:22:25.671Z" },
+    { url = "https://files.pythonhosted.org/packages/80/57/ce64fd16ac390fafde001268c364d559447ba09b509181b2808622420eec/tiktoken-0.12.0-cp314-cp314-win_amd64.whl", hash = "sha256:399c3dd672a6406719d84442299a490420b458c44d3ae65516302a99675888f3", size = 921067, upload-time = "2025-10-06T20:22:26.753Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/a4/72eed53e8976a099539cdd5eb36f241987212c29629d0a52c305173e0a68/tiktoken-0.12.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:c2c714c72bc00a38ca969dae79e8266ddec999c7ceccd603cc4f0d04ccd76365", size = 1050473, upload-time = "2025-10-06T20:22:27.775Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/d7/0110b8f54c008466b19672c615f2168896b83706a6611ba6e47313dbc6e9/tiktoken-0.12.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:cbb9a3ba275165a2cb0f9a83f5d7025afe6b9d0ab01a22b50f0e74fee2ad253e", size = 993855, upload-time = "2025-10-06T20:22:28.799Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/77/4f268c41a3957c418b084dd576ea2fad2e95da0d8e1ab705372892c2ca22/tiktoken-0.12.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:dfdfaa5ffff8993a3af94d1125870b1d27aed7cb97aa7eb8c1cefdbc87dbee63", size = 1129022, upload-time = "2025-10-06T20:22:29.981Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/2b/fc46c90fe5028bd094cd6ee25a7db321cb91d45dc87531e2bdbb26b4867a/tiktoken-0.12.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:584c3ad3d0c74f5269906eb8a659c8bfc6144a52895d9261cdaf90a0ae5f4de0", size = 1150736, upload-time = "2025-10-06T20:22:30.996Z" },
+    { url = "https://files.pythonhosted.org/packages/28/c0/3c7a39ff68022ddfd7d93f3337ad90389a342f761c4d71de99a3ccc57857/tiktoken-0.12.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:54c891b416a0e36b8e2045b12b33dd66fb34a4fe7965565f1b482da50da3e86a", size = 1194908, upload-time = "2025-10-06T20:22:32.073Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/0d/c1ad6f4016a3968c048545f5d9b8ffebf577774b2ede3e2e352553b685fe/tiktoken-0.12.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5edb8743b88d5be814b1a8a8854494719080c28faaa1ccbef02e87354fe71ef0", size = 1253706, upload-time = "2025-10-06T20:22:33.385Z" },
+    { url = "https://files.pythonhosted.org/packages/af/df/c7891ef9d2712ad774777271d39fdef63941ffba0a9d59b7ad1fd2765e57/tiktoken-0.12.0-cp314-cp314t-win_amd64.whl", hash = "sha256:f61c0aea5565ac82e2ec50a05e02a6c44734e91b51c10510b084ea1b8e633a71", size = 920667, upload-time = "2025-10-06T20:22:34.444Z" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.67.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
 ]
 
 [[package]]
@@ -545,6 +1133,24 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/65/36/2d24b2cbe78547c6532da33fb8613debd3126eccc33a6374ab788f5e46e9/uuid_utils-0.14.1-cp39-abi3-win32.whl", hash = "sha256:b54d6aa6252d96bac1fdbc80d26ba71bad9f220b2724d692ad2f2310c22ef523", size = 183476, upload-time = "2026-02-20T22:50:32.745Z" },
     { url = "https://files.pythonhosted.org/packages/83/92/2d7e90df8b1a69ec4cff33243ce02b7a62f926ef9e2f0eca5a026889cd73/uuid_utils-0.14.1-cp39-abi3-win_amd64.whl", hash = "sha256:fc27638c2ce267a0ce3e06828aff786f91367f093c80625ee21dad0208e0f5ba", size = 187147, upload-time = "2026-02-20T22:50:45.807Z" },
     { url = "https://files.pythonhosted.org/packages/d9/26/529f4beee17e5248e37e0bc17a2761d34c0fa3b1e5729c88adb2065bae6e/uuid_utils-0.14.1-cp39-abi3-win_arm64.whl", hash = "sha256:b04cb49b42afbc4ff8dbc60cf054930afc479d6f4dd7f1ec3bbe5dbfdde06b7a", size = 188132, upload-time = "2026-02-20T22:50:41.718Z" },
+]
+
+[[package]]
+name = "wcwidth"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/ee/afaf0f85a9a18fe47a67f1e4422ed6cf1fe642f0ae0a2f81166231303c52/wcwidth-0.7.0.tar.gz", hash = "sha256:90e3a7ea092341c44b99562e75d09e4d5160fe7a3974c6fb842a101a95e7eed0", size = 182132, upload-time = "2026-05-02T16:04:12.653Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/52/e465037f5375f43533d1a80b6923955201596a99142ed524d77b571a1418/wcwidth-0.7.0-py3-none-any.whl", hash = "sha256:5d69154c429a82910e241c738cd0e2976fac8a2dd47a1a805f4afed1c0f136f2", size = 110825, upload-time = "2026-05-02T16:04:11.033Z" },
+]
+
+[[package]]
+name = "xdg"
+version = "6.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2a/b9/0e6e6f19fb75cf5e1758f4f33c1256738f718966700cffc0fde2f966218b/xdg-6.0.0.tar.gz", hash = "sha256:24278094f2d45e846d1eb28a2ebb92d7b67fc0cab5249ee3ce88c95f649a1c92", size = 3453, upload-time = "2023-02-27T19:27:44.309Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dd/54/3516c1cf349060fc3578686d271eba242f10ec00b4530c2985af9faac49b/xdg-6.0.0-py3-none-any.whl", hash = "sha256:df3510755b4395157fc04fc3b02467c777f3b3ca383257397f09ab0d4c16f936", size = 3855, upload-time = "2023-02-27T19:27:42.151Z" },
 ]
 
 [[package]]
@@ -639,6 +1245,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ad/95/a26baa93b5241fd7630998816a4ec47a5a0bad193b3f8fc8f3593e1a4a67/xxhash-3.7.0-cp314-cp314t-win32.whl", hash = "sha256:a04a6cab47e2166435aaf5b9e5ee41d1532cc8300efdef87f2a4d0acb7db19ed", size = 31643, upload-time = "2026-04-25T11:09:08.153Z" },
     { url = "https://files.pythonhosted.org/packages/44/36/5454f13c447e395f9b06a3e91274c59f503d31fad84e1836efe3bdb71f6a/xxhash-3.7.0-cp314-cp314t-win_amd64.whl", hash = "sha256:8653dd7c2eda020545bb2c71c7f7039b53fe7434d0fc1a0a9deb79ab3f1a4fc1", size = 32522, upload-time = "2026-04-25T11:09:09.534Z" },
     { url = "https://files.pythonhosted.org/packages/74/35/698e7e3ff38e22992ea24870a511d8762474fb6783627a2910ff22a185c2/xxhash-3.7.0-cp314-cp314t-win_arm64.whl", hash = "sha256:468f0fc114faaa4b36699f8e328bbc3bb11dc418ba94ac52c26dd736d4b6c637", size = 28807, upload-time = "2026-04-25T11:09:11.234Z" },
+]
+
+[[package]]
+name = "zipp"
+version = "3.23.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/21/093488dfc7cc8964ded15ab726fad40f25fd3d788fd741cc1c5a17d78ee8/zipp-3.23.1.tar.gz", hash = "sha256:32120e378d32cd9714ad503c1d024619063ec28aad2248dc6672ad13edfa5110", size = 25965, upload-time = "2026-04-13T23:21:46.6Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/8a/0861bec20485572fbddf3dfba2910e38fe249796cb73ecdeb74e07eeb8d3/zipp-3.23.1-py3-none-any.whl", hash = "sha256:0b3596c50a5c700c9cb40ba8d86d9f2cc4807e9bedb06bcdf7fac85633e444dc", size = 10378, upload-time = "2026-04-13T23:21:45.386Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -7,6 +7,7 @@ name = "ai-bioworkflow"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "jinja2" },
     { name = "langchain" },
     { name = "langchain-anthropic" },
     { name = "langchain-deepseek" },
@@ -17,6 +18,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "jinja2", specifier = ">=3.1.6" },
     { name = "langchain", specifier = ">=1.2.18" },
     { name = "langchain-anthropic", specifier = ">=1.4.3" },
     { name = "langchain-deepseek", specifier = ">=1.0.1" },
@@ -202,6 +204,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
+]
+
+[[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
 ]
 
 [[package]]
@@ -440,6 +454,58 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/de/8a/1e8ea5e8bab2a65fa95bd36229ef38e8723ec46e430e20ca2d953487a7f1/langsmith-0.8.3.tar.gz", hash = "sha256:767ff7a8d136ed42926bf99059ac631dc6883542d6e3104b32e71c7625e1fa05", size = 4460330, upload-time = "2026-05-07T19:56:56.18Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/98/a9/51e644c1f1dbc3dd7d22dfd6412eab206d538c81e024e4f287373544bdcb/langsmith-0.8.3-py3-none-any.whl", hash = "sha256:b2e40e308222fa0beb2dccee3b4b30bfee9062d7a4f20a3e3e93df3c51a08ab4", size = 399048, upload-time = "2026-05-07T19:56:53.994Z" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622, upload-time = "2025-09-27T18:36:41.777Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029, upload-time = "2025-09-27T18:36:43.257Z" },
+    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374, upload-time = "2025-09-27T18:36:44.508Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980, upload-time = "2025-09-27T18:36:45.385Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990, upload-time = "2025-09-27T18:36:46.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784, upload-time = "2025-09-27T18:36:47.884Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588, upload-time = "2025-09-27T18:36:48.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041, upload-time = "2025-09-27T18:36:49.797Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543, upload-time = "2025-09-27T18:36:51.584Z" },
+    { url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113, upload-time = "2025-09-27T18:36:52.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911, upload-time = "2025-09-27T18:36:53.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658, upload-time = "2025-09-27T18:36:54.819Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066, upload-time = "2025-09-27T18:36:55.714Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639, upload-time = "2025-09-27T18:36:56.908Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569, upload-time = "2025-09-27T18:36:57.913Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284, upload-time = "2025-09-27T18:36:58.833Z" },
+    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801, upload-time = "2025-09-27T18:36:59.739Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769, upload-time = "2025-09-27T18:37:00.719Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642, upload-time = "2025-09-27T18:37:01.673Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
+    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619, upload-time = "2025-09-27T18:37:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload-time = "2025-09-27T18:37:07.213Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408, upload-time = "2025-09-27T18:37:09.572Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005, upload-time = "2025-09-27T18:37:10.58Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048, upload-time = "2025-09-27T18:37:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821, upload-time = "2025-09-27T18:37:12.48Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606, upload-time = "2025-09-27T18:37:13.485Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload-time = "2025-09-27T18:37:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747, upload-time = "2025-09-27T18:37:15.36Z" },
+    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341, upload-time = "2025-09-27T18:37:16.496Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073, upload-time = "2025-09-27T18:37:17.476Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661, upload-time = "2025-09-27T18:37:18.453Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670, upload-time = "2025-09-27T18:37:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598, upload-time = "2025-09-27T18:37:21.177Z" },
+    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261, upload-time = "2025-09-27T18:37:22.167Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835, upload-time = "2025-09-27T18:37:23.296Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733, upload-time = "2025-09-27T18:37:24.237Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload-time = "2025-09-27T18:37:25.271Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -17,6 +17,11 @@ dependencies = [
     { name = "python-dotenv" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "isort" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "jinja2", specifier = ">=3.1.6" },
@@ -28,6 +33,9 @@ requires-dist = [
     { name = "miniwdl", specifier = ">=1.14.2" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
 ]
+
+[package.metadata.requires-dev]
+dev = [{ name = "isort", specifier = ">=8.0.1" }]
 
 [[package]]
 name = "annotated-types"
@@ -265,6 +273,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/38/3d/2d244233ac4f76e38533cfcb2991c9eb4c7bf688ae0a036d30725b8faafe/importlib_metadata-9.0.0-py3-none-any.whl", hash = "sha256:2d21d1cc5a017bd0559e36150c21c830ab1dc304dedd1b7ea85d20f45ef3edd7", size = 27789, upload-time = "2026-03-20T06:42:55.665Z" },
+]
+
+[[package]]
+name = "isort"
+version = "8.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ef/7c/ec4ab396d31b3b395e2e999c8f46dec78c5e29209fac49d1f4dace04041d/isort-8.0.1.tar.gz", hash = "sha256:171ac4ff559cdc060bcfff550bc8404a486fee0caab245679c2abe7cb253c78d", size = 769592, upload-time = "2026-02-28T10:08:20.685Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/95/c7c34aa53c16353c56d0b802fba48d5f5caa2cdee7958acbcb795c830416/isort-8.0.1-py3-none-any.whl", hash = "sha256:28b89bc70f751b559aeca209e6120393d43fbe2490de0559662be7a9787e3d75", size = 89733, upload-time = "2026-02-28T10:08:19.466Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -9,6 +9,7 @@ source = { virtual = "." }
 dependencies = [
     { name = "langchain" },
     { name = "langchain-anthropic" },
+    { name = "langchain-deepseek" },
     { name = "langchain-openai" },
     { name = "langgraph" },
     { name = "python-dotenv" },
@@ -18,6 +19,7 @@ dependencies = [
 requires-dist = [
     { name = "langchain", specifier = ">=1.2.18" },
     { name = "langchain-anthropic", specifier = ">=1.4.3" },
+    { name = "langchain-deepseek", specifier = ">=1.0.1" },
     { name = "langchain-openai", specifier = ">=1.2.1" },
     { name = "langgraph", specifier = ">=1.1.10" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
@@ -323,6 +325,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d3/ae/8b74458fc3850ec3d150eb9f45e857db129dafa801fb5cf173dfc9f8bbf3/langchain_core-1.3.3.tar.gz", hash = "sha256:fa510a5db8efdc0c6ff41c0939fb5c00a0183c11f6b84233e892e3227ff69182", size = 915041, upload-time = "2026-05-05T19:02:36.612Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/01/4771b7ab2af1d1aba5b710bd8f13d9225c609425214b357590a17b01be77/langchain_core-1.3.3-py3-none-any.whl", hash = "sha256:18aae8506f37da7f74398492279a7d6efcee4f8e23c4c41c7af080eeb7ef7bd1", size = 543857, upload-time = "2026-05-05T19:02:34.52Z" },
+]
+
+[[package]]
+name = "langchain-deepseek"
+version = "1.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langchain-core" },
+    { name = "langchain-openai" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4e/c4/de579ea21e22777959f214af165761c6cd101248222bcc0886d020d67185/langchain_deepseek-1.0.1.tar.gz", hash = "sha256:e7a0238f2c14e928e1562641b2df639c19cdf867287a7f2293ffb1372daf83ae", size = 147216, upload-time = "2025-11-13T16:29:13.445Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cd/dd/a803dfbf64273232f3fc82f859487331abb717671bbcdf266fd80de6ef78/langchain_deepseek-1.0.1-py3-none-any.whl", hash = "sha256:0a9862f335f1873370bb0fe1928ac19b8b9292b014ef5412da462ded8bb82c5a", size = 8325, upload-time = "2025-11-13T16:29:12.385Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -11,6 +11,7 @@ dependencies = [
     { name = "langchain-anthropic" },
     { name = "langchain-openai" },
     { name = "langgraph" },
+    { name = "python-dotenv" },
 ]
 
 [package.metadata]
@@ -19,6 +20,7 @@ requires-dist = [
     { name = "langchain-anthropic", specifier = ">=1.4.3" },
     { name = "langchain-openai", specifier = ">=1.2.1" },
     { name = "langgraph", specifier = ">=1.1.10" },
+    { name = "python-dotenv", specifier = ">=1.2.2" },
 ]
 
 [[package]]
@@ -590,6 +592,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/30/a6/9f9f380dbb301f67023bf8f707aaa75daadf84f7152d95c410fd7e81d994/pydantic_core-2.46.4-cp314-cp314t-win32.whl", hash = "sha256:e846ae7835bf0703ae43f534ab79a867146dadd59dc9ca5c8b53d5c8f7c9ef02", size = 1955575, upload-time = "2026-05-06T13:38:51.116Z" },
     { url = "https://files.pythonhosted.org/packages/40/1f/f1eb9eb350e795d1af8586289746f5c5677d16043040d63710e22abc43c9/pydantic_core-2.46.4-cp314-cp314t-win_amd64.whl", hash = "sha256:2108ba5c1c1eca18030634489dc544844144ee36357f2f9f780b93e7ddbb44b5", size = 2051624, upload-time = "2026-05-06T13:38:21.672Z" },
     { url = "https://files.pythonhosted.org/packages/f6/d2/42dd53d0a85c27606f316d3aa5d2869c4e8470a5ed6dec30e4a1abe19192/pydantic_core-2.46.4-cp314-cp314t-win_arm64.whl", hash = "sha256:4fcbe087dbc2068af7eda3aa87634eba216dbda64d1ae73c8684b621d33f6596", size = 2017325, upload-time = "2026-05-06T13:40:52.723Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -13,6 +13,7 @@ dependencies = [
     { name = "langchain-deepseek" },
     { name = "langchain-openai" },
     { name = "langgraph" },
+    { name = "miniwdl" },
     { name = "python-dotenv" },
 ]
 
@@ -24,6 +25,7 @@ requires-dist = [
     { name = "langchain-deepseek", specifier = ">=1.0.1" },
     { name = "langchain-openai", specifier = ">=1.2.1" },
     { name = "langgraph", specifier = ">=1.1.10" },
+    { name = "miniwdl", specifier = ">=1.14.2" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
 ]
 
@@ -65,6 +67,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
+name = "argcomplete"
+version = "3.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/38/61/0b9ae6399dd4a58d8c1b1dc5a27d6f2808023d0b5dd3104bb99f45a33ff6/argcomplete-3.6.3.tar.gz", hash = "sha256:62e8ed4fd6a45864acc8235409461b72c9a28ee785a2011cc5eb78318786c89c", size = 73754, upload-time = "2025-10-20T03:33:34.741Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/f5/9373290775639cb67a2fce7f629a1c240dce9f12fe927bc32b2736e16dfc/argcomplete-3.6.3-py3-none-any.whl", hash = "sha256:f5007b3a600ccac5d25bbce33089211dfd49eab4a7718da3f10e3082525a92ce", size = 43846, upload-time = "2025-10-20T03:33:33.021Z" },
 ]
 
 [[package]]
@@ -143,12 +154,38 @@ wheels = [
 ]
 
 [[package]]
+name = "coloredlogs"
+version = "15.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "humanfriendly" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cc/c7/eed8f27100517e8c0e6b923d5f0845d0cb99763da6fdee00478f91db7325/coloredlogs-15.0.1.tar.gz", hash = "sha256:7c991aa71a4577af2f82600d8f8f3a89f936baeaf9b50a9c197da014e5bf16b0", size = 278520, upload-time = "2021-06-11T10:22:45.202Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/06/3d6badcf13db419e25b07041d9c7b4a2c331d3f4e7134445ec5df57714cd/coloredlogs-15.0.1-py2.py3-none-any.whl", hash = "sha256:612ee75c546f53e92e70049c9dbfcc18c935a2b9a53b66085ce9ef6a6e5c0934", size = 46018, upload-time = "2021-06-11T10:22:42.561Z" },
+]
+
+[[package]]
 name = "distro"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
+name = "docker"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "requests" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/91/9b/4a2ea29aeba62471211598dac5d96825bb49348fa07e906ea930394a83ce/docker-7.1.0.tar.gz", hash = "sha256:ad8c70e6e3f8926cb8a92619b832b4ea5299e2831c14284663184e200546fa6c", size = 117834, upload-time = "2024-05-23T11:13:57.216Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/26/57c6fb270950d476074c087527a558ccb6f4436657314bfb6cdf484114c4/docker-7.1.0-py3-none-any.whl", hash = "sha256:c96b93b7f0a746f9e77d325bcfb87422a3d8bd4f03136ae8a85b37f1898d5fc0", size = 147774, upload-time = "2024-05-23T11:13:55.01Z" },
 ]
 
 [[package]]
@@ -198,12 +235,36 @@ wheels = [
 ]
 
 [[package]]
+name = "humanfriendly"
+version = "10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyreadline3", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cc/3f/2c29224acb2e2df4d2046e4c73ee2662023c58ff5b113c4c1adac0886c43/humanfriendly-10.0.tar.gz", hash = "sha256:6b0b831ce8f15f7300721aa49829fc4e83921a9a301cc7f606be6686a2288ddc", size = 360702, upload-time = "2021-09-17T21:40:43.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/0f/310fb31e39e2d734ccaa2c0fb981ee41f7bd5056ce9bc29b2248bd569169/humanfriendly-10.0-py2.py3-none-any.whl", hash = "sha256:1697e1a8a8f550fd43c2865cd84542fc175a61dcb779b6fee18cf6b6ccba1477", size = 86794, upload-time = "2021-09-17T21:40:39.897Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.13"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
+]
+
+[[package]]
+name = "importlib-metadata"
+version = "9.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "zipp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/3d/2d244233ac4f76e38533cfcb2991c9eb4c7bf688ae0a036d30725b8faafe/importlib_metadata-9.0.0-py3-none-any.whl", hash = "sha256:2d21d1cc5a017bd0559e36150c21c830ab1dc304dedd1b7ea85d20f45ef3edd7", size = 27789, upload-time = "2026-03-20T06:42:55.665Z" },
 ]
 
 [[package]]
@@ -457,6 +518,15 @@ wheels = [
 ]
 
 [[package]]
+name = "lark"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/34/28fff3ab31ccff1fd4f6c7c7b0ceb2b6968d8ea4950663eadcb5720591a0/lark-1.3.1.tar.gz", hash = "sha256:b426a7a6d6d53189d318f2b6236ab5d6429eaf09259f1ca33eb716eed10d2905", size = 382732, upload-time = "2025-10-27T18:25:56.653Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3d/14ce75ef66813643812f3093ab17e46d3a206942ce7376d31ec2d36229e7/lark-1.3.1-py3-none-any.whl", hash = "sha256:c629b661023a014c37da873b4ff58a817398d12635d3bbb2c5a03be7fe5d1e12", size = 113151, upload-time = "2025-10-27T18:25:54.882Z" },
+]
+
+[[package]]
 name = "markupsafe"
 version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -506,6 +576,29 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
     { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
     { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
+name = "miniwdl"
+version = "1.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "argcomplete" },
+    { name = "coloredlogs" },
+    { name = "docker" },
+    { name = "importlib-metadata" },
+    { name = "lark" },
+    { name = "psutil" },
+    { name = "pygtail" },
+    { name = "python-json-logger" },
+    { name = "questionary" },
+    { name = "regex" },
+    { name = "ruamel-yaml" },
+    { name = "xdg" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/85/05/3314988f43cc7eab978eef05463eb7876eae4396a4f1fc30ea4bf79fb3ac/miniwdl-1.14.2.tar.gz", hash = "sha256:5272ab56beeefb403770841a7486d9d00f8e687f363f3dd4467844e799495ecf", size = 487061, upload-time = "2026-04-26T21:52:58.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/4b/d69af3f83138751ee894fe9c5b39d99a50f608f2ac4fe06ee11a024b963b/miniwdl-1.14.2-py3-none-any.whl", hash = "sha256:aa0e6dc0cd6626fa0b11601ade154456ec0be98ca46ecb4da7315c6c2d1ed6d9", size = 200188, upload-time = "2026-04-26T21:52:56.49Z" },
 ]
 
 [[package]]
@@ -605,6 +698,46 @@ wheels = [
 ]
 
 [[package]]
+name = "prompt-toolkit"
+version = "3.0.52"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/96/06e01a7b38dce6fe1db213e061a4602dd6032a8a97ef6c1a862537732421/prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855", size = 434198, upload-time = "2025-08-27T15:24:02.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955", size = 391431, upload-time = "2025-08-27T15:23:59.498Z" },
+]
+
+[[package]]
+name = "psutil"
+version = "7.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c6/d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372", size = 493740, upload-time = "2026-01-28T18:14:54.428Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/08/510cbdb69c25a96f4ae523f733cdc963ae654904e8db864c07585ef99875/psutil-7.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:2edccc433cbfa046b980b0df0171cd25bcaeb3a68fe9022db0979e7aa74a826b", size = 130595, upload-time = "2026-01-28T18:14:57.293Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/f5/97baea3fe7a5a9af7436301f85490905379b1c6f2dd51fe3ecf24b4c5fbf/psutil-7.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78c8603dcd9a04c7364f1a3e670cea95d51ee865e4efb3556a3a63adef958ea", size = 131082, upload-time = "2026-01-28T18:14:59.732Z" },
+    { url = "https://files.pythonhosted.org/packages/37/d6/246513fbf9fa174af531f28412297dd05241d97a75911ac8febefa1a53c6/psutil-7.2.2-cp313-cp313t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1a571f2330c966c62aeda00dd24620425d4b0cc86881c89861fbc04549e5dc63", size = 181476, upload-time = "2026-01-28T18:15:01.884Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/b5/9182c9af3836cca61696dabe4fd1304e17bc56cb62f17439e1154f225dd3/psutil-7.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:917e891983ca3c1887b4ef36447b1e0873e70c933afc831c6b6da078ba474312", size = 184062, upload-time = "2026-01-28T18:15:04.436Z" },
+    { url = "https://files.pythonhosted.org/packages/16/ba/0756dca669f5a9300d0cbcbfae9a4c30e446dfc7440ffe43ded5724bfd93/psutil-7.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:ab486563df44c17f5173621c7b198955bd6b613fb87c71c161f827d3fb149a9b", size = 139893, upload-time = "2026-01-28T18:15:06.378Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/61/8fa0e26f33623b49949346de05ec1ddaad02ed8ba64af45f40a147dbfa97/psutil-7.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:ae0aefdd8796a7737eccea863f80f81e468a1e4cf14d926bd9b6f5f2d5f90ca9", size = 135589, upload-time = "2026-01-28T18:15:08.03Z" },
+    { url = "https://files.pythonhosted.org/packages/81/69/ef179ab5ca24f32acc1dac0c247fd6a13b501fd5534dbae0e05a1c48b66d/psutil-7.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:eed63d3b4d62449571547b60578c5b2c4bcccc5387148db46e0c2313dad0ee00", size = 130664, upload-time = "2026-01-28T18:15:09.469Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/64/665248b557a236d3fa9efc378d60d95ef56dd0a490c2cd37dafc7660d4a9/psutil-7.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7b6d09433a10592ce39b13d7be5a54fbac1d1228ed29abc880fb23df7cb694c9", size = 131087, upload-time = "2026-01-28T18:15:11.724Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2e/e6782744700d6759ebce3043dcfa661fb61e2fb752b91cdeae9af12c2178/psutil-7.2.2-cp314-cp314t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fa4ecf83bcdf6e6c8f4449aff98eefb5d0604bf88cb883d7da3d8d2d909546a", size = 182383, upload-time = "2026-01-28T18:15:13.445Z" },
+    { url = "https://files.pythonhosted.org/packages/57/49/0a41cefd10cb7505cdc04dab3eacf24c0c2cb158a998b8c7b1d27ee2c1f5/psutil-7.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e452c464a02e7dc7822a05d25db4cde564444a67e58539a00f929c51eddda0cf", size = 185210, upload-time = "2026-01-28T18:15:16.002Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/2c/ff9bfb544f283ba5f83ba725a3c5fec6d6b10b8f27ac1dc641c473dc390d/psutil-7.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:c7663d4e37f13e884d13994247449e9f8f574bc4655d509c3b95e9ec9e2b9dc1", size = 141228, upload-time = "2026-01-28T18:15:18.385Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/fc/f8d9c31db14fcec13748d373e668bc3bed94d9077dbc17fb0eebc073233c/psutil-7.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:11fe5a4f613759764e79c65cf11ebdf26e33d6dd34336f8a337aa2996d71c841", size = 136284, upload-time = "2026-01-28T18:15:19.912Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/36/5ee6e05c9bd427237b11b3937ad82bb8ad2752d72c6969314590dd0c2f6e/psutil-7.2.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ed0cace939114f62738d808fdcecd4c869222507e266e574799e9c0faa17d486", size = 129090, upload-time = "2026-01-28T18:15:22.168Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c4/f5af4c1ca8c1eeb2e92ccca14ce8effdeec651d5ab6053c589b074eda6e1/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a7b04c10f32cc88ab39cbf606e117fd74721c831c98a27dc04578deb0c16979", size = 129859, upload-time = "2026-01-28T18:15:23.795Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9", size = 155560, upload-time = "2026-01-28T18:15:25.976Z" },
+    { url = "https://files.pythonhosted.org/packages/63/65/37648c0c158dc222aba51c089eb3bdfa238e621674dc42d48706e639204f/psutil-7.2.2-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b0726cecd84f9474419d67252add4ac0cd9811b04d61123054b9fb6f57df6e9e", size = 156997, upload-time = "2026-01-28T18:15:27.794Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/13/125093eadae863ce03c6ffdbae9929430d116a246ef69866dad94da3bfbc/psutil-7.2.2-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd04ef36b4a6d599bbdb225dd1d3f51e00105f6d48a28f006da7f9822f2606d8", size = 148972, upload-time = "2026-01-28T18:15:29.342Z" },
+    { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
+]
+
+[[package]]
 name = "pydantic"
 version = "2.13.4"
 source = { registry = "https://pypi.org/simple" }
@@ -676,12 +809,52 @@ wheels = [
 ]
 
 [[package]]
+name = "pygtail"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/89/437120e303d5d2c81107ed3415d5f3c9975f7dfdeef9e4440cef364e3bf9/pygtail-0.14.0.tar.gz", hash = "sha256:55616d31a081eaaeb069d0946f2bc7e530ebf505d4c3c050f8e941786a3449d3", size = 13509, upload-time = "2022-11-06T14:54:28.816Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/77/5558c3904229d2e320722ec58d38b82f9ff3063b7eeda49a8821b5595de1/pygtail-0.14.0-py3-none-any.whl", hash = "sha256:3d8e847d4d5c56e3cece1f65577562e63f8b75af7b93bf21b71c3213d369c2a9", size = 14319, upload-time = "2022-11-06T14:54:26.714Z" },
+]
+
+[[package]]
+name = "pyreadline3"
+version = "3.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/49/4cea918a08f02817aabae639e3d0ac046fef9f9180518a3ad394e22da148/pyreadline3-3.5.4.tar.gz", hash = "sha256:8d57d53039a1c75adba8e50dd3d992b28143480816187ea5efbd5c78e6c885b7", size = 99839, upload-time = "2024-09-19T02:40:10.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/dc/491b7661614ab97483abf2056be1deee4dc2490ecbf7bff9ab5cdbac86e1/pyreadline3-3.5.4-py3-none-any.whl", hash = "sha256:eaf8e6cc3c49bcccf145fc6067ba8643d1df34d604a1ec0eccbf7a18e6d3fae6", size = 83178, upload-time = "2024-09-19T02:40:08.598Z" },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "python-json-logger"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f7/ff/3cc9165fd44106973cd7ac9facb674a65ed853494592541d339bdc9a30eb/python_json_logger-4.1.0.tar.gz", hash = "sha256:b396b9e3ed782b09ff9d6e4f1683d46c83ad0d35d2e407c09a9ebbf038f88195", size = 17573, upload-time = "2026-03-29T04:39:56.805Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/be/0631a861af4d1c875f096c07d34e9a63639560a717130e7a87cbc82b7e3f/python_json_logger-4.1.0-py3-none-any.whl", hash = "sha256:132994765cf75bf44554be9aa49b06ef2345d23661a96720262716438141b6b2", size = 15021, upload-time = "2026-03-29T04:39:55.266Z" },
+]
+
+[[package]]
+name = "pywin32"
+version = "311"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/be/3fd5de0979fcb3994bfee0d65ed8ca9506a8a1260651b86174f6a86f52b3/pywin32-311-cp313-cp313-win32.whl", hash = "sha256:f95ba5a847cba10dd8c4d8fefa9f2a6cf283b8b88ed6178fa8a6c1ab16054d0d", size = 8705700, upload-time = "2025-07-14T20:13:26.471Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/28/e0a1909523c6890208295a29e05c2adb2126364e289826c0a8bc7297bd5c/pywin32-311-cp313-cp313-win_amd64.whl", hash = "sha256:718a38f7e5b058e76aee1c56ddd06908116d35147e133427e59a3983f703a20d", size = 9494700, upload-time = "2025-07-14T20:13:28.243Z" },
+    { url = "https://files.pythonhosted.org/packages/04/bf/90339ac0f55726dce7d794e6d79a18a91265bdf3aa70b6b9ca52f35e022a/pywin32-311-cp313-cp313-win_arm64.whl", hash = "sha256:7b4075d959648406202d92a2310cb990fea19b535c7f4a78d3f5e10b926eeb8a", size = 8709318, upload-time = "2025-07-14T20:13:30.348Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/31/097f2e132c4f16d99a22bfb777e0fd88bd8e1c634304e102f313af69ace5/pywin32-311-cp314-cp314-win32.whl", hash = "sha256:b7a2c10b93f8986666d0c803ee19b5990885872a7de910fc460f9b0c2fbf92ee", size = 8840714, upload-time = "2025-07-14T20:13:32.449Z" },
+    { url = "https://files.pythonhosted.org/packages/90/4b/07c77d8ba0e01349358082713400435347df8426208171ce297da32c313d/pywin32-311-cp314-cp314-win_amd64.whl", hash = "sha256:3aca44c046bd2ed8c90de9cb8427f581c479e594e99b5c0bb19b29c10fd6cb87", size = 9656800, upload-time = "2025-07-14T20:13:34.312Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/d2/21af5c535501a7233e734b8af901574572da66fcc254cb35d0609c9080dd/pywin32-311-cp314-cp314-win_arm64.whl", hash = "sha256:a508e2d9025764a8270f93111a970e1d0fbfc33f4153b388bb649b7eec4f9b42", size = 8932540, upload-time = "2025-07-14T20:13:36.379Z" },
 ]
 
 [[package]]
@@ -718,6 +891,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "questionary"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "prompt-toolkit" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f6/45/eafb0bba0f9988f6a2520f9ca2df2c82ddfa8d67c95d6625452e97b204a5/questionary-2.1.1.tar.gz", hash = "sha256:3d7e980292bb0107abaa79c68dd3eee3c561b83a0f89ae482860b181c8bd412d", size = 25845, upload-time = "2025-08-28T19:00:20.851Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3c/26/1062c7ec1b053db9e499b4d2d5bc231743201b74051c973dadeac80a8f43/questionary-2.1.1-py3-none-any.whl", hash = "sha256:a51af13f345f1cdea62347589fbb6df3b290306ab8930713bfae4d475a7d4a59", size = 36753, upload-time = "2025-08-28T19:00:19.56Z" },
 ]
 
 [[package]]
@@ -817,6 +1002,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f3/61/d7545dafb7ac2230c70d38d31cbfe4cc64f7144dc41f6e4e4b78ecd9f5bb/requests-toolbelt-1.0.0.tar.gz", hash = "sha256:7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6", size = 206888, upload-time = "2023-05-01T04:11:33.229Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3f/51/d4db610ef29373b879047326cbf6fa98b6c1969d6f6dc423279de2b1be2c/requests_toolbelt-1.0.0-py2.py3-none-any.whl", hash = "sha256:cccfdd665f0a24fcf4726e690f65639d272bb0637b9b92dfd91a5568ccf6bd06", size = 54481, upload-time = "2023-05-01T04:11:28.427Z" },
+]
+
+[[package]]
+name = "ruamel-yaml"
+version = "0.19.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/3b/ebda527b56beb90cb7652cb1c7e4f91f48649fbcd8d2eb2fb6e77cd3329b/ruamel_yaml-0.19.1.tar.gz", hash = "sha256:53eb66cd27849eff968ebf8f0bf61f46cdac2da1d1f3576dd4ccee9b25c31993", size = 142709, upload-time = "2026-01-02T16:50:31.84Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/0c/51f6841f1d84f404f92463fc2b1ba0da357ca1e3db6b7fbda26956c3b82a/ruamel_yaml-0.19.1-py3-none-any.whl", hash = "sha256:27592957fedf6e0b62f281e96effd28043345e0e66001f97683aa9a40c667c93", size = 118102, upload-time = "2026-01-02T16:50:29.201Z" },
 ]
 
 [[package]]
@@ -942,6 +1136,24 @@ wheels = [
 ]
 
 [[package]]
+name = "wcwidth"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/ee/afaf0f85a9a18fe47a67f1e4422ed6cf1fe642f0ae0a2f81166231303c52/wcwidth-0.7.0.tar.gz", hash = "sha256:90e3a7ea092341c44b99562e75d09e4d5160fe7a3974c6fb842a101a95e7eed0", size = 182132, upload-time = "2026-05-02T16:04:12.653Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/52/e465037f5375f43533d1a80b6923955201596a99142ed524d77b571a1418/wcwidth-0.7.0-py3-none-any.whl", hash = "sha256:5d69154c429a82910e241c738cd0e2976fac8a2dd47a1a805f4afed1c0f136f2", size = 110825, upload-time = "2026-05-02T16:04:11.033Z" },
+]
+
+[[package]]
+name = "xdg"
+version = "6.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2a/b9/0e6e6f19fb75cf5e1758f4f33c1256738f718966700cffc0fde2f966218b/xdg-6.0.0.tar.gz", hash = "sha256:24278094f2d45e846d1eb28a2ebb92d7b67fc0cab5249ee3ce88c95f649a1c92", size = 3453, upload-time = "2023-02-27T19:27:44.309Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dd/54/3516c1cf349060fc3578686d271eba242f10ec00b4530c2985af9faac49b/xdg-6.0.0-py3-none-any.whl", hash = "sha256:df3510755b4395157fc04fc3b02467c777f3b3ca383257397f09ab0d4c16f936", size = 3855, upload-time = "2023-02-27T19:27:42.151Z" },
+]
+
+[[package]]
 name = "xxhash"
 version = "3.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1033,6 +1245,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ad/95/a26baa93b5241fd7630998816a4ec47a5a0bad193b3f8fc8f3593e1a4a67/xxhash-3.7.0-cp314-cp314t-win32.whl", hash = "sha256:a04a6cab47e2166435aaf5b9e5ee41d1532cc8300efdef87f2a4d0acb7db19ed", size = 31643, upload-time = "2026-04-25T11:09:08.153Z" },
     { url = "https://files.pythonhosted.org/packages/44/36/5454f13c447e395f9b06a3e91274c59f503d31fad84e1836efe3bdb71f6a/xxhash-3.7.0-cp314-cp314t-win_amd64.whl", hash = "sha256:8653dd7c2eda020545bb2c71c7f7039b53fe7434d0fc1a0a9deb79ab3f1a4fc1", size = 32522, upload-time = "2026-04-25T11:09:09.534Z" },
     { url = "https://files.pythonhosted.org/packages/74/35/698e7e3ff38e22992ea24870a511d8762474fb6783627a2910ff22a185c2/xxhash-3.7.0-cp314-cp314t-win_arm64.whl", hash = "sha256:468f0fc114faaa4b36699f8e328bbc3bb11dc418ba94ac52c26dd736d4b6c637", size = 28807, upload-time = "2026-04-25T11:09:11.234Z" },
+]
+
+[[package]]
+name = "zipp"
+version = "3.23.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/21/093488dfc7cc8964ded15ab726fad40f25fd3d788fd741cc1c5a17d78ee8/zipp-3.23.1.tar.gz", hash = "sha256:32120e378d32cd9714ad503c1d024619063ec28aad2248dc6672ad13edfa5110", size = 25965, upload-time = "2026-04-13T23:21:46.6Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/8a/0861bec20485572fbddf3dfba2910e38fe249796cb73ecdeb74e07eeb8d3/zipp-3.23.1-py3-none-any.whl", hash = "sha256:0b3596c50a5c700c9cb40ba8d86d9f2cc4807e9bedb06bcdf7fac85633e444dc", size = 10378, upload-time = "2026-04-13T23:21:45.386Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -7,11 +7,19 @@ name = "ai-bioworkflow"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "langchain" },
+    { name = "langchain-anthropic" },
+    { name = "langchain-openai" },
     { name = "langgraph" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "langgraph", specifier = ">=1.1.10" }]
+requires-dist = [
+    { name = "langchain", specifier = ">=1.2.18" },
+    { name = "langchain-anthropic", specifier = ">=1.4.3" },
+    { name = "langchain-openai", specifier = ">=1.2.1" },
+    { name = "langgraph", specifier = ">=1.1.10" },
+]
 
 [[package]]
 name = "annotated-types"
@@ -20,6 +28,25 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "anthropic"
+version = "0.100.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "docstring-parser" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9c/2d/24caf0ff727cba2ed863925017c8f93463a2ea6224a0efe5626e672bc3d2/anthropic-0.100.0.tar.gz", hash = "sha256:650dee9e023afb16395939ee4104bbc21f966b380210119fb91122c12099c79a", size = 758255, upload-time = "2026-05-06T15:07:13.578Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/a0/c775c59ab9445ecabb57ef3d5c24027de060139189a9e312ef9ef889a665/anthropic-0.100.0-py3-none-any.whl", hash = "sha256:1c15769efa15d8fd5c1ebf900e25c57e3ee540f8554a29aa56e4edefffe2951d", size = 753596, upload-time = "2026-05-06T15:07:12.106Z" },
 ]
 
 [[package]]
@@ -101,6 +128,33 @@ wheels = [
 ]
 
 [[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "distro"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
+name = "docstring-parser"
+version = "0.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -147,6 +201,60 @@ wheels = [
 ]
 
 [[package]]
+name = "jiter"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/c1/0cddc6eb17d4c53a99840953f95dd3accdc5cfc7a337b0e9b26476276be9/jiter-0.14.0.tar.gz", hash = "sha256:e8a39e66dac7153cf3f964a12aad515afa8d74938ec5cc0018adcdae5367c79e", size = 165725, upload-time = "2026-04-10T14:28:42.01Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/97/2a/09f70020898507a89279659a1afe3364d57fc1b2c89949081975d135f6f5/jiter-0.14.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:af72f204cf4d44258e5b4c1745130ac45ddab0e71a06333b01de660ab4187a94", size = 315502, upload-time = "2026-04-10T14:26:47.697Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/be/080c96a45cd74f9fce5db4fd68510b88087fb37ffe2541ff73c12db92535/jiter-0.14.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4b77da71f6e819be5fbcec11a453fde5b1d0267ef6ed487e2a392fd8e14e4e3a", size = 314870, upload-time = "2026-04-10T14:26:49.149Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/5e/2d0fee155826a968a832cc32438de5e2a193292c8721ca70d0b53e58245b/jiter-0.14.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:77f4ea612fe8b84b8b04e51d0e78029ecf3466348e25973f953de6e6a59aa4c1", size = 343406, upload-time = "2026-04-10T14:26:50.762Z" },
+    { url = "https://files.pythonhosted.org/packages/70/af/bf9ee0d3a4f8dc0d679fc1337f874fe60cdbf841ebbb304b374e1c9aaceb/jiter-0.14.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:62fe2451f8fcc0240261e6a4df18ecbcd58327857e61e625b2393ea3b468aac9", size = 369415, upload-time = "2026-04-10T14:26:52.188Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/83/8e8561eadba31f4d3948a5b712fb0447ec71c3560b57a855449e7b8ddc98/jiter-0.14.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6112f26f5afc75bcb475787d29da3aa92f9d09c7858f632f4be6ffe607be82e9", size = 461456, upload-time = "2026-04-10T14:26:53.611Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/c9/c5299e826a5fe6108d172b344033f61c69b1bb979dd8d9ddd4278a160971/jiter-0.14.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:215a6cb8fb7dc702aa35d475cc00ddc7f970e5c0b1417fb4b4ac5d82fa2a29db", size = 378488, upload-time = "2026-04-10T14:26:55.211Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/37/c16d9d15c0a471b8644b1abe3c82668092a707d9bedcf076f24ff2e380cd/jiter-0.14.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fc4ab96a30fb3cb2c7e0cd33f7616c8860da5f5674438988a54ac717caccdbaa", size = 353242, upload-time = "2026-04-10T14:26:56.705Z" },
+    { url = "https://files.pythonhosted.org/packages/58/ea/8050cb0dc654e728e1bfacbc0c640772f2181af5dedd13ae70145743a439/jiter-0.14.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:3a99c1387b1f2928f799a9de899193484d66206a50e98233b6b088a7f0c1edb2", size = 356823, upload-time = "2026-04-10T14:26:58.281Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/3b/cf71506d270e5f84d97326bf220e47aed9b95e9a4a060758fb07772170ab/jiter-0.14.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ab18d11074485438695f8d34a1b6da61db9754248f96d51341956607a8f39985", size = 392564, upload-time = "2026-04-10T14:27:00.018Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/cc/8c6c74a3efb5bd671bfd14f51e8a73375464ca914b1551bc3b40e26ac2c9/jiter-0.14.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:801028dcfc26ac0895e4964cbc0fd62c73be9fd4a7d7b1aaf6e5790033a719b7", size = 520322, upload-time = "2026-04-10T14:27:01.664Z" },
+    { url = "https://files.pythonhosted.org/packages/41/24/68d7b883ec959884ddf00d019b2e0e82ba81b167e1253684fa90519ce33c/jiter-0.14.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:ad425b087aafb4a1c7e1e98a279200743b9aaf30c3e0ba723aec93f061bd9bc8", size = 552619, upload-time = "2026-04-10T14:27:03.316Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/89/b1a0985223bbf3150ff9e8f46f98fc9360c1de94f48abe271bbe1b465682/jiter-0.14.0-cp313-cp313-win32.whl", hash = "sha256:882bcb9b334318e233950b8be366fe5f92c86b66a7e449e76975dfd6d776a01f", size = 205699, upload-time = "2026-04-10T14:27:04.662Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/19/3f339a5a7f14a11730e67f6be34f9d5105751d547b615ef593fa122a5ded/jiter-0.14.0-cp313-cp313-win_amd64.whl", hash = "sha256:9b8c571a5dba09b98bd3462b5a53f27209a5cbbe85670391692ede71974e979f", size = 201323, upload-time = "2026-04-10T14:27:06.139Z" },
+    { url = "https://files.pythonhosted.org/packages/50/56/752dd89c84be0e022a8ea3720bcfa0a8431db79a962578544812ce061739/jiter-0.14.0-cp313-cp313-win_arm64.whl", hash = "sha256:34f19dcc35cb1abe7c369b3756babf8c7f04595c0807a848df8f26ef8298ef92", size = 191099, upload-time = "2026-04-10T14:27:07.564Z" },
+    { url = "https://files.pythonhosted.org/packages/91/28/292916f354f25a1fe8cf2c918d1415c699a4a659ae00be0430e1c5d9ffea/jiter-0.14.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e89bcd7d426a75bb4952c696b267075790d854a07aad4c9894551a82c5b574ab", size = 320880, upload-time = "2026-04-10T14:27:09.326Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/c7/b002a7d8b8957ac3d469bd59c18ef4b1595a5216ae0de639a287b9816023/jiter-0.14.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7b25beaa0d4447ea8c7ae0c18c688905d34840d7d0b937f2f7bdd52162c98a40", size = 346563, upload-time = "2026-04-10T14:27:11.287Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/3b/f8d07580d8706021d255a6356b8fab13ee4c869412995550ce6ed4ddf97d/jiter-0.14.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:651a8758dd413c51e3b7f6557cdc6921faf70b14106f45f969f091f5cda990ea", size = 357928, upload-time = "2026-04-10T14:27:12.729Z" },
+    { url = "https://files.pythonhosted.org/packages/47/5b/ac1a974da29e35507230383110ffec59998b290a8732585d04e19a9eb5ba/jiter-0.14.0-cp313-cp313t-win_amd64.whl", hash = "sha256:e1a7eead856a5038a8d291f1447176ab0b525c77a279a058121b5fccee257f6f", size = 203519, upload-time = "2026-04-10T14:27:14.125Z" },
+    { url = "https://files.pythonhosted.org/packages/96/6d/9fc8433d667d2454271378a79747d8c76c10b51b482b454e6190e511f244/jiter-0.14.0-cp313-cp313t-win_arm64.whl", hash = "sha256:2e692633a12cda97e352fdcd1c4acc971b1c28707e1e33aeef782b0cbf051975", size = 190113, upload-time = "2026-04-10T14:27:16.638Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/1e/354ed92461b165bd581f9ef5150971a572c873ec3b68a916d5aa91da3cc2/jiter-0.14.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:6f396837fc7577871ca8c12edaf239ed9ccef3bbe39904ae9b8b63ce0a48b140", size = 315277, upload-time = "2026-04-10T14:27:18.109Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/95/8c7c7028aa8636ac21b7a55faef3e34215e6ed0cbf5ae58258427f621aa3/jiter-0.14.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a4d50ea3d8ba4176f79754333bd35f1bbcd28e91adc13eb9b7ca91bc52a6cef9", size = 315923, upload-time = "2026-04-10T14:27:19.603Z" },
+    { url = "https://files.pythonhosted.org/packages/47/40/e2a852a44c4a089f2681a16611b7ce113224a80fd8504c46d78491b47220/jiter-0.14.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce17f8a050447d1b4153bda4fb7d26e6a9e74eb4f4a41913f30934c5075bf615", size = 344943, upload-time = "2026-04-10T14:27:21.262Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/1f/670f92adee1e9895eac41e8a4d623b6da68c4d46249d8b556b60b63f949e/jiter-0.14.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f4f1c4b125e1652aefbc2e2c1617b60a160ab789d180e3d423c41439e5f32850", size = 369725, upload-time = "2026-04-10T14:27:22.766Z" },
+    { url = "https://files.pythonhosted.org/packages/01/2f/541c9ba567d05de1c4874a0f8f8c5e3fd78e2b874266623da9a775cf46e0/jiter-0.14.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:be808176a6a3a14321d18c603f2d40741858a7c4fc982f83232842689fe86dd9", size = 461210, upload-time = "2026-04-10T14:27:24.315Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/a9/c31cbec09627e0d5de7aeaec7690dba03e090caa808fefd8133137cf45bc/jiter-0.14.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:26679d58ba816f88c3849306dd58cb863a90a1cf352cdd4ef67e30ccf8a77994", size = 380002, upload-time = "2026-04-10T14:27:26.155Z" },
+    { url = "https://files.pythonhosted.org/packages/50/02/3c05c1666c41904a2f607475a73e7a4763d1cbde2d18229c4f85b22dc253/jiter-0.14.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:80381f5a19af8fa9aef743f080e34f6b25ebd89656475f8cf0470ec6157052aa", size = 354678, upload-time = "2026-04-10T14:27:27.701Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/97/e15b33545c2b13518f560d695f974b9891b311641bdcf178d63177e8801e/jiter-0.14.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:004df5fdb8ecbd6d99f3227df18ba1a259254c4359736a2e6f036c944e02d7c5", size = 358920, upload-time = "2026-04-10T14:27:29.256Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/d2/8b1461def6b96ba44530df20d07ef7a1c7da22f3f9bf1727e2d611077bf1/jiter-0.14.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:cff5708f7ed0fa098f2b53446c6fa74c48469118e5cd7497b4f1cd569ab06928", size = 394512, upload-time = "2026-04-10T14:27:31.344Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/88/837566dd6ed6e452e8d3205355afd484ce44b2533edfa4ed73a298ea893e/jiter-0.14.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:2492e5f06c36a976d25c7cc347a60e26d5470178d44cde1b9b75e60b4e519f28", size = 521120, upload-time = "2026-04-10T14:27:33.299Z" },
+    { url = "https://files.pythonhosted.org/packages/89/6b/b00b45c4d1b4c031777fe161d620b755b5b02cdade1e316dcb46e4471d63/jiter-0.14.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:7609cfbe3a03d37bfdbf5052012d5a879e72b83168a363deae7b3a26564d57de", size = 553668, upload-time = "2026-04-10T14:27:34.868Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/d8/6fe5b42011d19397433d345716eac16728ac241862a2aac9c91923c7509a/jiter-0.14.0-cp314-cp314-win32.whl", hash = "sha256:7282342d32e357543565286b6450378c3cd402eea333fc1ebe146f1fabb306fc", size = 207001, upload-time = "2026-04-10T14:27:36.455Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/43/5c2e08da1efad5e410f0eaaabeadd954812612c33fbbd8fd5328b489139d/jiter-0.14.0-cp314-cp314-win_amd64.whl", hash = "sha256:bd77945f38866a448e73b0b7637366afa814d4617790ecd88a18ca74377e6c02", size = 202187, upload-time = "2026-04-10T14:27:38Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/1f/6e39ac0b4cdfa23e606af5b245df5f9adaa76f35e0c5096790da430ca506/jiter-0.14.0-cp314-cp314-win_arm64.whl", hash = "sha256:f2d4c61da0821ee42e0cdf5489da60a6d074306313a377c2b35af464955a3611", size = 192257, upload-time = "2026-04-10T14:27:39.504Z" },
+    { url = "https://files.pythonhosted.org/packages/05/57/7dbc0ffbbb5176a27e3518716608aa464aee2e2887dc938f0b900a120449/jiter-0.14.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1bf7ff85517dd2f20a5750081d2b75083c1b269cf75afc7511bdf1f9548beb3b", size = 323441, upload-time = "2026-04-10T14:27:41.039Z" },
+    { url = "https://files.pythonhosted.org/packages/83/6e/7b3314398d8983f06b557aa21b670511ec72d3b79a68ee5e4d9bff972286/jiter-0.14.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c8ef8791c3e78d6c6b157c6d360fbb5c715bebb8113bc6a9303c5caff012754a", size = 348109, upload-time = "2026-04-10T14:27:42.552Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/4f/8dc674bcd7db6dba566de73c08c763c337058baff1dbeb34567045b27cdc/jiter-0.14.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e74663b8b10da1fe0f4e4703fd7980d24ad17174b6bb35d8498d6e3ebce2ae6a", size = 368328, upload-time = "2026-04-10T14:27:44.574Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/5f/188e09a1f20906f98bbdec44ed820e19f4e8eb8aff88b9d1a5a497587ff3/jiter-0.14.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1aca29ba52913f78362ec9c2da62f22cdc4c3083313403f90c15460979b84d9b", size = 463301, upload-time = "2026-04-10T14:27:46.717Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/f0/19046ef965ed8f349e8554775bb12ff4352f443fbe12b95d31f575891256/jiter-0.14.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8b39b7d87a952b79949af5fef44d2544e58c21a28da7f1bae3ef166455c61746", size = 378891, upload-time = "2026-04-10T14:27:48.32Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/c3/da43bd8431ee175695777ee78cf0e93eacbb47393ff493f18c45231b427d/jiter-0.14.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:78d918a68b26e9fab068c2b5453577ef04943ab2807b9a6275df2a812599a310", size = 360749, upload-time = "2026-04-10T14:27:49.88Z" },
+    { url = "https://files.pythonhosted.org/packages/72/26/e054771be889707c6161dbdec9c23d33a9ec70945395d70f07cfea1e9a6f/jiter-0.14.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:b08997c35aee1201c1a5361466a8fb9162d03ae7bf6568df70b6c859f1e654a4", size = 358526, upload-time = "2026-04-10T14:27:51.504Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/0f/7bea65ea2a6d91f2bf989ff11a18136644392bf2b0497a1fa50934c30a9c/jiter-0.14.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:260bf7ca20704d58d41f669e5e9fe7fe2fa72901a6b324e79056f5d52e9c9be2", size = 393926, upload-time = "2026-04-10T14:27:53.368Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a1/b1ff7d70deef61ac0b7c6c2f12d2ace950cdeecb4fdc94500a0926802857/jiter-0.14.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:37826e3df29e60f30a382f9294348d0238ef127f4b5d7f5f8da78b5b9e050560", size = 521052, upload-time = "2026-04-10T14:27:55.058Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/7b/3b0649983cbaf15eda26a414b5b1982e910c67bd6f7b1b490f3cfc76896a/jiter-0.14.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:645be49c46f2900937ba0eaf871ad5183c96858c0af74b6becc7f4e367e36e06", size = 553716, upload-time = "2026-04-10T14:27:57.269Z" },
+    { url = "https://files.pythonhosted.org/packages/97/f8/33d78c83bd93ae0c0af05293a6660f88a1977caef39a6d72a84afab94ce0/jiter-0.14.0-cp314-cp314t-win32.whl", hash = "sha256:2f7877ed45118de283786178eceaf877110abacd04fde31efff3940ae9672674", size = 207957, upload-time = "2026-04-10T14:27:59.285Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/ac/2b760516c03e2227826d1f7025d89bf6bf6357a28fe75c2a2800873c50bf/jiter-0.14.0-cp314-cp314t-win_amd64.whl", hash = "sha256:14c0cb10337c49f5eafe8e7364daca5e29a020ea03580b8f8e6c597fed4e1588", size = 204690, upload-time = "2026-04-10T14:28:00.962Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/2e/a44c20c58aeed0355f2d326969a181696aeb551a25195f47563908a815be/jiter-0.14.0-cp314-cp314t-win_arm64.whl", hash = "sha256:5419d4aa2024961da9fe12a9cfe7484996735dca99e8e090b5c88595ef1951ff", size = 191338, upload-time = "2026-04-10T14:28:02.853Z" },
+]
+
+[[package]]
 name = "jsonpatch"
 version = "1.33"
 source = { registry = "https://pypi.org/simple" }
@@ -168,6 +276,34 @@ wheels = [
 ]
 
 [[package]]
+name = "langchain"
+version = "1.2.18"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langchain-core" },
+    { name = "langgraph" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/4e/b651ecac63af474b28519384f7011294493d139937b1a9591581291eef34/langchain-1.2.18.tar.gz", hash = "sha256:7e829dbf117affadfd2067a0e97b4af20222f535f30fb812a28472d842c1074c", size = 582882, upload-time = "2026-05-08T13:59:19.895Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/20/959f6098c79158afe5aedce7de05c3700f10d293890ef9e5dace6c3ad94b/langchain-1.2.18-py3-none-any.whl", hash = "sha256:8432d43a65540845ed6f1a783d38d869c4659a6b9405f9a510169ad40d2f7bae", size = 113643, upload-time = "2026-05-08T13:59:18.461Z" },
+]
+
+[[package]]
+name = "langchain-anthropic"
+version = "1.4.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anthropic" },
+    { name = "langchain-core" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fa/e3/d2f9dec95602524b1cfb4be2747ba5bc38d32501b2a56cb4bcb76e80bb45/langchain_anthropic-1.4.3.tar.gz", hash = "sha256:f8a2442463c0629b1b3110eaeaa56fdbdc87df2a802f8c7f5ecf611eb4874ec8", size = 685219, upload-time = "2026-05-03T17:33:27.118Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d3/55/482a1968c95275e8be6d8c1e53b54f0f7be0b8b155ce1608c947a95cf543/langchain_anthropic-1.4.3-py3-none-any.whl", hash = "sha256:65466e0f2f95909a009708f2958e917dfdbfab79c612b4484a30866a85e1f291", size = 50389, upload-time = "2026-05-03T17:33:25.671Z" },
+]
+
+[[package]]
 name = "langchain-core"
 version = "1.3.3"
 source = { registry = "https://pypi.org/simple" }
@@ -185,6 +321,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d3/ae/8b74458fc3850ec3d150eb9f45e857db129dafa801fb5cf173dfc9f8bbf3/langchain_core-1.3.3.tar.gz", hash = "sha256:fa510a5db8efdc0c6ff41c0939fb5c00a0183c11f6b84233e892e3227ff69182", size = 915041, upload-time = "2026-05-05T19:02:36.612Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/01/4771b7ab2af1d1aba5b710bd8f13d9225c609425214b357590a17b01be77/langchain_core-1.3.3-py3-none-any.whl", hash = "sha256:18aae8506f37da7f74398492279a7d6efcee4f8e23c4c41c7af080eeb7ef7bd1", size = 543857, upload-time = "2026-05-05T19:02:34.52Z" },
+]
+
+[[package]]
+name = "langchain-openai"
+version = "1.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langchain-core" },
+    { name = "openai" },
+    { name = "tiktoken" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9a/0e/d8e16c28aa67106d285e63b8ffc04c5af68341e345ce24a0751dbf2e167e/langchain_openai-1.2.1.tar.gz", hash = "sha256:ee4480b787706361b7125fad46930589a624df87aa158c6986ef1fad10d10675", size = 1146092, upload-time = "2026-04-24T19:46:43.328Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/55/2865b18ee3a3dd11160b8c4b2cf37e75bf2a4a8d1d38868ffffc7b7cc180/langchain_openai-1.2.1-py3-none-any.whl", hash = "sha256:a80732185030d4f453dda6c25feef46f645f665423fdffe38ae3edf1ac3c6c4d", size = 98626, upload-time = "2026-04-24T19:46:41.971Z" },
 ]
 
 [[package]]
@@ -273,6 +423,25 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/de/8a/1e8ea5e8bab2a65fa95bd36229ef38e8723ec46e430e20ca2d953487a7f1/langsmith-0.8.3.tar.gz", hash = "sha256:767ff7a8d136ed42926bf99059ac631dc6883542d6e3104b32e71c7625e1fa05", size = 4460330, upload-time = "2026-05-07T19:56:56.18Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/98/a9/51e644c1f1dbc3dd7d22dfd6412eab206d538c81e024e4f287373544bdcb/langsmith-0.8.3-py3-none-any.whl", hash = "sha256:b2e40e308222fa0beb2dccee3b4b30bfee9062d7a4f20a3e3e93df3c51a08ab4", size = 399048, upload-time = "2026-05-07T19:56:53.994Z" },
+]
+
+[[package]]
+name = "openai"
+version = "2.36.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f4/a1/4d5e84cf51720fc1526cc49e10ac1961abcccb55b0efb3d970db1e9a2728/openai-2.36.0.tar.gz", hash = "sha256:139dea0edd2f1b30c33d46ae1a6929e03906254140318e4608e98fe8c566f2e7", size = 753003, upload-time = "2026-05-07T17:33:17.075Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/1c/5d43735b2553baae2a5e899dcbcd0670a86930d993184d72ca909bf11c9b/openai-2.36.0-py3-none-any.whl", hash = "sha256:143f6194b548dbc2c921af1f1b03b9f14c85fed8a75b5b516f5bcc11a2a50c63", size = 1302361, upload-time = "2026-05-07T17:33:15.063Z" },
 ]
 
 [[package]]
@@ -460,6 +629,78 @@ wheels = [
 ]
 
 [[package]]
+name = "regex"
+version = "2026.5.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/0e/49aee608ad09480e7fd276898c99ec6192985fa331abe4eb3a986094490b/regex-2026.5.9.tar.gz", hash = "sha256:a8234aa23ec39894bfe4a3f1b85616a7032481964a13ac6fc9f10de4f6fca270", size = 416074, upload-time = "2026-05-09T23:15:19.37Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/aa/da/797e91ecec6f84135da778ddce78c20e0af5d2a15c26f87a81bc3eadb6db/regex-2026.5.9-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d626b84406444b165fc0ba981604edea39f0588ff1f92baa23fe50799ea9afdb", size = 490303, upload-time = "2026-05-09T23:13:04.382Z" },
+    { url = "https://files.pythonhosted.org/packages/44/da/bf30abaaa737b58f4a4b8c4a03659e02fd92092c822e0197ed9e0daab917/regex-2026.5.9-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:d7bdc0ab8f3dd7e1b4f9ab88634e13374669db86bb3c72e8292f07ae313f539f", size = 292019, upload-time = "2026-05-09T23:13:06.022Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/e7/d0eaf5713828417b9e5648cf81fa9bacd4961f6ab98c380c2034f8716e35/regex-2026.5.9-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a8820737949116ffff55fe18f9fc644530063ba6ebfcb8314239416e78f1347c", size = 289468, upload-time = "2026-05-09T23:13:08.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/9b/b3fdd62b003baa1a9b593cd8c8699c9651c2e80cc21a5c715707983c42d7/regex-2026.5.9-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aa0fbdbac82cb3e4450d0ccde7d7a35607f4cb2dd9fba4b8b69bfaf8c9fa6aed", size = 796749, upload-time = "2026-05-09T23:13:10.573Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/30/66ab84588765f5b4b271a9ca09ef7ce2b87caa95176ec3d2ad65d7bc4902/regex-2026.5.9-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:57e8915c7986aa33d25e4d3629cef711cd2863f2961b10409f0c04cb8b7d9020", size = 865445, upload-time = "2026-05-09T23:13:12.523Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/89/f05169e8588aac365f35ffc7f3bc3184f095ef4cfded7cfaa3c7fd5dbd89/regex-2026.5.9-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:508f56a89ba9cb26e4168cbc37dbd60a28d82430a9e18ad1d25fe0883c314ca2", size = 912322, upload-time = "2026-05-09T23:13:14.281Z" },
+    { url = "https://files.pythonhosted.org/packages/30/e1/c93444052cf41581f3c884ab3fb5823daf0992f11cd4388d4275ca610558/regex-2026.5.9-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b6d189041f15691cfa2b6c4290448ec221244d225b3f5fe9e7771b34ffcdf6e2", size = 801269, upload-time = "2026-05-09T23:13:16.569Z" },
+    { url = "https://files.pythonhosted.org/packages/50/fe/0cf96b882f540e62e8b9956599798203d599c44cf4c77917ca27400ff69b/regex-2026.5.9-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e82db382b44d0111b22601c509c89f64434816c9e0eef9d1989cda8cc6ff1c04", size = 777085, upload-time = "2026-05-09T23:13:18.675Z" },
+    { url = "https://files.pythonhosted.org/packages/23/5c/d78d4924e7fc875557b9e9b768423925fdfaac5549d06da7810019a9bd26/regex-2026.5.9-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:2acfb48634f64996b57f90f39afa692ff362162722581921fe92239a59960f3c", size = 785153, upload-time = "2026-05-09T23:13:20.525Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/e0/5214774090e7b4524dcea3e3c4aa74141d43043f8beb49c1599db1c8b53a/regex-2026.5.9-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:d29eebfc9525db68cad3c97eedd7f754fa265aa5cd0cf4f863b2421e1b48fc9f", size = 860164, upload-time = "2026-05-09T23:13:22.263Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/e1/4a57a83350319b1271f0d7a249b8672513ed928b237a741631270de6caea/regex-2026.5.9-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:debb893095e944091c16e641a6e33c1b0f4cb61ab945ec5afbf53ce7068834d8", size = 765731, upload-time = "2026-05-09T23:13:24.277Z" },
+    { url = "https://files.pythonhosted.org/packages/12/f4/499e74a20c156fc75836ee04a72a38d1a063978f600937f9760467beb1b0/regex-2026.5.9-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:d659eee77986549c9ea45b861c7567e44d6287c3dc9a4565478853f7b9fe2ff6", size = 852062, upload-time = "2026-05-09T23:13:26.125Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/92/7eebc0d0a01e78629695f342ba17e0deaff8fb45e79cc0d7b98287da6e3e/regex-2026.5.9-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:2efa205e6d98b24d1f3ab395c11aa15cdf10935bca283d0285e0499c284fba21", size = 789577, upload-time = "2026-05-09T23:13:27.814Z" },
+    { url = "https://files.pythonhosted.org/packages/05/a4/018e71f7d2ad48c1ebe6d3ae0026f9b7cb4802fd15c7cc02fdf724355102/regex-2026.5.9-cp313-cp313-win32.whl", hash = "sha256:f3844f134e834076677dd369976e9f5068679fcb8e50102fdf6b7ac96a3ec127", size = 266691, upload-time = "2026-05-09T23:13:29.549Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/1d/861a93719fb9ee7dbfc3761b3797b7a3e112a5d42c6129459d2d741be9b5/regex-2026.5.9-cp313-cp313-win_amd64.whl", hash = "sha256:3527bb4942d2c14552155406cdedd906567456821848aed1cb4933a391bf5eca", size = 277747, upload-time = "2026-05-09T23:13:31.859Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/c6/0a2436ae4da1ba76e51cb98943c6838a9a721faa40ebe2dce07694ae34e3/regex-2026.5.9-cp313-cp313-win_arm64.whl", hash = "sha256:56a33f191f17d8c417f99945ebdc1e691d3af9605d86ec68c7e54a57e3e17af6", size = 270500, upload-time = "2026-05-09T23:13:33.525Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e9/d21346f7b60ed58789371358ed66b09d00f832e1bd7c06e55d9da5679882/regex-2026.5.9-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:01f28d868834624c934b8d2e0aa1c8341337e37831f4a012f18a5afcba4cbaf3", size = 494172, upload-time = "2026-05-09T23:13:35.935Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/43/fd1177a2032037c681baecdb3422ee4e1424aec4e4f470ef47793d325274/regex-2026.5.9-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:48036f6374aaa79eb3b754ec29c61d1c6b1606749d705a13f8854fa2539671f6", size = 293952, upload-time = "2026-05-09T23:13:38.307Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7d/9fbf919768368d3f8a4f6c692cf2aa61e482b2b81ec6a298ace4cbf02480/regex-2026.5.9-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:b96350aa424e79d4fd6b567b344dcbe2b2d6bfc48dfe7717587e1fa6d43da6ff", size = 292314, upload-time = "2026-05-09T23:13:40.353Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/6c/e41bfeecb589716843e7c4df09ba46ff2a42961457afece19059d85caeef/regex-2026.5.9-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8f3af7a4903c5c04a11a196a5aa75cdd7dd3f8508132f9fb3259d9f5908e3b88", size = 811681, upload-time = "2026-05-09T23:13:42.543Z" },
+    { url = "https://files.pythonhosted.org/packages/87/83/a5c1c525fba0aa656e88ad0face0b1829788ef4c2fb6b26df58aa1151b84/regex-2026.5.9-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7e87577720152d2caae19fe2baaf1f8d5ca12091e9e229f03915c37d1e4b9178", size = 871135, upload-time = "2026-05-09T23:13:44.326Z" },
+    { url = "https://files.pythonhosted.org/packages/18/d4/80882e799e440dd878b0979cbebf8fa4d54624a332c83037c7a701649e3f/regex-2026.5.9-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c8b9b9d294cfea3cd19c718ade7cc93492b2c4991abd9a68d0b3477ae6d8e100", size = 917265, upload-time = "2026-05-09T23:13:47.295Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/ff/8db60211e2286e396aad7dc7725356c502bff0901ea05bd6cdc2e1a042b9/regex-2026.5.9-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:728d8bfd28a8845c8b6bc5dc7ce010453d206396786c0765c2740cb65f37791e", size = 816311, upload-time = "2026-05-09T23:13:49.885Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/47/742ef579c61730f8d268e5cf1f9ce0e37e2ea041ad0f5644724f2378e463/regex-2026.5.9-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7e30b874d341fac767d7df5a0870540541c2c054b80cfaac116e8d367a8a7ff2", size = 785498, upload-time = "2026-05-09T23:13:52.25Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/ab/cb0999802dcb0fb95b1ab005e8d4163d8afdd67efc2cb6b6630ac13f8cb1/regex-2026.5.9-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:fd190e88a895a8901325fad284a3f74ea52b1da8525b76cc811fa9b1edf0ce2b", size = 801348, upload-time = "2026-05-09T23:13:54.127Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/62/8ca59a24c55bc34d166eefaf3717bd77772f329fdbf984d86581e0a3571c/regex-2026.5.9-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:8e76e8161ad00694cfce6767d5dea860c6391ac5b83e5c3a39661e696f11fc7e", size = 866493, upload-time = "2026-05-09T23:13:56.067Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/3d/30f2ae62cef3278bb5bb821f467277a55fb73f01032cf85997e15e8289a8/regex-2026.5.9-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:ddda5340e6c01a293027dd46232fa79eaff1b48058ce7a98f572b6445b088041", size = 772811, upload-time = "2026-05-09T23:13:57.867Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/ae/7d2089bcd78ad0c0161bc684339df50032acb438a7bd3305e7ddb1193cec/regex-2026.5.9-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:205109e96b3cf5adf8f4cd62bedde9487feb282b9497a3535451e5a24cd706a0", size = 856584, upload-time = "2026-05-09T23:13:59.679Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/29/92ff47f75990131ea4f24ba17819e5a9d141e10819807e09addd73409af6/regex-2026.5.9-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:dfbe4579b9f08036aa7d101d1835437a20783574ac66327e6b29b4018a138081", size = 803453, upload-time = "2026-05-09T23:14:01.978Z" },
+    { url = "https://files.pythonhosted.org/packages/04/99/eff29f1037dcab36702c9ee5d6858cf1ce2336ea8ea2987f64245b99ea5e/regex-2026.5.9-cp313-cp313t-win32.whl", hash = "sha256:ed2c9e8068b614c574d8d30e543d617cf5379b0535d46f97ef00e904745a08b5", size = 269951, upload-time = "2026-05-09T23:14:03.661Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/9d/8870b8981d27b22cda77bb26a5ac7ebfa9c7d9e0dea195a834a82380e748/regex-2026.5.9-cp313-cp313t-win_amd64.whl", hash = "sha256:b46b0f094dc1d3b90356c85a0bd2c9bafc4a6a190b9d6f8ddd5a033b6e088ed4", size = 281240, upload-time = "2026-05-09T23:14:05.56Z" },
+    { url = "https://files.pythonhosted.org/packages/72/b1/3379415e8f135c13ac551353397cc4fe97b4978f3cac73c5fcbcded548b8/regex-2026.5.9-cp313-cp313t-win_arm64.whl", hash = "sha256:872acc074bd29ffc9913ecdfedf6ea77502312ca44a4aa0d3779089c6069d8de", size = 272383, upload-time = "2026-05-09T23:14:07.843Z" },
+    { url = "https://files.pythonhosted.org/packages/13/3e/9c3cd292d8808b3645a2ce517e200179b6d0e903f176300bd8b542e14de5/regex-2026.5.9-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:1bd7587a2948b4085195d5a3374eaf4a425dc3e55784c038175355ecf3bbbf8a", size = 490376, upload-time = "2026-05-09T23:14:09.64Z" },
+    { url = "https://files.pythonhosted.org/packages/60/70/d43ee8a2ca0a8b68d167f21658b85520ac0574617c7f320367c5047f7556/regex-2026.5.9-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:dea2e88e1cce4522496cce630e11e67b98b7076620bc4336c3f674bc21a375f4", size = 291964, upload-time = "2026-05-09T23:14:11.424Z" },
+    { url = "https://files.pythonhosted.org/packages/21/91/9d50b433828d8e74196904e168a43abf1e6e88b2a15d47ed742456720c37/regex-2026.5.9-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:2099f7e7ff7b6aa3192312650a56e91cc091e49d50b04e4f6f8b6e28b3b27f1c", size = 289682, upload-time = "2026-05-09T23:14:13.123Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/d2/b835e3cafbb9d977736912436259ff551d60919f7d7b3d37d46659c63564/regex-2026.5.9-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ecd353045824e4477562a2ac718c25799cdaaa41f7aa925a806a8a3e6848a5b9", size = 796996, upload-time = "2026-05-09T23:14:14.923Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/a6/9f992d00019166b9de01c546dd4549bc679f2a68df11b877740b0760b7c2/regex-2026.5.9-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:65c8c8c37377794bd5b2f3ebe51919042bf17aec802e23c833d89782ed0c78af", size = 866089, upload-time = "2026-05-09T23:14:17.757Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/08/4d32af657e049b19cb62b02e46e38fe1518797bfb2203ee93a510b21b0dc/regex-2026.5.9-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5b73ab8afcf66c622db143d1c6fda4e58e4d537ee4f125229ad47b1ab80f34c0", size = 911530, upload-time = "2026-05-09T23:14:20.353Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/27/2af43dd1dc201d1fecefda64a45f4ad0995855b92724f795a777b402ee69/regex-2026.5.9-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0de5cf193997384ed2ca6f1cd4f78055b255d93d82d5a8cd6ba0d11c10b167e4", size = 800643, upload-time = "2026-05-09T23:14:22.265Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/dd/23a249047013b5321d4a60c4d2437462086f601b061776a525e5fba2a59f/regex-2026.5.9-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d641a8c9a61618047796d572a39a79b26167b0411d2c3031937b2fe2d081e2cf", size = 777223, upload-time = "2026-05-09T23:14:24.179Z" },
+    { url = "https://files.pythonhosted.org/packages/94/6a/e85ed9538cd19586d0465076a4578a12e093ce776d15f3f8ce92733a8dd6/regex-2026.5.9-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:24b2355ef5cc9aa5b8f07d17704face1c166fdcc2290fa7bd6e6c925655a8346", size = 785760, upload-time = "2026-05-09T23:14:26.065Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/c4/f25473209438638e947c55f9156fd8f236f74169229028cc99116380868e/regex-2026.5.9-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:a24852d3c29ad9e47593593d8a247c44ccc3d0548ef12c822d6ed0810affe676", size = 860891, upload-time = "2026-05-09T23:14:28.17Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/f7/f4f86e3c74419c37370e91f150ae0c2ef7d34b2e0e4cdd5da046a02e4022/regex-2026.5.9-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:916714069da19329ef7de197dcbc77bb3104145c7c2c864dbfbe318f46b88b14", size = 765891, upload-time = "2026-05-09T23:14:30.06Z" },
+    { url = "https://files.pythonhosted.org/packages/26/70/704d8e13765939146b1cd0ef4e2feb71d7929727d2290f026eed10095955/regex-2026.5.9-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:fa411799ca8da32a8d38d020a88faa5b6f91657d284761352940ecf9f7c3bbdd", size = 851380, upload-time = "2026-05-09T23:14:32.123Z" },
+    { url = "https://files.pythonhosted.org/packages/26/29/1a13582a8460038edc38e49f64ceb0dd7c60f5caba77571f4bf6601965d9/regex-2026.5.9-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:1e6da47d679b7010ef27556b6e0f99771b744936db1792a10ceac6547ae1503e", size = 789350, upload-time = "2026-05-09T23:14:34.799Z" },
+    { url = "https://files.pythonhosted.org/packages/73/56/3dcafe34fc72e271d62ad9a291801e88a1457bb251c132f15fcc2e5aad1a/regex-2026.5.9-cp314-cp314-win32.whl", hash = "sha256:98bd73080e8756255137e1bd3f3f00295bbc5aa383c0e0f973920e9134d7c4ad", size = 272130, upload-time = "2026-05-09T23:14:36.729Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/9c/02eebf0be95efe416c664db7fb8b6b05b7a0b06a7544f2884f2558b0526f/regex-2026.5.9-cp314-cp314-win_amd64.whl", hash = "sha256:ff8d372ac2acdc048d1c19916f27ee61bc5722728458ba6ca5052f2c72d51763", size = 280999, upload-time = "2026-05-09T23:14:39.126Z" },
+    { url = "https://files.pythonhosted.org/packages/70/5a/1dd1abee76cb7a846a0bcf42fdc87e5720c3c33c24f3e37814310a513d9f/regex-2026.5.9-cp314-cp314-win_arm64.whl", hash = "sha256:e1d93bf647916292e8edcec150c07ddf3dc50179ccaf770c04a7f9e452155372", size = 273500, upload-time = "2026-05-09T23:14:41.059Z" },
+    { url = "https://files.pythonhosted.org/packages/86/c1/c5f619b0057a7965cb78ec559c1d7a45ce8c99a35bea95483d64959a93d9/regex-2026.5.9-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:83d0ee4a57d1c87cb549e195ec300b8f0ec3a82eba66d835e4e2ed8634fe4499", size = 494269, upload-time = "2026-05-09T23:14:42.869Z" },
+    { url = "https://files.pythonhosted.org/packages/05/2c/5d01f1aee33de4bbe60c8452945bfc8477ca7c5ae4450f6bfe711036cb36/regex-2026.5.9-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:d3d7eb5c9a7f6df82ed3cfac9beb93882a5cbcb5b8b157b56cb2b3b276574ac1", size = 293954, upload-time = "2026-05-09T23:14:44.822Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/fe/e8988b2ae2108c6ef71bd4aa8d87fbe257976dd0810e826cd75f701c68b6/regex-2026.5.9-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:075160bf16658e16d35233300b8453aac25de4cbea808d22348b6979668e924d", size = 292405, upload-time = "2026-05-09T23:14:47.211Z" },
+    { url = "https://files.pythonhosted.org/packages/79/34/d2b0937faa7859263f7f0a3c6b103a1296306be6952dc173d0154e9a2f49/regex-2026.5.9-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:45375819235558a4ff1c4971dc32881f022613abdb180128f5cb4768c1765a1c", size = 811855, upload-time = "2026-05-09T23:14:49.21Z" },
+    { url = "https://files.pythonhosted.org/packages/80/fe/daf53a47457a8486db66c66c01ceb9c2303eecee3f87197f1e77eb1a736d/regex-2026.5.9-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ead4b163ac30a29574510cd4b3e2e985ac5290c05fc7095557d6a5f403fc31b5", size = 871189, upload-time = "2026-05-09T23:14:51.555Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/75/058fc4470cbfbf57d800aff1a0022b929a3f9fa553ee10a0cdf2070eb31f/regex-2026.5.9-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8c6e4218fbdfbcd4f6c19efca40930d24a621bf4b48cb76bc6640543bd28ef20", size = 917485, upload-time = "2026-05-09T23:14:53.633Z" },
+    { url = "https://files.pythonhosted.org/packages/88/e7/179cfda3a28bc843b5c6cfe7f79f23489c791ed95f151083803660878432/regex-2026.5.9-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6351571c8a42b505eb555c0dc47d740d0fb66977dc142919eea6f4325b7c56a0", size = 816369, upload-time = "2026-05-09T23:14:56.198Z" },
+    { url = "https://files.pythonhosted.org/packages/41/90/6f0cc422071688266d344fca8462d787cba0a2c144acb25721f9a61ec265/regex-2026.5.9-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:002205cafd2a9e78c6290c7d1df277bf3277b3b7a30e0b4bb0dac2e2e3f7cb2d", size = 785869, upload-time = "2026-05-09T23:14:58.602Z" },
+    { url = "https://files.pythonhosted.org/packages/02/67/a31f1760f09c27b251ef39e9beb541f462cf977381d067faa764c2c0e393/regex-2026.5.9-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8abd33fef90b2a9efac5557d6033ca82d1195ed3a15fea5af15ba7b463c6a63b", size = 801427, upload-time = "2026-05-09T23:15:00.642Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/c4/1a80654597b6bc1e1ea0494824c31200e8a956abe290afae9b19a166a148/regex-2026.5.9-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:31037c82eccb44b7ea2e9e221d7c01429430e989a1f4b91ea5a855f6017b509a", size = 866482, upload-time = "2026-05-09T23:15:03.384Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/960724e06482c08466ff5611e242e86f80062949cdf6b4b9cc317b9dd93d/regex-2026.5.9-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:5604dfd046dc37eca90250fc3be938b076c8059fa772ac0ed6f499b0f0fb0415", size = 773022, upload-time = "2026-05-09T23:15:05.625Z" },
+    { url = "https://files.pythonhosted.org/packages/50/a8/a9979c3e7918280e93159ebcab5ef1a65116dd4f3bd6091be0eae4a126e8/regex-2026.5.9-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:0e1b1b4e496afbb24f4a62aba855ee4f88f25578927697b340702e48c9ee6bc2", size = 856642, upload-time = "2026-05-09T23:15:07.966Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/d4/a9b732f2f0072c0ab12227483abb24fffcb9f73f8a2b203df0a6d0434735/regex-2026.5.9-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:be3372b9df6ddecff6486d37e19095a7b4973137caf5512407a89f4455361f41", size = 803552, upload-time = "2026-05-09T23:15:10.215Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/fe/1b3113817447a1d4155e4ac76d2e072f42c0bcba2f43fa8a0e756ea2cd91/regex-2026.5.9-cp314-cp314t-win32.whl", hash = "sha256:3ddd90103f9e5c471c49c7852ecc1fe27c7e45eb99e977aefe7caa4e779f4f58", size = 275746, upload-time = "2026-05-09T23:15:12.609Z" },
+    { url = "https://files.pythonhosted.org/packages/92/73/93d42045302636c91f2e5ef588b65b84b01428f28ec77de256b1dfdfbe5c/regex-2026.5.9-cp314-cp314t-win_amd64.whl", hash = "sha256:ca518ed29c46eecba6010b15f1b9a479314d2de409536e71b6a13aa04e3b8a77", size = 285685, upload-time = "2026-05-09T23:15:15.086Z" },
+    { url = "https://files.pythonhosted.org/packages/da/80/35b4c33c804a165a7f55289afda3ea9e3eb6d15800341a2d66455c0f1f30/regex-2026.5.9-cp314-cp314t-win_arm64.whl", hash = "sha256:5e41809d2683fcde7d5a8c87a6567ba1fb1ce0de9f31bff578de00a4b2d76daa", size = 275713, upload-time = "2026-05-09T23:15:16.98Z" },
+]
+
+[[package]]
 name = "requests"
 version = "2.33.1"
 source = { registry = "https://pypi.org/simple" }
@@ -487,12 +728,73 @@ wheels = [
 ]
 
 [[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
 name = "tenacity"
 version = "9.1.4"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
+]
+
+[[package]]
+name = "tiktoken"
+version = "0.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "regex" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/ab/4d017d0f76ec3171d469d80fc03dfbb4e48a4bcaddaa831b31d526f05edc/tiktoken-0.12.0.tar.gz", hash = "sha256:b18ba7ee2b093863978fcb14f74b3707cdc8d4d4d3836853ce7ec60772139931", size = 37806, upload-time = "2025-10-06T20:22:45.419Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/61/441588ee21e6b5cdf59d6870f86beb9789e532ee9718c251b391b70c68d6/tiktoken-0.12.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:775c2c55de2310cc1bc9a3ad8826761cbdc87770e586fd7b6da7d4589e13dab3", size = 1050802, upload-time = "2025-10-06T20:22:00.96Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/05/dcf94486d5c5c8d34496abe271ac76c5b785507c8eae71b3708f1ad9b45a/tiktoken-0.12.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a01b12f69052fbe4b080a2cfb867c4de12c704b56178edf1d1d7b273561db160", size = 993995, upload-time = "2025-10-06T20:22:02.788Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/70/5163fe5359b943f8db9946b62f19be2305de8c3d78a16f629d4165e2f40e/tiktoken-0.12.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:01d99484dc93b129cd0964f9d34eee953f2737301f18b3c7257bf368d7615baa", size = 1128948, upload-time = "2025-10-06T20:22:03.814Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/da/c028aa0babf77315e1cef357d4d768800c5f8a6de04d0eac0f377cb619fa/tiktoken-0.12.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:4a1a4fcd021f022bfc81904a911d3df0f6543b9e7627b51411da75ff2fe7a1be", size = 1151986, upload-time = "2025-10-06T20:22:05.173Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/5a/886b108b766aa53e295f7216b509be95eb7d60b166049ce2c58416b25f2a/tiktoken-0.12.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:981a81e39812d57031efdc9ec59fa32b2a5a5524d20d4776574c4b4bd2e9014a", size = 1194222, upload-time = "2025-10-06T20:22:06.265Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f8/4db272048397636ac7a078d22773dd2795b1becee7bc4922fe6207288d57/tiktoken-0.12.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9baf52f84a3f42eef3ff4e754a0db79a13a27921b457ca9832cf944c6be4f8f3", size = 1255097, upload-time = "2025-10-06T20:22:07.403Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/32/45d02e2e0ea2be3a9ed22afc47d93741247e75018aac967b713b2941f8ea/tiktoken-0.12.0-cp313-cp313-win_amd64.whl", hash = "sha256:b8a0cd0c789a61f31bf44851defbd609e8dd1e2c8589c614cc1060940ef1f697", size = 879117, upload-time = "2025-10-06T20:22:08.418Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/76/994fc868f88e016e6d05b0da5ac24582a14c47893f4474c3e9744283f1d5/tiktoken-0.12.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:d5f89ea5680066b68bcb797ae85219c72916c922ef0fcdd3480c7d2315ffff16", size = 1050309, upload-time = "2025-10-06T20:22:10.939Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/b8/57ef1456504c43a849821920d582a738a461b76a047f352f18c0b26c6516/tiktoken-0.12.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:b4e7ed1c6a7a8a60a3230965bdedba8cc58f68926b835e519341413370e0399a", size = 993712, upload-time = "2025-10-06T20:22:12.115Z" },
+    { url = "https://files.pythonhosted.org/packages/72/90/13da56f664286ffbae9dbcfadcc625439142675845baa62715e49b87b68b/tiktoken-0.12.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:fc530a28591a2d74bce821d10b418b26a094bf33839e69042a6e86ddb7a7fb27", size = 1128725, upload-time = "2025-10-06T20:22:13.541Z" },
+    { url = "https://files.pythonhosted.org/packages/05/df/4f80030d44682235bdaecd7346c90f67ae87ec8f3df4a3442cb53834f7e4/tiktoken-0.12.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:06a9f4f49884139013b138920a4c393aa6556b2f8f536345f11819389c703ebb", size = 1151875, upload-time = "2025-10-06T20:22:14.559Z" },
+    { url = "https://files.pythonhosted.org/packages/22/1f/ae535223a8c4ef4c0c1192e3f9b82da660be9eb66b9279e95c99288e9dab/tiktoken-0.12.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:04f0e6a985d95913cabc96a741c5ffec525a2c72e9df086ff17ebe35985c800e", size = 1194451, upload-time = "2025-10-06T20:22:15.545Z" },
+    { url = "https://files.pythonhosted.org/packages/78/a7/f8ead382fce0243cb625c4f266e66c27f65ae65ee9e77f59ea1653b6d730/tiktoken-0.12.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:0ee8f9ae00c41770b5f9b0bb1235474768884ae157de3beb5439ca0fd70f3e25", size = 1253794, upload-time = "2025-10-06T20:22:16.624Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e0/6cc82a562bc6365785a3ff0af27a2a092d57c47d7a81d9e2295d8c36f011/tiktoken-0.12.0-cp313-cp313t-win_amd64.whl", hash = "sha256:dc2dd125a62cb2b3d858484d6c614d136b5b848976794edfb63688d539b8b93f", size = 878777, upload-time = "2025-10-06T20:22:18.036Z" },
+    { url = "https://files.pythonhosted.org/packages/72/05/3abc1db5d2c9aadc4d2c76fa5640134e475e58d9fbb82b5c535dc0de9b01/tiktoken-0.12.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:a90388128df3b3abeb2bfd1895b0681412a8d7dc644142519e6f0a97c2111646", size = 1050188, upload-time = "2025-10-06T20:22:19.563Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7b/50c2f060412202d6c95f32b20755c7a6273543b125c0985d6fa9465105af/tiktoken-0.12.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:da900aa0ad52247d8794e307d6446bd3cdea8e192769b56276695d34d2c9aa88", size = 993978, upload-time = "2025-10-06T20:22:20.702Z" },
+    { url = "https://files.pythonhosted.org/packages/14/27/bf795595a2b897e271771cd31cb847d479073497344c637966bdf2853da1/tiktoken-0.12.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:285ba9d73ea0d6171e7f9407039a290ca77efcdb026be7769dccc01d2c8d7fff", size = 1129271, upload-time = "2025-10-06T20:22:22.06Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/de/9341a6d7a8f1b448573bbf3425fa57669ac58258a667eb48a25dfe916d70/tiktoken-0.12.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:d186a5c60c6a0213f04a7a802264083dea1bbde92a2d4c7069e1a56630aef830", size = 1151216, upload-time = "2025-10-06T20:22:23.085Z" },
+    { url = "https://files.pythonhosted.org/packages/75/0d/881866647b8d1be4d67cb24e50d0c26f9f807f994aa1510cb9ba2fe5f612/tiktoken-0.12.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:604831189bd05480f2b885ecd2d1986dc7686f609de48208ebbbddeea071fc0b", size = 1194860, upload-time = "2025-10-06T20:22:24.602Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/1e/b651ec3059474dab649b8d5b69f5c65cd8fcd8918568c1935bd4136c9392/tiktoken-0.12.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:8f317e8530bb3a222547b85a58583238c8f74fd7a7408305f9f63246d1a0958b", size = 1254567, upload-time = "2025-10-06T20:22:25.671Z" },
+    { url = "https://files.pythonhosted.org/packages/80/57/ce64fd16ac390fafde001268c364d559447ba09b509181b2808622420eec/tiktoken-0.12.0-cp314-cp314-win_amd64.whl", hash = "sha256:399c3dd672a6406719d84442299a490420b458c44d3ae65516302a99675888f3", size = 921067, upload-time = "2025-10-06T20:22:26.753Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/a4/72eed53e8976a099539cdd5eb36f241987212c29629d0a52c305173e0a68/tiktoken-0.12.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:c2c714c72bc00a38ca969dae79e8266ddec999c7ceccd603cc4f0d04ccd76365", size = 1050473, upload-time = "2025-10-06T20:22:27.775Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/d7/0110b8f54c008466b19672c615f2168896b83706a6611ba6e47313dbc6e9/tiktoken-0.12.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:cbb9a3ba275165a2cb0f9a83f5d7025afe6b9d0ab01a22b50f0e74fee2ad253e", size = 993855, upload-time = "2025-10-06T20:22:28.799Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/77/4f268c41a3957c418b084dd576ea2fad2e95da0d8e1ab705372892c2ca22/tiktoken-0.12.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:dfdfaa5ffff8993a3af94d1125870b1d27aed7cb97aa7eb8c1cefdbc87dbee63", size = 1129022, upload-time = "2025-10-06T20:22:29.981Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/2b/fc46c90fe5028bd094cd6ee25a7db321cb91d45dc87531e2bdbb26b4867a/tiktoken-0.12.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:584c3ad3d0c74f5269906eb8a659c8bfc6144a52895d9261cdaf90a0ae5f4de0", size = 1150736, upload-time = "2025-10-06T20:22:30.996Z" },
+    { url = "https://files.pythonhosted.org/packages/28/c0/3c7a39ff68022ddfd7d93f3337ad90389a342f761c4d71de99a3ccc57857/tiktoken-0.12.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:54c891b416a0e36b8e2045b12b33dd66fb34a4fe7965565f1b482da50da3e86a", size = 1194908, upload-time = "2025-10-06T20:22:32.073Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/0d/c1ad6f4016a3968c048545f5d9b8ffebf577774b2ede3e2e352553b685fe/tiktoken-0.12.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5edb8743b88d5be814b1a8a8854494719080c28faaa1ccbef02e87354fe71ef0", size = 1253706, upload-time = "2025-10-06T20:22:33.385Z" },
+    { url = "https://files.pythonhosted.org/packages/af/df/c7891ef9d2712ad774777271d39fdef63941ffba0a9d59b7ad1fd2765e57/tiktoken-0.12.0-cp314-cp314t-win_amd64.whl", hash = "sha256:f61c0aea5565ac82e2ec50a05e02a6c44734e91b51c10510b084ea1b8e633a71", size = 920667, upload-time = "2025-10-06T20:22:34.444Z" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.67.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

This PR turns the prototype into a deterministic Workflow IR compiler pipeline with a natural-language planning front door.

- Adds a Workflow IR schema, static analyzer, deterministic WDL renderer, and miniwdl validation path.
- Wires Recipe / Tool Catalog inputs into the LangGraph planner path.
- Adds a conservative IR repair loop for deterministic fixes such as call ordering and obvious File/String output literal quoting.
- Adds a CLI for natural-language prompts, prompt files, structured Recipe Tool Plans, and Workflow IR inputs.
- Adds natural-language planner observability with saved planner prompts/plans and clearer JSON/schema/catalog failure classes.
- Adds container resolver foundations plus explicit offline container filling through `--fill-containers` / `--container-images`.
- Adds RNA-seq differential expression examples and test coverage across catalog resolution, graph compilation, CLI behavior, planner parsing, container resolution, and WDL validation.

## Validation

- `git diff --check`
- `.venv/bin/python -m unittest discover -v`
- Latest full local run: 46 tests passed.

## Follow-ups

- Add a real Biocontainers / Quay provider behind the existing `ContainerImageProvider` interface.
- Add query caching for container lookup results.
- Expand the recipe/tool catalog beyond the current RNA-seq differential expression path.
- Add real LLM planner output fixtures as regression tests.
- Explore an LLM-assisted repairer after the deterministic compiler path stays stable.