### PR TITLE
Add executable RNA-seq DEG workflow support

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -60,7 +60,7 @@ AI-bioworkflow/
 
 1. **状态管理 (`state.py`)**：必须保持强类型。除了 LangGraph 原生的 `messages` 列表，还需要定义好接收前端传入的 `parsed_json`、标准化后的 `workflow_ir`、流转中的 `current_wdl`、`analysis_errors` 和 `validation_message`。
 2. **提示词隔离 (`prompts.py`)**：绝对不要将长篇大论的 System Prompt 硬编码在业务逻辑文件中。
-3. **IR 优先 (`schema.py`)**：workflow 的调用关系与 task 的定义必须分离。`workflow.calls` 表达 DAG，`tasks` 表达可复用 task 模板。
+3. **IR 优先 (`schema.py`)**：workflow 的调用关系与 task 的定义必须分离。`workflow.steps` 表达 call/scatter DAG，`workflow.calls` 作为旧输入兼容，`tasks` 表达可复用 task 模板。
 4. **自然语言只到 Plan (`nl_planner.py`)**：LLM 的职责是把用户需求转成 Recipe Tool Plan，不直接生成 WDL。Planner 失败需要区分 JSON 解析、plan schema、recipe/catalog 校验三类错误，便于调试真实模型输出。
 5. **Catalog 先于自由生成 (`catalog/`, `recipes/`)**：常见生信工具、版本、参数、runtime 与配方步骤应沉淀为结构化目录，Planner 可以把 Recipe Tool Plan 解析成标准 IR。
 6. **静态分析先于渲染 (`analyzer.py`)**：在生成 WDL 前先检查 task 是否存在、输入是否齐全、上游输出引用是否有效、基础类型是否匹配。
@@ -68,11 +68,12 @@ AI-bioworkflow/
 8. **确定性渲染 (`renderers/`)**：标准 IR 到 WDL 必须由模板或普通代码生成，不应依赖 LLM 的自由文本输出。
 9. **工具封装 (`tools/`)**：所有与底层操作系统或第三方生信软件的交互（如调用 `miniwdl check`）都必须封装为独立 Tool，确保生成代码闭环验证。
 10. **Catalog 镜像权威来源 (`catalog/`)**：每个 Tool Catalog 条目必须显式声明 `runtime.docker`。编译链路不搜索、不猜测、不联网补全镜像；新增或升级工具时由维护者明确选择镜像并写入 catalog。
-11. **渐进式重构**：先保证 Natural Language -> Recipe Tool Plan -> IR -> WDL -> miniwdl check 的主链路稳定，再逐步扩展 recipe/tool catalog、可解释错误报告与 LLM repairer。
+11. **辅助脚本镜像化 (`containers/`)**：tximport、DESeq2、MultiQC 等辅助脚本随项目镜像构建进入容器，不作为 WDL 输入，也不内联到 command 中。
+12. **渐进式重构**：先保证 Natural Language -> Recipe Tool Plan -> IR -> WDL -> miniwdl check 的主链路稳定，再逐步扩展 recipe/tool catalog、可解释错误报告与 LLM repairer。
 
 ## 后续待办
 
-- [ ] **低优先级：自建工具镜像管理规范**：当 Catalog 中某些工具没有合适公共镜像时，考虑在 `containers/<tool>/<version>/` 维护 Dockerfile、smoke test 与构建说明；镜像构建并推送到内部 registry 后，只把最终 tag 或 digest 显式写入 Tool Catalog。该工作不接入编译链路，也不恢复镜像搜索或自动补全。
+- [x] **自建工具镜像管理规范初版**：当 Catalog 中某些工具没有合适公共镜像时，在 `containers/<tool>/<version>/` 维护 Dockerfile、smoke test 与构建说明；镜像构建并推送到 registry 后，只把最终 tag 或 digest 显式写入 Tool Catalog。该工作不接入编译链路，也不恢复镜像搜索或自动补全。
 
 ## 当前 LangGraph 流程
 
@@ -81,11 +82,11 @@ START
   ↓
 nl_planner        # 自然语言需求 -> Recipe Tool Plan（CLI 自然语言入口）
   ↓
-ir_normalizer    # 标准 IR / Legacy JSON / Recipe Tool Plan -> Workflow IR
+ir_normalizer    # 标准 IR / Legacy JSON / Recipe Tool Plan -> Workflow IR steps
   ↓
 analyzer_node    # IR 静态分析
   ↓
-renderer_node    # Workflow IR -> WDL
+renderer_node    # Workflow IR steps/scatter -> WDL
   ↓
 checker_node     # miniwdl check
   ↓

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -12,6 +12,8 @@ AI-bioworkflow/
 ├── pyproject.toml        # uv 依赖配置文件
 ├── README.md             # 项目基础说明
 ├── DEVELOPMENT.md        # 本开发指南
+├── docs/
+│   └── workflow-ir.md    # Workflow IR 结构、表达式规则与后端映射规范
 │
 ├── src/                  # 核心源代码目录
 │   ├── __init__.py
@@ -70,6 +72,14 @@ AI-bioworkflow/
 10. **Catalog 镜像权威来源 (`catalog/`)**：每个 Tool Catalog 条目必须显式声明 `runtime.docker`。编译链路不搜索、不猜测、不联网补全镜像；新增或升级工具时由维护者明确选择镜像并写入 catalog。
 11. **辅助脚本镜像化 (`containers/`)**：tximport、DESeq2、MultiQC 等辅助脚本随项目镜像构建进入容器，不作为 WDL 输入，也不内联到 command 中。
 12. **渐进式重构**：先保证 Natural Language -> Recipe Tool Plan -> IR -> WDL -> miniwdl check 的主链路稳定，再逐步扩展 recipe/tool catalog、可解释错误报告与 LLM repairer。
+
+## Workflow IR 规范
+
+Workflow IR 是本项目的核心编译契约。字段结构、表达式系统、scatter 类型提升、Recipe Tool Plan 到 IR 的转换，以及 IR 到 WDL 1.0 的映射规则，统一维护在：
+
+👉 **[Workflow IR 规范与后端映射](./docs/workflow-ir.md)**
+
+后续新增 IR 数据结构、表达式形式、renderer backend 或 Nextflow 支持时，应先更新该规范，再实现代码与测试。
 
 ## 后续待办
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ LLM 在这个架构中更适合承担规划、补全、修复与解释任务；�
 
 ## ✨ 核心特性
 
-- **Workflow IR 驱动**：将 workflow 调用关系与 task 定义分离，支持多个 task、复用 task 和明确的数据依赖。
+- **Workflow IR 驱动**：将 workflow 调用关系与 task 定义分离，支持多个 task、复用 task、scatter 和明确的数据依赖。
 - **确定性 WDL 编译**：通过 Jinja2 Renderer 从 IR 生成 WDL，避免让 LLM 承担模板引擎职责。
 - **静态分析**：在渲染前检查 task/call 引用、输入完整性、上游输出引用和基础类型匹配。
 - **Recipe / Tool Catalog**：支持用预定义生信工具目录和分析配方生成 Workflow IR。
@@ -62,7 +62,7 @@ uv run main.py
 也可以直接传入自然语言需求：
 
 ```bash
-uv run main.py --prompt "做一个 bulk RNA-seq 差异表达分析流程，输入双端 FASTQ、Salmon index 和样本分组表，先 fastp，再 salmon，最后 DESeq2。"
+uv run main.py --prompt "做一个 bulk RNA-seq 差异表达分析流程，输入多个样本的双端 FASTQ、样本 ID、Salmon index、tx2gene 和样本分组表，先 fastp，再 salmon，然后 tximport、DESeq2 和 MultiQC。"
 ```
 
 或者从文本文件读取需求并写出 WDL：
@@ -113,7 +113,7 @@ uv run main.py \
 
 结构化输入用于开发、调试和集成测试，目前支持两类：
 
-1. **标准 Workflow IR**：直接提供 `workflow.calls` 和 `tasks`，适合精确控制每个 task 的命令、输入、输出和 runtime。
+1. **标准 Workflow IR**：直接提供 `workflow.steps` / `workflow.calls` 和 `tasks`，适合精确控制每个 task 的命令、输入、输出、scatter 和 runtime。
 2. **Recipe Tool Plan**：提供 `workflow.recipe` 和 `workflow.tool_calls`，由内置 recipe/tool catalog 自动解析为 Workflow IR。
 
 Recipe Tool Plan 示例：
@@ -124,9 +124,11 @@ Recipe Tool Plan 示例：
     "name": "RNASeqDEG",
     "recipe": "rnaseq_differential_expression",
     "inputs": {
-      "raw_r1": "File",
-      "raw_r2": "File",
+      "sample_ids": "Array[String]",
+      "raw_r1s": "Array[File]",
+      "raw_r2s": "Array[File]",
       "transcriptome_index": "File",
+      "tx2gene": "File",
       "sample_groups": "File"
     },
     "tool_calls": [
@@ -136,8 +138,8 @@ Recipe Tool Plan 示例：
         "tool": "fastp",
         "version": "0.23.2",
         "inputs": {
-          "r1": "raw_r1",
-          "r2": "raw_r2"
+          "r1": "raw_r1s",
+          "r2": "raw_r2s"
         },
         "params": {
           "thread": 4
@@ -163,6 +165,7 @@ Recipe Tool Plan 示例：
 - [x] 接入 Recipe / Tool Catalog 输入到 LangGraph Planner。
 - [x] 闭环修复机制初版：当分析器或校验器发现可确定修复的问题时，优先修复 IR 并重新编译 WDL。
 - [x] Tool Catalog 强制显式声明 `runtime.docker`，作为镜像来源的唯一权威。
+- [x] 支持 `workflow.steps` 与 WDL scatter，RNA-seq DEG recipe 升级为多样本 Salmon -> tximport -> DESeq2 -> MultiQC。
 - [ ] 扩展更多常用生信 recipe 与 tool catalog。
 
 ## 📄 许可证

--- a/README.md
+++ b/README.md
@@ -150,6 +150,8 @@ Recipe Tool Plan 示例：
 }
 ```
 
+`tool_calls[].inputs` 的值既可以是单个表达式字符串，也可以是表达式数组。数组会被编译成 WDL `Array[...]` 输入；例如 MultiQC 的 `report_files` 可以写成 `["qc.html_report", "qc.json_report", "quantify.log_file"]`，scatter 内产生的多个 `Array[File]` 会在渲染时自动展开为 `flatten([...])`。Catalog output 也可以用 `tags: [multiqc_input]` 标记可汇总文件；MultiQC 未显式提供 `report_files` 时会自动收集前序带标签输出。
+
 ## 🏗️ 架构与开发指南
 
 对于希望了解本项目底层实现原理、LangGraph 状态图设计，或有志于参与二次开发的工程师，请务必阅读我们的开发文档：

--- a/README.md
+++ b/README.md
@@ -158,6 +158,10 @@ Recipe Tool Plan 示例：
 
 👉 **[查看 DEVELOPMENT.md 开发指南](./DEVELOPMENT.md)**
 
+Workflow IR 的结构、表达式规则、scatter 语义和 WDL 后端映射详见：
+
+👉 **[Workflow IR 规范与后端映射](./docs/workflow-ir.md)**
+
 ## 📅 未来路线图 (Roadmap)
 
 - [x] 搭建基础 LangGraph 状态机。

--- a/containers/README.md
+++ b/containers/README.md
@@ -1,0 +1,18 @@
+# Workflow helper containers
+
+Catalog entries may reference helper images when a workflow task depends on
+project-maintained scripts. Build and publish images explicitly, then copy the
+final tag or digest into the Tool Catalog YAML. The compiler never searches for
+or fills in container images automatically.
+
+Default tag pattern:
+
+```bash
+ghcr.io/yuanzhw/ai-bioworkflow/<tool>:<version>
+```
+
+Each container directory should include:
+
+- `Dockerfile`
+- helper scripts copied into the image
+- `smoke_test.sh` for a fast post-build check

--- a/containers/deseq2/1.42.0/Dockerfile
+++ b/containers/deseq2/1.42.0/Dockerfile
@@ -1,0 +1,8 @@
+FROM bioconductor/bioconductor_docker:RELEASE_3_18
+
+RUN Rscript -e 'BiocManager::install(c("DESeq2", "readr"), ask = FALSE, update = FALSE)'
+
+COPY run_deseq2.R /usr/local/bin/run_deseq2.R
+RUN chmod +x /usr/local/bin/run_deseq2.R
+
+ENTRYPOINT []

--- a/containers/deseq2/1.42.0/run_deseq2.R
+++ b/containers/deseq2/1.42.0/run_deseq2.R
@@ -1,0 +1,59 @@
+#!/usr/bin/env Rscript
+
+suppressPackageStartupMessages({
+  library(DESeq2)
+  library(readr)
+})
+
+args <- commandArgs(trailingOnly = TRUE)
+
+value_after <- function(flag) {
+  pos <- match(flag, args)
+  if (is.na(pos) || pos == length(args)) {
+    stop(paste("missing argument", flag), call. = FALSE)
+  }
+  args[[pos + 1]]
+}
+
+counts_path <- value_after("--counts")
+sample_groups_path <- value_after("--sample-groups")
+contrast_column <- value_after("--contrast")
+output_path <- value_after("--output")
+
+counts_df <- read_tsv(counts_path, col_names = TRUE, show_col_types = FALSE)
+sample_groups <- read_tsv(sample_groups_path, col_names = TRUE, show_col_types = FALSE)
+
+if (!"gene_id" %in% names(counts_df)) {
+  stop("counts table must contain a gene_id column", call. = FALSE)
+}
+if (!"sample_id" %in% names(sample_groups)) {
+  stop("sample metadata must contain a sample_id column", call. = FALSE)
+}
+if (!contrast_column %in% names(sample_groups)) {
+  stop(paste("sample metadata is missing contrast column", contrast_column), call. = FALSE)
+}
+
+count_matrix <- as.matrix(counts_df[, setdiff(names(counts_df), "gene_id")])
+rownames(count_matrix) <- counts_df$gene_id
+count_matrix <- round(count_matrix)
+
+sample_groups <- as.data.frame(sample_groups)
+rownames(sample_groups) <- sample_groups$sample_id
+sample_groups <- sample_groups[colnames(count_matrix), , drop = FALSE]
+sample_groups[[contrast_column]] <- factor(sample_groups[[contrast_column]])
+
+if (length(levels(sample_groups[[contrast_column]])) < 2) {
+  stop("contrast column must contain at least two groups", call. = FALSE)
+}
+
+dds <- DESeqDataSetFromMatrix(
+  countData = count_matrix,
+  colData = sample_groups,
+  design = as.formula(paste("~", contrast_column))
+)
+dds <- DESeq(dds, quiet = TRUE)
+groups <- levels(sample_groups[[contrast_column]])
+res <- results(dds, contrast = c(contrast_column, groups[[2]], groups[[1]]))
+res_df <- as.data.frame(res)
+res_df <- cbind(gene_id = rownames(res_df), res_df)
+write_tsv(res_df, output_path)

--- a/containers/deseq2/1.42.0/smoke_test.sh
+++ b/containers/deseq2/1.42.0/smoke_test.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+command -v Rscript >/dev/null
+test -x /usr/local/bin/run_deseq2.R
+Rscript -e 'library(DESeq2); library(readr)'

--- a/containers/multiqc/1.21/Dockerfile
+++ b/containers/multiqc/1.21/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.11-slim
+
+RUN pip install --no-cache-dir multiqc==1.21
+
+COPY run_multiqc.sh /usr/local/bin/run_multiqc.sh
+RUN chmod +x /usr/local/bin/run_multiqc.sh
+
+ENTRYPOINT []

--- a/containers/multiqc/1.21/run_multiqc.sh
+++ b/containers/multiqc/1.21/run_multiqc.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+manifest="$1"
+output="$2"
+
+mkdir -p multiqc_inputs
+while IFS= read -r source_file; do
+  [ -n "$source_file" ] || continue
+  cp "$source_file" "multiqc_inputs/$(basename "$source_file")"
+done < "$manifest"
+
+multiqc multiqc_inputs --filename "$output" --force

--- a/containers/multiqc/1.21/smoke_test.sh
+++ b/containers/multiqc/1.21/smoke_test.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+command -v multiqc >/dev/null
+test -x /usr/local/bin/run_multiqc.sh

--- a/containers/tximport/1.30.0/Dockerfile
+++ b/containers/tximport/1.30.0/Dockerfile
@@ -1,0 +1,8 @@
+FROM bioconductor/bioconductor_docker:RELEASE_3_18
+
+RUN Rscript -e 'BiocManager::install(c("tximport", "readr"), ask = FALSE, update = FALSE)'
+
+COPY run_tximport.R /usr/local/bin/run_tximport.R
+RUN chmod +x /usr/local/bin/run_tximport.R
+
+ENTRYPOINT []

--- a/containers/tximport/1.30.0/run_tximport.R
+++ b/containers/tximport/1.30.0/run_tximport.R
@@ -1,0 +1,35 @@
+#!/usr/bin/env Rscript
+
+suppressPackageStartupMessages({
+  library(readr)
+  library(tximport)
+})
+
+args <- commandArgs(trailingOnly = TRUE)
+
+value_after <- function(flag) {
+  pos <- match(flag, args)
+  if (is.na(pos) || pos == length(args)) {
+    stop(paste("missing argument", flag), call. = FALSE)
+  }
+  args[[pos + 1]]
+}
+
+quant_files_path <- value_after("--quant-files")
+sample_ids_path <- value_after("--sample-ids")
+tx2gene_path <- value_after("--tx2gene")
+output_path <- value_after("--output")
+
+quant_files <- readLines(quant_files_path, warn = FALSE)
+sample_ids <- readLines(sample_ids_path, warn = FALSE)
+tx2gene <- read_tsv(tx2gene_path, col_names = TRUE, show_col_types = FALSE)
+
+if (length(quant_files) != length(sample_ids)) {
+  stop("quant_files and sample_ids must have the same length", call. = FALSE)
+}
+
+names(quant_files) <- sample_ids
+txi <- tximport(quant_files, type = "salmon", tx2gene = tx2gene)
+counts <- as.data.frame(txi$counts)
+counts <- cbind(gene_id = rownames(counts), counts)
+write_tsv(counts, output_path)

--- a/containers/tximport/1.30.0/smoke_test.sh
+++ b/containers/tximport/1.30.0/smoke_test.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+command -v Rscript >/dev/null
+test -x /usr/local/bin/run_tximport.R
+Rscript -e 'library(tximport); library(readr)'

--- a/docs/workflow-ir.md
+++ b/docs/workflow-ir.md
@@ -1,0 +1,845 @@
+# Workflow IR 规范与后端映射
+
+本文档定义 AI-bioworkflow 的 Workflow IR 结构、表达式规则，以及当前 WDL 后端的转换约定。它面向项目开发者和 catalog / recipe 维护者，而不是终端用户。
+
+Workflow IR 的目标不是把 WDL 用 JSON 重写一遍，而是在自然语言 Planner、Recipe / Tool Catalog、静态分析器、修复器和 workflow 后端之间建立一个稳定的语义契约。WDL 是当前第一个后端；未来支持 Nextflow 或其他 workflow engine 时，应优先扩展 IR 的语义层，而不是把某个后端的语法直接渗入 IR。
+
+## 设计原则
+
+1. **IR 是 canonical model**：进入 LangGraph 编译链路后，标准 Workflow IR 是后续 Analyzer、Repairer、Renderer 的共同输入。
+2. **确定性优先**：IR 到后端代码的转换由普通代码完成，不依赖 LLM 自由生成最终 WDL。
+3. **语义先于语法**：IR 表达的是调用、依赖、并行映射、输入输出和 runtime 约束，不直接保存 WDL AST。
+4. **小表达式语言**：IR 只支持项目定义的有限表达式集合。任意 WDL / shell / Python 表达式不能直接塞进 IR。
+5. **后端可扩展**：新增 backend 可以把同一组 IR 语义映射到自己的语言；无法支持的 feature 应显式报错。
+
+## 输入层级
+
+项目目前存在三层输入/中间表示：
+
+1. **自然语言需求**：由 `src/nl_planner.py` 调用 LLM 转成 Recipe Tool Plan。
+2. **Recipe Tool Plan**：面向 catalog 的轻量结构，只声明 recipe、workflow 输入和每一步选用的 tool。
+3. **Workflow IR**：编译器内部 canonical model，包含 workflow DAG、task 定义、表达式和 runtime。
+
+LangGraph 中的 `ir_normalizer` 节点只处理结构化输入到 Workflow IR 的转换。自然语言到 Recipe Tool Plan 的 LLM 调用发生在 CLI 入口、进入 graph 之前。
+
+## 顶层结构
+
+标准 Workflow IR 的顶层结构如下：
+
+```json
+{
+  "version": "1.0",
+  "workflow": {
+    "name": "RNASeqDEG",
+    "inputs": {
+      "sample_ids": "Array[String]",
+      "raw_r1s": "Array[File]",
+      "raw_r2s": "Array[File]"
+    },
+    "steps": [],
+    "calls": [],
+    "outputs": {
+      "deg_table": "deg.deg_table"
+    }
+  },
+  "tasks": {}
+}
+```
+
+`version` 标识 IR schema 版本。当前实现默认为 `"1.0"`。后续如果引入不兼容语义，应提升版本，而不是悄悄改变旧字段含义。
+
+`workflow` 描述 workflow 级别的输入、步骤和输出。
+
+`tasks` 是 task 模板字典。workflow step 通过 task 名引用这里的定义。task 定义与 workflow 调用关系必须分离，以便同一个 task 模板被不同 call 复用。
+
+## WorkflowSpec
+
+`workflow` 字段对应 `WorkflowSpec`。
+
+```json
+{
+  "name": "RNASeqDEG",
+  "inputs": {
+    "sample_ids": "Array[String]",
+    "raw_r1s": "Array[File]"
+  },
+  "steps": [
+    {
+      "kind": "scatter",
+      "id": "per_sample",
+      "item": "i",
+      "over": "range(length(sample_ids))",
+      "body": []
+    }
+  ],
+  "calls": [],
+  "outputs": {
+    "multiqc_report": "report.multiqc_report"
+  }
+}
+```
+
+### `workflow.name`
+
+Workflow 名称，必须是合法标识符：
+
+```text
+[A-Za-z_][A-Za-z0-9_]*
+```
+
+当前 WDL 后端会直接把它渲染为：
+
+```wdl
+workflow RNASeqDEG {
+}
+```
+
+### `workflow.inputs`
+
+Workflow 级输入字典：
+
+```json
+{
+  "raw_r1s": "Array[File]",
+  "sample_groups": "File"
+}
+```
+
+key 是输入名，value 是 IR 类型字符串。当前支持的基础类型来自 WDL 常用类型：
+
+```text
+Boolean
+File
+Float
+Int
+String
+Array[T]
+T?
+```
+
+当前类型兼容判断是保守的：去掉 optional 标记 `?` 后必须完全相等。`Array[File]` 不会隐式兼容 `File`，除非表达式规则明确进行索引或聚合。
+
+### `workflow.steps`
+
+`steps` 是新的 canonical workflow DAG 表达，支持普通 call 和 scatter。
+
+```json
+[
+  {
+    "kind": "call",
+    "id": "summarize",
+    "task": "tximport_summarize",
+    "inputs": {
+      "quant_files": "quantify.quant_file"
+    }
+  }
+]
+```
+
+```json
+[
+  {
+    "kind": "scatter",
+    "id": "per_sample",
+    "item": "i",
+    "over": "range(length(sample_ids))",
+    "body": [
+      {
+        "kind": "call",
+        "id": "qc",
+        "task": "fastp_qc",
+        "inputs": {
+          "r1": "raw_r1s[i]"
+        }
+      }
+    ]
+  }
+]
+```
+
+Analyzer 和 Renderer 都以 `workflow.steps` 为准。
+
+### `workflow.calls`
+
+`calls` 是旧输入兼容字段。旧 IR 只提供 `workflow.calls` 时，normalizer 会把每个 call 转成 `steps` 中的 `kind: "call"`。
+
+当前输出 IR 仍会保留扁平化的 `calls`，用于兼容旧测试、旧工具和调试输出。但新功能不应只更新 `calls` 而忽略 `steps`。
+
+### `workflow.outputs`
+
+Workflow 输出字典：
+
+```json
+{
+  "deg_table": "deg.deg_table",
+  "multiqc_report": "report.multiqc_report"
+}
+```
+
+key 是 workflow output 名称，value 是 IR 表达式。Renderer 会调用 Analyzer 推断表达式类型，再渲染为 WDL output：
+
+```wdl
+output {
+  File deg_table = deg.deg_table
+}
+```
+
+## TaskSpec
+
+`tasks` 中每个条目对应一个 `TaskSpec`。
+
+```json
+{
+  "fastp_qc": {
+    "inputs": {
+      "r1": "File",
+      "r2": "File?",
+      "thread": "Int"
+    },
+    "command": "fastp -i ~{r1} -I ~{r2} -o clean_R1.fq.gz",
+    "outputs": {
+      "clean_r1": {
+        "type": "File",
+        "value": "\"clean_R1.fq.gz\""
+      }
+    },
+    "runtime": {
+      "docker": "quay.io/biocontainers/fastp:0.23.2",
+      "cpu": 4,
+      "memory": "8G"
+    }
+  }
+}
+```
+
+### `task.inputs`
+
+Task 输入名到类型的映射。Call step 的 `inputs` 必须覆盖所有非 optional task inputs。
+
+Optional 输入使用 `T?` 表示。例如：
+
+```json
+{
+  "r2": "File?"
+}
+```
+
+### `task.command`
+
+Task 命令模板当前按 WDL command 语义保存，变量插值使用 `~{name}`：
+
+```text
+salmon quant
+-i ~{index}
+-1 ~{r1}
+-2 ~{r2}
+-o salmon_quant
+```
+
+Analyzer 会检查 command 中出现的 `~{identifier}` 是否在 `task.inputs` 中声明。当前 command 字符串仍偏 WDL；未来如果支持 Nextflow，建议引入 backend-neutral command model 或明确把 command 作为 shell script body，由各后端负责包装。
+
+### `task.outputs`
+
+Task 输出名到 `OutputSpec` 的映射：
+
+```json
+{
+  "html_report": {
+    "type": "File",
+    "value": "\"fastp.html\"",
+    "tags": ["multiqc_input"]
+  }
+}
+```
+
+`type` 是输出类型。
+
+`value` 是输出表达式。对于 `File` / `String` 字面量，应使用带引号的表达式，例如 `"\"fastp.html\""` 在 JSON 中表示 WDL 的 `"fastp.html"`。
+
+`tags` 是可选语义标签，不影响 WDL task output 本身，但可被 resolver 或后续 backend 用于自动连线。例如 `multiqc_input` 表示该输出适合被 MultiQC 汇总。
+
+### `task.runtime`
+
+Runtime 定义当前包含：
+
+```json
+{
+  "docker": "ghcr.io/yuanzhw/ai-bioworkflow/deseq2:1.42.0",
+  "cpu": 4,
+  "memory": "16G",
+  "disks": "local-disk 50 HDD"
+}
+```
+
+Catalog tool 必须显式声明 `runtime.docker`。编译链路不搜索、不猜测、不联网补齐镜像。
+
+WDL 后端会渲染为：
+
+```wdl
+runtime {
+  cpu: 4
+  docker: "ghcr.io/yuanzhw/ai-bioworkflow/deseq2:1.42.0"
+  memory: "16G"
+}
+```
+
+未来 Nextflow 后端可把 `docker` 映射为 `container`，把 `cpu` / `memory` 映射为 process directive。
+
+## CallSpec
+
+普通 call step 结构：
+
+```json
+{
+  "kind": "call",
+  "id": "deg",
+  "task": "deseq2_deg",
+  "inputs": {
+    "counts": "summarize.gene_counts",
+    "sample_groups": "sample_groups",
+    "contrast": "\"condition\""
+  }
+}
+```
+
+`id` 是 call 实例名。它决定后续表达式中的引用前缀，例如 `deg.deg_table`。
+
+`task` 必须引用 `tasks` 中存在的 task 名。
+
+`inputs` 是 task input 名到 `ExpressionValue` 的映射。当前 `ExpressionValue` 支持：
+
+```text
+string expression
+list[string expression]
+```
+
+也就是说，单个输入可以来自一个表达式，也可以来自表达式数组。
+
+## ScatterSpec
+
+Scatter step 表示对集合输入的并行映射语义。
+
+```json
+{
+  "kind": "scatter",
+  "id": "per_sample",
+  "item": "i",
+  "over": "range(length(sample_ids))",
+  "body": [
+    {
+      "kind": "call",
+      "id": "qc",
+      "task": "fastp_qc",
+      "inputs": {
+        "r1": "raw_r1s[i]",
+        "r2": "raw_r2s[i]"
+      }
+    }
+  ]
+}
+```
+
+`id` 是 scatter block 名称，用于调试和未来 backend metadata。
+
+`item` 是 scatter body 内的循环变量名。当前常用 `i`。
+
+`over` 必须解析为 `Array[...]` 类型。RNA-seq recipe 当前使用：
+
+```text
+range(length(sample_ids))
+```
+
+`body` 是嵌套 workflow steps。当前 Analyzer 和 Renderer 递归处理 scatter body。
+
+Scatter 的关键类型规则是：scatter body 内产生的 call output，在 scatter 外部被提升为数组。
+
+如果 `qc.html_report` 在 scatter 内部类型是：
+
+```text
+File
+```
+
+那么在 scatter 外部引用 `qc.html_report` 时类型是：
+
+```text
+Array[File]
+```
+
+这条规则是 MultiQC 汇总、tximport 汇总等多样本工作流的基础。
+
+## 表达式系统
+
+IR 表达式是项目自定义的小表达式语言。表达式的职责是描述数据依赖和简单集合操作，而不是承载完整后端语言能力。
+
+### Workflow 输入引用
+
+```text
+sample_groups
+raw_r1s
+```
+
+如果表达式正好匹配 `workflow.inputs` 中的输入名，类型就是该 workflow input 的类型。
+
+### Call 输出引用
+
+```text
+qc.clean_r1
+summarize.gene_counts
+deg.deg_table
+```
+
+格式：
+
+```text
+call_id.output_name
+```
+
+Analyzer 要求被引用的 call 已经在当前作用域中可用。默认不允许前向引用；Repairer 可以在某些简单情况下重排 step 顺序。
+
+### 索引表达式
+
+```text
+raw_r1s[i]
+```
+
+如果 `raw_r1s` 是 `Array[File]`，且 `i` 是 `Int`，则 `raw_r1s[i]` 类型为 `File`。
+
+Recipe resolver 在 scatter step 中会自动把匹配的 workflow array input 索引成单样本输入。例如 tool 需要 `File r1`，plan 写的是：
+
+```json
+{
+  "r1": "raw_r1s"
+}
+```
+
+如果 recipe step 带有 `scatter.item: "i"`，resolver 会生成：
+
+```json
+{
+  "r1": "raw_r1s[i]"
+}
+```
+
+### 函数表达式
+
+当前支持两个函数：
+
+```text
+length(x)
+range(x)
+```
+
+`length(Array[T]) -> Int`
+
+`length(String) -> Int`
+
+`range(Int) -> Array[Int]`
+
+典型 scatter 入口：
+
+```text
+range(length(sample_ids))
+```
+
+### 字面量
+
+Analyzer 支持基础字面量类型推断：
+
+```text
+"condition" -> String
+true / false -> Boolean
+1 -> Int
+1.5 -> Float
+```
+
+在 Recipe Tool Plan resolver 中，tool params 会被格式化为 WDL 字面量。例如 Python 字符串 `"condition"` 会进入 IR call input 为：
+
+```text
+"condition"
+```
+
+### 数组表达式
+
+Call input 可以直接使用表达式数组：
+
+```json
+{
+  "report_files": [
+    "qc.html_report",
+    "qc.json_report",
+    "quantify.log_file"
+  ]
+}
+```
+
+Analyzer 会逐个推断元素类型。如果元素是 `T` 或 `Array[T]`，数组表达式整体可推断为 `Array[T]`。这使得 scatter 外部的多个 `Array[File]` 可以组合成一个 `Array[File]` 输入。
+
+当前数组表达式为空时无法推断类型。需要空数组语义时，应先扩展 IR 表达式系统，为空数组携带显式元素类型。
+
+### 不支持的表达式
+
+当前不支持：
+
+```text
+qc.html_report + qc.json_report
+a || b
+if (...) then ... else ...
+select_first(...)
+glob(...)
+任意 WDL 表达式透传
+任意 shell 字符串拼接
+```
+
+尤其要注意，数组收集必须写成 JSON array：
+
+```json
+{
+  "report_files": ["qc.html_report", "qc.json_report"]
+}
+```
+
+不要写成：
+
+```json
+{
+  "report_files": "qc.html_report + qc.json_report"
+}
+```
+
+后者既不是当前 IR 表达式，也不是 backend-neutral 语义。
+
+## 作用域与依赖规则
+
+Analyzer 按 `workflow.steps` 顺序递归分析。
+
+普通 call 完成分析后，其 outputs 进入后续作用域。
+
+Scatter body 分析时会创建内部作用域，并加入 scatter item：
+
+```text
+i: Int
+```
+
+Scatter body 中新增的 call outputs 在离开 scatter 后进入外部作用域，但类型提升一层 `Array[...]`。
+
+例如：
+
+```text
+inside scatter:
+  qc.html_report: File
+
+outside scatter:
+  qc.html_report: Array[File]
+```
+
+这也意味着 scatter 外部对内部 call output 的引用是合法的，但类型通常已经变为数组。
+
+## Recipe Tool Plan 到 IR 的转换
+
+Recipe Tool Plan 是更接近 LLM 和 catalog 的输入格式：
+
+```json
+{
+  "workflow": {
+    "name": "RNASeqDEG",
+    "recipe": "rnaseq_differential_expression",
+    "inputs": {
+      "sample_ids": "Array[String]",
+      "raw_r1s": "Array[File]"
+    },
+    "tool_calls": [
+      {
+        "id": "qc",
+        "step": "qc",
+        "tool": "fastp",
+        "version": "0.23.2",
+        "inputs": {
+          "r1": "raw_r1s"
+        },
+        "params": {
+          "thread": 4
+        }
+      }
+    ]
+  }
+}
+```
+
+Resolver 的主要职责：
+
+1. 校验 `workflow.recipe` 是否存在。
+2. 校验每个 `tool_call.step` 是否属于 recipe。
+3. 校验选用 tool 是否在该 recipe step 的 `allowed_tools` 中。
+4. 根据 Tool Catalog 生成 task inputs、command、outputs、runtime。
+5. 把 tool params 转成 task inputs 和 WDL 字面量。
+6. 根据 recipe scatter metadata 生成 `workflow.steps` 中的 scatter block。
+7. 在 scatter 中自动把 workflow array input 索引为单元素输入。
+8. 保留扁平化 `workflow.calls` 作为兼容字段。
+9. 收集 catalog output tags，用于自动连接某些通用汇总工具。
+
+### MultiQC 自动收集
+
+Tool Catalog output 可以标记：
+
+```yaml
+outputs:
+  html_report:
+    type: File
+    value: '"fastp.html"'
+    tags:
+      - multiqc_input
+```
+
+当 MultiQC tool call 没有显式提供 `report_files` 时，resolver 会自动收集前序 call 中带 `multiqc_input` tag 的输出：
+
+```json
+{
+  "report_files": [
+    "qc.html_report",
+    "qc.json_report",
+    "quantify.log_file"
+  ]
+}
+```
+
+这保持了 MultiQC 的通用性：它接收的是 `Array[File]`，而不是某个 fastp 专用字段。
+
+## IR 到 WDL 1.0 的映射
+
+当前唯一实现的后端是 WDL 1.0，入口在 `src/renderers/wdl.py`。
+
+### Workflow 输入
+
+IR:
+
+```json
+{
+  "inputs": {
+    "sample_ids": "Array[String]",
+    "sample_groups": "File"
+  }
+}
+```
+
+WDL:
+
+```wdl
+input {
+  Array[String] sample_ids
+  File sample_groups
+}
+```
+
+### 普通 call
+
+IR:
+
+```json
+{
+  "kind": "call",
+  "id": "deg",
+  "task": "deseq2_deg",
+  "inputs": {
+    "counts": "summarize.gene_counts"
+  }
+}
+```
+
+WDL:
+
+```wdl
+call deseq2_deg as deg {
+  input:
+    counts = summarize.gene_counts
+}
+```
+
+如果 `id` 与 `task` 相同，可以省略 alias。
+
+### Scatter
+
+IR:
+
+```json
+{
+  "kind": "scatter",
+  "id": "per_sample",
+  "item": "i",
+  "over": "range(length(sample_ids))",
+  "body": []
+}
+```
+
+WDL:
+
+```wdl
+scatter (i in range(length(sample_ids))) {
+}
+```
+
+### 数组输入
+
+IR:
+
+```json
+{
+  "report_files": [
+    "qc.html_report",
+    "qc.json_report"
+  ]
+}
+```
+
+如果所有元素都是标量 `File`，WDL 渲染为：
+
+```wdl
+report_files = [qc.html_report, qc.json_report]
+```
+
+如果任一元素是 `Array[File]`，WDL 渲染为 `flatten(...)`。例如 scatter 外部：
+
+```json
+{
+  "report_files": [
+    "qc.html_report",
+    "qc.json_report",
+    "extra_report"
+  ]
+}
+```
+
+其中 `qc.html_report` 和 `qc.json_report` 是 `Array[File]`，`extra_report` 是 `File`，WDL 渲染为：
+
+```wdl
+report_files = flatten([qc.html_report, qc.json_report, [extra_report]])
+```
+
+如果所有元素都是 scatter 输出数组，则渲染为：
+
+```wdl
+report_files = flatten([qc.html_report, qc.json_report, quantify.log_file])
+```
+
+### Workflow 输出
+
+IR:
+
+```json
+{
+  "outputs": {
+    "multiqc_report": "report.multiqc_report"
+  }
+}
+```
+
+WDL:
+
+```wdl
+output {
+  File multiqc_report = report.multiqc_report
+}
+```
+
+输出类型由 Analyzer 根据表达式推断。
+
+### Task
+
+IR task 渲染为 WDL task：
+
+```wdl
+task multiqc_report {
+  input {
+    Array[File] report_files
+  }
+
+  command <<<
+    run_multiqc.sh
+    ~{write_lines(report_files)}
+    multiqc_report.html
+  >>>
+
+  output {
+    File multiqc_report = "multiqc_report.html"
+  }
+
+  runtime {
+    cpu: 2
+    docker: "ghcr.io/yuanzhw/ai-bioworkflow/multiqc:1.21"
+    memory: "4G"
+  }
+}
+```
+
+Renderer 只负责确定性渲染。生成后由 `miniwdl check` 做 WDL 语法校验。
+
+## 后端中立约束
+
+为了给 Nextflow 等后续后端留下空间，新增 IR 字段时应遵守以下约束：
+
+1. 不要把字段命名为 WDL 专有概念，除非该字段只属于 WDL backend options。
+2. 不要把任意 WDL 表达式作为 IR 表达式透传。
+3. 新表达式必须先定义语义、类型规则和作用域规则，再实现 WDL 渲染。
+4. 后端不支持某个 IR feature 时，应在 backend capability 检查中明确报错。
+5. Catalog 里描述 tool 的生物信息学语义和 runtime，不描述某个后端的 DAG 语法。
+
+## Nextflow 后端展望
+
+Nextflow 支持时，不建议把 IR 改造成 Nextflow channel DSL 的 JSON 版本。推荐映射方向：
+
+```text
+Workflow IR workflow.inputs -> Nextflow params / input channel bootstrap
+TaskSpec -> process
+CallSpec -> process invocation / channel wiring
+ScatterSpec -> channel fan-out / per-item process execution
+Scatter output Array[T] -> collected channel or value channel
+RuntimeSpec.docker -> process container
+RuntimeSpec.cpu/memory -> process cpus / memory
+ExpressionValue list -> channel mix / collect / flatten strategy
+```
+
+这部分目前只是扩展方向，不是已实现行为。正式实现前应补充 backend capability model，例如：
+
+```text
+supports_scatter
+supports_nested_scatter
+supports_optional_inputs
+supports_array_file_inputs
+supports_runtime_docker
+supports_resource_hints
+```
+
+## 扩展 checklist
+
+新增或修改 IR 结构时，应同步检查：
+
+1. `src/schema.py`：Pydantic model 与兼容 normalizer。
+2. `src/analyzer.py`：类型推断、作用域、错误信息。
+3. `src/repairer.py`：是否需要递归处理新结构。
+4. `src/renderers/wdl.py`：WDL 后端映射。
+5. `src/catalog/resolver.py`：Recipe Tool Plan 是否需要生成新结构。
+6. `src/prompts.py`：LLM Planner 是否需要知道新表达式规则。
+7. `tests/`：schema、analyzer、renderer、catalog resolver、graph 编译链路测试。
+8. `docs/workflow-ir.md`：更新本规范。
+
+新增 backend 时，应先定义：
+
+1. backend 支持哪些 IR feature。
+2. 不支持 feature 的错误信息。
+3. IR 类型到 backend 类型/通道的映射。
+4. task command 和 runtime 的包装策略。
+5. backend 生成代码的本地校验工具。
+
+## 当前保留扩展点
+
+以下能力尚未实现，但 IR 设计应为它们保留空间：
+
+1. Conditional step：条件执行。
+2. Nested scatter：多层并行映射。
+3. Subworkflow：workflow 复用。
+4. Backend capabilities：不同后端的能力声明与报错。
+5. Rich metadata：样本表、数据集、tool provenance、container digest。
+6. Resource hints：更完整的 cpu、memory、disk、preemptible、gpu 等资源语义。
+7. Script packaging：辅助脚本与容器镜像的显式绑定。
+8. More expression forms：条件表达式、可选值处理、typed empty arrays。
+
+这些扩展进入实现前，应先补充本文档中的语义定义，再改代码。

--- a/examples/rnaseq_deg_recipe_plan.json
+++ b/examples/rnaseq_deg_recipe_plan.json
@@ -3,9 +3,11 @@
     "name": "RNASeqDEG",
     "recipe": "rnaseq_differential_expression",
     "inputs": {
-      "raw_r1": "File",
-      "raw_r2": "File",
+      "sample_ids": "Array[String]",
+      "raw_r1s": "Array[File]",
+      "raw_r2s": "Array[File]",
       "transcriptome_index": "File",
+      "tx2gene": "File",
       "sample_groups": "File"
     },
     "tool_calls": [
@@ -15,8 +17,8 @@
         "tool": "fastp",
         "version": "0.23.2",
         "inputs": {
-          "r1": "raw_r1",
-          "r2": "raw_r2"
+          "r1": "raw_r1s",
+          "r2": "raw_r2s"
         },
         "params": {
           "thread": 4
@@ -37,21 +39,44 @@
         }
       },
       {
+        "id": "summarize",
+        "step": "summarize_transcripts",
+        "tool": "tximport",
+        "version": "1.30.0",
+        "inputs": {
+          "quant_files": "quantify.quant_file",
+          "sample_ids": "sample_ids",
+          "tx2gene": "tx2gene"
+        },
+        "params": {}
+      },
+      {
         "id": "deg",
         "step": "differential_expression",
         "tool": "deseq2",
         "version": "1.42.0",
         "inputs": {
-          "counts": "quantify.gene_counts",
+          "counts": "summarize.gene_counts",
           "sample_groups": "sample_groups"
         },
         "params": {
           "contrast": "condition"
         }
+      },
+      {
+        "id": "report",
+        "step": "qc_report",
+        "tool": "multiqc",
+        "version": "1.21",
+        "inputs": {
+          "report_files": "qc.html_report"
+        },
+        "params": {}
       }
     ],
     "outputs": {
-      "deg_table": "deg.deg_table"
+      "deg_table": "deg.deg_table",
+      "multiqc_report": "report.multiqc_report"
     }
   }
 }

--- a/examples/rnaseq_deg_recipe_plan.json
+++ b/examples/rnaseq_deg_recipe_plan.json
@@ -69,7 +69,11 @@
         "tool": "multiqc",
         "version": "1.21",
         "inputs": {
-          "report_files": "qc.html_report"
+          "report_files": [
+            "qc.html_report",
+            "qc.json_report",
+            "quantify.log_file"
+          ]
         },
         "params": {}
       }

--- a/examples/rnaseq_deg_request.txt
+++ b/examples/rnaseq_deg_request.txt
@@ -1,9 +1,13 @@
 Build a bulk RNA-seq differential expression workflow.
 
 Inputs:
-- paired-end FASTQ files
+- sample IDs
+- paired-end FASTQ files for multiple samples
 - a Salmon transcriptome index
+- a transcript-to-gene mapping table
 - a sample metadata table with group labels
 
-Run fastp for read quality control, Salmon for quantification, and DESeq2 for
-differential expression. Return the differential expression table.
+Run fastp for read quality control per sample, Salmon for transcript
+quantification per sample, tximport for gene-level count summarization, DESeq2
+for differential expression, and MultiQC for a quality-control summary. Return
+the differential expression table and the MultiQC report.

--- a/examples/tiny/README.md
+++ b/examples/tiny/README.md
@@ -1,0 +1,13 @@
+# Tiny RNA-seq DEG fixture
+
+`tests/test_tiny_run.py` runs only when the local machine has `miniwdl`, a
+Docker/Podman runtime, all required container images, and an input JSON at:
+
+```text
+examples/tiny/rnaseq_deg.inputs.json
+```
+
+The input JSON should point to a tiny Salmon index, four paired FASTQ files,
+a `tx2gene` table, and a sample metadata table with at least two groups. Keep
+large binary fixtures out of git; generate or download them locally before
+running the optional end-to-end test.

--- a/main.py
+++ b/main.py
@@ -27,9 +27,11 @@ load_dotenv()
 
 DEMO_PROMPT = """
 Build a bulk RNA-seq differential expression workflow. The inputs are paired-end
-FASTQ files, a Salmon transcriptome index, and a sample metadata table. Run fastp
-for read QC, Salmon for quantification, and DESeq2 for differential expression.
-Return the differential expression table as the workflow output.
+FASTQ files for multiple samples, sample IDs, a Salmon transcriptome index, a
+transcript-to-gene mapping table, and a sample metadata table. Run fastp for read
+QC, Salmon for quantification, tximport for gene-level summarization, DESeq2 for
+differential expression, and MultiQC for a QC summary. Return the differential
+expression table and MultiQC report as workflow outputs.
 """.strip()
 
 

--- a/src/analyzer.py
+++ b/src/analyzer.py
@@ -1,7 +1,14 @@
 import re
 from dataclasses import dataclass, field
 
-from src.schema import IDENTIFIER_PATTERN, CallSpec, ScatterSpec, WorkflowIR, extract_command_inputs
+from src.schema import (
+    IDENTIFIER_PATTERN,
+    CallSpec,
+    ExpressionValue,
+    ScatterSpec,
+    WorkflowIR,
+    extract_command_inputs,
+)
 
 
 INDEX_EXPRESSION_PATTERN = re.compile(r"^(.+)\[([^\[\]]+)\]$")
@@ -169,7 +176,12 @@ def _analyze_call(
         target_type = task.inputs[input_name]
 
         if source_type is None:
-            if "." in expression:
+            if isinstance(expression, list):
+                report.errors.append(
+                    f"call '{call.id}' input '{input_name}' has invalid array expression "
+                    f"'{_format_expression(expression)}'"
+                )
+            elif "." in expression:
                 report.errors.append(
                     f"call '{call.id}' input '{input_name}' references unavailable output "
                     f"'{expression}'"
@@ -183,7 +195,7 @@ def _analyze_call(
         if not _types_compatible(target_type, source_type):
             report.errors.append(
                 f"call '{call.id}' input '{input_name}' expects {target_type} "
-                f"but received {source_type} from '{expression}'"
+                f"but received {source_type} from '{_format_expression(expression)}'"
             )
 
     return True
@@ -204,10 +216,13 @@ def _analyze_workflow_outputs(
 
 def _resolve_expression_type(
     ir: WorkflowIR,
-    expression: str,
+    expression: ExpressionValue,
     available_calls: dict[str, AvailableCall],
     variables: dict[str, str],
 ) -> str | None:
+    if isinstance(expression, list):
+        return _resolve_array_expression_type(ir, expression, available_calls, variables)
+
     expression = expression.strip()
 
     if expression in variables:
@@ -253,6 +268,31 @@ def _resolve_expression_type(
     return None
 
 
+def _resolve_array_expression_type(
+    ir: WorkflowIR,
+    expressions: list[str],
+    available_calls: dict[str, AvailableCall],
+    variables: dict[str, str],
+) -> str | None:
+    if not expressions:
+        return None
+
+    element_type: str | None = None
+    for item in expressions:
+        item_type = _resolve_expression_type(ir, item, available_calls, variables)
+        if item_type is None:
+            return None
+
+        item_inner_type = _array_inner_type(item_type)
+        candidate_type = _normalize_type(item_inner_type or item_type)
+        if element_type is None:
+            element_type = candidate_type
+        elif element_type != candidate_type:
+            return None
+
+    return f"Array[{element_type}]"
+
+
 def _available_calls_after_steps(
     ir: WorkflowIR,
     steps: list[CallSpec | ScatterSpec],
@@ -295,6 +335,12 @@ def _looks_like_unknown_expression(expression: str) -> bool:
     if IDENTIFIER_PATTERN.match(expression):
         return True
     return INDEX_EXPRESSION_PATTERN.match(expression) is not None
+
+
+def _format_expression(expression: ExpressionValue) -> str:
+    if isinstance(expression, list):
+        return "[" + ", ".join(expression) + "]"
+    return expression
 
 
 def _types_compatible(expected: str, actual: str) -> bool:

--- a/src/analyzer.py
+++ b/src/analyzer.py
@@ -1,6 +1,12 @@
+import re
 from dataclasses import dataclass, field
 
-from src.schema import IDENTIFIER_PATTERN, WorkflowIR, extract_command_inputs
+from src.schema import IDENTIFIER_PATTERN, CallSpec, ScatterSpec, WorkflowIR, extract_command_inputs
+
+
+INDEX_EXPRESSION_PATTERN = re.compile(r"^(.+)\[([^\[\]]+)\]$")
+LENGTH_EXPRESSION_PATTERN = re.compile(r"^length\((.+)\)$")
+RANGE_EXPRESSION_PATTERN = re.compile(r"^range\((.+)\)$")
 
 
 @dataclass
@@ -20,24 +26,41 @@ class AnalysisReport:
         }
 
 
+@dataclass(frozen=True)
+class AvailableCall:
+    task: str
+    array_depth: int = 0
+
+
 def analyze_workflow_ir(ir: WorkflowIR) -> AnalysisReport:
     report = AnalysisReport()
 
     if not ir.tasks:
         report.errors.append("workflow IR must define at least one task")
-    if not ir.workflow.calls:
-        report.errors.append("workflow must contain at least one call")
+    if not ir.workflow.steps:
+        report.errors.append("workflow must contain at least one step")
 
     _analyze_tasks(ir, report)
-    _analyze_calls(ir, report)
-    _analyze_workflow_outputs(ir, report)
+    available_calls = _analyze_steps(
+        ir=ir,
+        steps=ir.workflow.steps,
+        report=report,
+        available_calls={},
+        variables=dict(ir.workflow.inputs),
+        seen_call_ids=set(),
+    )
+    _analyze_workflow_outputs(ir, report, available_calls)
 
     return report
 
 
 def resolve_workflow_output_type(ir: WorkflowIR, expression: str) -> str | None:
-    call_by_id = {call.id: call for call in ir.workflow.calls}
-    return _resolve_expression_type(ir, expression, call_by_id)
+    return _resolve_expression_type(
+        ir=ir,
+        expression=expression,
+        available_calls=_available_calls_after_steps(ir, ir.workflow.steps),
+        variables=dict(ir.workflow.inputs),
+    )
 
 
 def _analyze_tasks(ir: WorkflowIR, report: AnalysisReport) -> None:
@@ -60,64 +83,119 @@ def _analyze_tasks(ir: WorkflowIR, report: AnalysisReport) -> None:
                 report.errors.append(f"task '{task_name}' output '{output_name}' has empty value")
 
 
-def _analyze_calls(ir: WorkflowIR, report: AnalysisReport) -> None:
-    seen_calls = {}
+def _analyze_steps(
+    ir: WorkflowIR,
+    steps: list[CallSpec | ScatterSpec],
+    report: AnalysisReport,
+    available_calls: dict[str, AvailableCall],
+    variables: dict[str, str],
+    seen_call_ids: set[str],
+) -> dict[str, AvailableCall]:
+    scoped_calls = dict(available_calls)
 
-    for call in ir.workflow.calls:
-        if call.id in seen_calls:
-            report.errors.append(f"duplicate call id '{call.id}'")
+    for step in steps:
+        if isinstance(step, CallSpec):
+            if _analyze_call(ir, step, report, scoped_calls, variables, seen_call_ids):
+                scoped_calls[step.id] = AvailableCall(task=step.task)
             continue
 
-        task = ir.tasks.get(call.task)
-        if task is None:
-            report.errors.append(f"call '{call.id}' references unknown task '{call.task}'")
-            continue
+        if not step.body:
+            report.errors.append(f"scatter '{step.id}' must contain at least one step")
 
-        expected_inputs = {
-            input_name
-            for input_name, input_type in task.inputs.items()
-            if not _is_optional_type(input_type)
-        }
-        declared_inputs = set(task.inputs)
-        provided_inputs = set(call.inputs)
+        over_type = _resolve_expression_type(ir, step.over, scoped_calls, variables)
+        if over_type is None:
+            report.errors.append(f"scatter '{step.id}' iterates over unknown value '{step.over}'")
+        elif _array_inner_type(over_type) is None:
+            report.errors.append(f"scatter '{step.id}' expects an Array expression but received {over_type}")
 
-        for missing in sorted(expected_inputs - provided_inputs):
-            report.errors.append(f"call '{call.id}' is missing input '{missing}'")
-        for unexpected in sorted(provided_inputs - declared_inputs):
-            report.errors.append(f"call '{call.id}' provides unknown input '{unexpected}'")
+        inner_variables = dict(variables)
+        inner_variables[step.item] = "Int"
+        before_body = dict(scoped_calls)
+        inner_after = _analyze_steps(
+            ir=ir,
+            steps=step.body,
+            report=report,
+            available_calls=before_body,
+            variables=inner_variables,
+            seen_call_ids=seen_call_ids,
+        )
 
-        for input_name, expression in call.inputs.items():
-            if input_name not in task.inputs:
-                continue
-
-            source_type = _resolve_expression_type(ir, expression, seen_calls)
-            target_type = task.inputs[input_name]
-
-            if source_type is None:
-                if "." in expression:
-                    report.errors.append(
-                        f"call '{call.id}' input '{input_name}' references unavailable output "
-                        f"'{expression}'"
-                    )
-                elif _looks_like_unknown_identifier(expression):
-                    report.errors.append(
-                        f"call '{call.id}' input '{input_name}' references unknown value '{expression}'"
-                    )
-                continue
-
-            if not _types_compatible(target_type, source_type):
-                report.errors.append(
-                    f"call '{call.id}' input '{input_name}' expects {target_type} "
-                    f"but received {source_type} from '{expression}'"
+        for call_id, available in inner_after.items():
+            if call_id not in before_body:
+                scoped_calls[call_id] = AvailableCall(
+                    task=available.task,
+                    array_depth=available.array_depth + 1,
                 )
 
-        seen_calls[call.id] = call
+    return scoped_calls
 
 
-def _analyze_workflow_outputs(ir: WorkflowIR, report: AnalysisReport) -> None:
-    call_by_id = {call.id: call for call in ir.workflow.calls}
+def _analyze_call(
+    ir: WorkflowIR,
+    call: CallSpec,
+    report: AnalysisReport,
+    available_calls: dict[str, AvailableCall],
+    variables: dict[str, str],
+    seen_call_ids: set[str],
+) -> bool:
+    if call.id in seen_call_ids:
+        report.errors.append(f"duplicate call id '{call.id}'")
+        return False
+    seen_call_ids.add(call.id)
+
+    task = ir.tasks.get(call.task)
+    if task is None:
+        report.errors.append(f"call '{call.id}' references unknown task '{call.task}'")
+        return False
+
+    expected_inputs = {
+        input_name
+        for input_name, input_type in task.inputs.items()
+        if not _is_optional_type(input_type)
+    }
+    declared_inputs = set(task.inputs)
+    provided_inputs = set(call.inputs)
+
+    for missing in sorted(expected_inputs - provided_inputs):
+        report.errors.append(f"call '{call.id}' is missing input '{missing}'")
+    for unexpected in sorted(provided_inputs - declared_inputs):
+        report.errors.append(f"call '{call.id}' provides unknown input '{unexpected}'")
+
+    for input_name, expression in call.inputs.items():
+        if input_name not in task.inputs:
+            continue
+
+        source_type = _resolve_expression_type(ir, expression, available_calls, variables)
+        target_type = task.inputs[input_name]
+
+        if source_type is None:
+            if "." in expression:
+                report.errors.append(
+                    f"call '{call.id}' input '{input_name}' references unavailable output "
+                    f"'{expression}'"
+                )
+            elif _looks_like_unknown_expression(expression):
+                report.errors.append(
+                    f"call '{call.id}' input '{input_name}' references unknown value '{expression}'"
+                )
+            continue
+
+        if not _types_compatible(target_type, source_type):
+            report.errors.append(
+                f"call '{call.id}' input '{input_name}' expects {target_type} "
+                f"but received {source_type} from '{expression}'"
+            )
+
+    return True
+
+
+def _analyze_workflow_outputs(
+    ir: WorkflowIR,
+    report: AnalysisReport,
+    available_calls: dict[str, AvailableCall],
+) -> None:
     for output_name, expression in ir.workflow.outputs.items():
-        output_type = _resolve_expression_type(ir, expression, call_by_id)
+        output_type = _resolve_expression_type(ir, expression, available_calls, dict(ir.workflow.inputs))
         if output_type is None:
             report.errors.append(
                 f"workflow output '{output_name}' references unknown value '{expression}'"
@@ -127,28 +205,75 @@ def _analyze_workflow_outputs(ir: WorkflowIR, report: AnalysisReport) -> None:
 def _resolve_expression_type(
     ir: WorkflowIR,
     expression: str,
-    available_calls: dict,
+    available_calls: dict[str, AvailableCall],
+    variables: dict[str, str],
 ) -> str | None:
     expression = expression.strip()
 
-    if expression in ir.workflow.inputs:
-        return ir.workflow.inputs[expression]
+    if expression in variables:
+        return variables[expression]
 
     literal_type = _infer_literal_type(expression)
     if literal_type:
         return literal_type
 
+    index_match = INDEX_EXPRESSION_PATTERN.match(expression)
+    if index_match:
+        source_type = _resolve_expression_type(ir, index_match.group(1).strip(), available_calls, variables)
+        index_type = _resolve_expression_type(ir, index_match.group(2).strip(), available_calls, variables)
+        inner_type = _array_inner_type(source_type or "")
+        if inner_type and index_type == "Int":
+            return inner_type
+        return None
+
+    length_match = LENGTH_EXPRESSION_PATTERN.match(expression)
+    if length_match:
+        source_type = _resolve_expression_type(ir, length_match.group(1).strip(), available_calls, variables)
+        if source_type and (_array_inner_type(source_type) is not None or _normalize_type(source_type) == "String"):
+            return "Int"
+        return None
+
+    range_match = RANGE_EXPRESSION_PATTERN.match(expression)
+    if range_match:
+        source_type = _resolve_expression_type(ir, range_match.group(1).strip(), available_calls, variables)
+        if source_type == "Int":
+            return "Array[Int]"
+        return None
+
     if "." in expression:
         call_id, output_name = expression.split(".", 1)
-        call = available_calls.get(call_id)
-        if call is None:
+        available = available_calls.get(call_id)
+        if available is None:
             return None
-        task = ir.tasks.get(call.task)
+        task = ir.tasks.get(available.task)
         if task is None or output_name not in task.outputs:
             return None
-        return task.outputs[output_name].type
+        return _wrap_array_type(task.outputs[output_name].type, available.array_depth)
 
     return None
+
+
+def _available_calls_after_steps(
+    ir: WorkflowIR,
+    steps: list[CallSpec | ScatterSpec],
+    available_calls: dict[str, AvailableCall] | None = None,
+) -> dict[str, AvailableCall]:
+    scoped_calls = dict(available_calls or {})
+    for step in steps:
+        if isinstance(step, CallSpec):
+            if step.task in ir.tasks:
+                scoped_calls[step.id] = AvailableCall(task=step.task)
+            continue
+
+        before_body = dict(scoped_calls)
+        inner_after = _available_calls_after_steps(ir, step.body, before_body)
+        for call_id, available in inner_after.items():
+            if call_id not in before_body:
+                scoped_calls[call_id] = AvailableCall(
+                    task=available.task,
+                    array_depth=available.array_depth + 1,
+                )
+    return scoped_calls
 
 
 def _infer_literal_type(expression: str) -> str | None:
@@ -165,8 +290,11 @@ def _infer_literal_type(expression: str) -> str | None:
     return "Float"
 
 
-def _looks_like_unknown_identifier(expression: str) -> bool:
-    return bool(IDENTIFIER_PATTERN.match(expression))
+def _looks_like_unknown_expression(expression: str) -> bool:
+    expression = expression.strip()
+    if IDENTIFIER_PATTERN.match(expression):
+        return True
+    return INDEX_EXPRESSION_PATTERN.match(expression) is not None
 
 
 def _types_compatible(expected: str, actual: str) -> bool:
@@ -175,6 +303,20 @@ def _types_compatible(expected: str, actual: str) -> bool:
 
 def _normalize_type(value: str) -> str:
     return value.strip().rstrip("?")
+
+
+def _array_inner_type(value: str) -> str | None:
+    normalized = _normalize_type(value)
+    if not normalized.startswith("Array[") or not normalized.endswith("]"):
+        return None
+    return normalized[len("Array["):-1]
+
+
+def _wrap_array_type(value: str, depth: int) -> str:
+    wrapped = _normalize_type(value)
+    for _ in range(depth):
+        wrapped = f"Array[{wrapped}]"
+    return wrapped
 
 
 def _is_optional_type(value: str) -> bool:

--- a/src/catalog/resolver.py
+++ b/src/catalog/resolver.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator, model_valida
 
 from src.catalog.loader import ToolCatalog
 from src.catalog.schema import (
+    ToolInputSpec,
     ToolParamSpec,
     ToolSpec,
     validate_identifier,
@@ -16,7 +17,10 @@ from src.catalog.schema import (
 )
 from src.recipes.loader import RecipeCatalog
 from src.recipes.schema import RecipeSpec
-from src.schema import WorkflowIR
+from src.schema import ExpressionValue, WorkflowIR
+
+
+MULTIQC_INPUT_TAG = "multiqc_input"
 
 
 class PlannedToolCall(BaseModel):
@@ -26,7 +30,7 @@ class PlannedToolCall(BaseModel):
     step: str
     tool: str
     version: str
-    inputs: dict[str, str] = Field(default_factory=dict)
+    inputs: dict[str, ExpressionValue] = Field(default_factory=dict)
     params: dict[str, Any] = Field(default_factory=dict)
 
     @field_validator("id", "step", "tool")
@@ -92,6 +96,7 @@ def resolve_tool_plan(
     calls: list[dict[str, Any]] = []
     steps: list[dict[str, Any]] = []
     scatter_steps: dict[str, dict[str, Any]] = {}
+    tagged_outputs: dict[str, list[str]] = {MULTIQC_INPUT_TAG: []}
 
     for tool_call in plan.workflow.tool_calls:
         step = recipe.step_by_id(tool_call.step)
@@ -111,7 +116,7 @@ def resolve_tool_plan(
             "inputs": task_inputs,
             "command": command,
             "outputs": {
-                output_name: output.model_dump(mode="json", exclude_none=True)
+                output_name: output.model_dump(mode="json", exclude_none=True, exclude_defaults=True)
                 for output_name, output in tool.outputs.items()
             },
             "runtime": tool.runtime.model_dump(mode="json", exclude_none=True),
@@ -122,7 +127,13 @@ def resolve_tool_plan(
             "id": tool_call.id,
             "task": task_name,
             "inputs": {
-                **_resolve_inputs(tool_call, tool, plan.workflow.inputs, step.scatter),
+                **_resolve_inputs(
+                    tool_call,
+                    tool,
+                    plan.workflow.inputs,
+                    step.scatter,
+                    tagged_outputs,
+                ),
                 **{
                     param_name: _format_wdl_literal(param_value)
                     for param_name, param_value in params.items()
@@ -131,6 +142,7 @@ def resolve_tool_plan(
         }
         calls.append(call_step)
         _append_workflow_step(steps, scatter_steps, call_step, step.scatter)
+        _record_tagged_outputs(tagged_outputs, tool_call.id, tool)
 
     workflow_outputs = plan.workflow.outputs or _default_workflow_outputs(calls, task_defs)
     return WorkflowIR.model_validate(
@@ -216,18 +228,25 @@ def _resolve_inputs(
     tool: ToolSpec,
     workflow_inputs: dict[str, str],
     scatter,
-) -> dict[str, str]:
+    tagged_outputs: dict[str, list[str]],
+) -> dict[str, ExpressionValue]:
     provided = set(tool_call.inputs)
     expected = set(tool.inputs)
+    input_expressions = dict(tool_call.inputs)
 
     for unexpected in sorted(provided - expected):
         raise ValueError(f"tool call '{tool_call.id}' provides unknown input '{unexpected}'")
     for input_name, spec in tool.inputs.items():
-        if spec.required and input_name not in tool_call.inputs:
+        if input_name in input_expressions:
+            continue
+        auto_expression = _auto_collect_input(tool, input_name, spec, tagged_outputs)
+        if auto_expression is not None:
+            input_expressions[input_name] = auto_expression
+        elif spec.required:
             raise ValueError(f"tool call '{tool_call.id}' is missing required input '{input_name}'")
 
     resolved = {}
-    for input_name, expression in tool_call.inputs.items():
+    for input_name, expression in input_expressions.items():
         resolved[input_name] = _index_scatter_input_if_needed(
             expression=expression,
             target_type=tool.inputs[input_name].type,
@@ -237,12 +256,49 @@ def _resolve_inputs(
     return resolved
 
 
+def _auto_collect_input(
+    tool: ToolSpec,
+    input_name: str,
+    input_spec: ToolInputSpec,
+    tagged_outputs: dict[str, list[str]],
+) -> ExpressionValue | None:
+    if tool.id != "multiqc" or input_name != "report_files":
+        return None
+    if _types_compatible(input_spec.type, "Array[File]"):
+        collected = tagged_outputs.get(MULTIQC_INPUT_TAG, [])
+        if collected:
+            return list(collected)
+    return None
+
+
+def _record_tagged_outputs(
+    tagged_outputs: dict[str, list[str]],
+    call_id: str,
+    tool: ToolSpec,
+) -> None:
+    for output_name, output_spec in tool.outputs.items():
+        for tag in output_spec.tags:
+            tagged_outputs.setdefault(tag, []).append(f"{call_id}.{output_name}")
+
+
 def _index_scatter_input_if_needed(
-    expression: str,
+    expression: ExpressionValue,
     target_type: str,
     workflow_inputs: dict[str, str],
     scatter,
-) -> str:
+) -> ExpressionValue:
+    if isinstance(expression, list):
+        item_target_type = _array_inner_type(target_type) or target_type
+        return [
+            _index_scatter_input_if_needed(
+                expression=item,
+                target_type=item_target_type,
+                workflow_inputs=workflow_inputs,
+                scatter=scatter,
+            )
+            for item in expression
+        ]
+
     if scatter is None:
         return expression
 

--- a/src/catalog/resolver.py
+++ b/src/catalog/resolver.py
@@ -90,6 +90,8 @@ def resolve_tool_plan(
 
     task_defs: dict[str, dict[str, Any]] = {}
     calls: list[dict[str, Any]] = []
+    steps: list[dict[str, Any]] = []
+    scatter_steps: dict[str, dict[str, Any]] = {}
 
     for tool_call in plan.workflow.tool_calls:
         step = recipe.step_by_id(tool_call.step)
@@ -115,19 +117,20 @@ def resolve_tool_plan(
             "runtime": tool.runtime.model_dump(mode="json", exclude_none=True),
         }
 
-        calls.append(
-            {
-                "id": tool_call.id,
-                "task": task_name,
-                "inputs": {
-                    **_resolve_inputs(tool_call, tool),
-                    **{
-                        param_name: _format_wdl_literal(param_value)
-                        for param_name, param_value in params.items()
-                    },
+        call_step = {
+            "kind": "call",
+            "id": tool_call.id,
+            "task": task_name,
+            "inputs": {
+                **_resolve_inputs(tool_call, tool, plan.workflow.inputs, step.scatter),
+                **{
+                    param_name: _format_wdl_literal(param_value)
+                    for param_name, param_value in params.items()
                 },
-            }
-        )
+            },
+        }
+        calls.append(call_step)
+        _append_workflow_step(steps, scatter_steps, call_step, step.scatter)
 
     workflow_outputs = plan.workflow.outputs or _default_workflow_outputs(calls, task_defs)
     return WorkflowIR.model_validate(
@@ -137,6 +140,7 @@ def resolve_tool_plan(
                 "name": plan.workflow.name,
                 "inputs": plan.workflow.inputs,
                 "calls": calls,
+                "steps": steps,
                 "outputs": workflow_outputs,
             },
             "tasks": task_defs,
@@ -207,7 +211,12 @@ def _types_compatible(expected: str, actual: str) -> bool:
     return expected.strip().rstrip("?") == actual.strip().rstrip("?")
 
 
-def _resolve_inputs(tool_call: PlannedToolCall, tool: ToolSpec) -> dict[str, str]:
+def _resolve_inputs(
+    tool_call: PlannedToolCall,
+    tool: ToolSpec,
+    workflow_inputs: dict[str, str],
+    scatter,
+) -> dict[str, str]:
     provided = set(tool_call.inputs)
     expected = set(tool.inputs)
 
@@ -217,7 +226,34 @@ def _resolve_inputs(tool_call: PlannedToolCall, tool: ToolSpec) -> dict[str, str
         if spec.required and input_name not in tool_call.inputs:
             raise ValueError(f"tool call '{tool_call.id}' is missing required input '{input_name}'")
 
-    return dict(tool_call.inputs)
+    resolved = {}
+    for input_name, expression in tool_call.inputs.items():
+        resolved[input_name] = _index_scatter_input_if_needed(
+            expression=expression,
+            target_type=tool.inputs[input_name].type,
+            workflow_inputs=workflow_inputs,
+            scatter=scatter,
+        )
+    return resolved
+
+
+def _index_scatter_input_if_needed(
+    expression: str,
+    target_type: str,
+    workflow_inputs: dict[str, str],
+    scatter,
+) -> str:
+    if scatter is None:
+        return expression
+
+    source_type = workflow_inputs.get(expression)
+    if source_type is None:
+        return expression
+
+    inner_type = _array_inner_type(source_type)
+    if inner_type is not None and _types_compatible(inner_type, target_type):
+        return f"{expression}[{scatter.item}]"
+    return expression
 
 
 def _resolve_params(tool_call: PlannedToolCall, tool: ToolSpec) -> dict[str, Any]:
@@ -306,3 +342,34 @@ def _format_wdl_literal(value: Any) -> str:
     if isinstance(value, bool):
         return "true" if value else "false"
     return str(value)
+
+
+def _append_workflow_step(
+    steps: list[dict[str, Any]],
+    scatter_steps: dict[str, dict[str, Any]],
+    call_step: dict[str, Any],
+    scatter,
+) -> None:
+    if scatter is None:
+        steps.append(call_step)
+        return
+
+    if scatter.id not in scatter_steps:
+        scatter_step = {
+            "kind": "scatter",
+            "id": scatter.id,
+            "item": scatter.item,
+            "over": scatter.over,
+            "body": [],
+        }
+        scatter_steps[scatter.id] = scatter_step
+        steps.append(scatter_step)
+
+    scatter_steps[scatter.id]["body"].append(call_step)
+
+
+def _array_inner_type(value: str) -> str | None:
+    normalized = value.strip().rstrip("?")
+    if not normalized.startswith("Array[") or not normalized.endswith("]"):
+        return None
+    return normalized[len("Array["):-1]

--- a/src/catalog/schema.py
+++ b/src/catalog/schema.py
@@ -41,6 +41,14 @@ class ToolOutputSpec(BaseModel):
     type: str
     value: str
     description: str | None = None
+    tags: list[str] = Field(default_factory=list)
+
+    @field_validator("tags")
+    @classmethod
+    def validate_tags(cls, value: list[str]) -> list[str]:
+        for tag in value:
+            validate_identifier(tag, "tool output tag")
+        return value
 
 
 class ToolSpec(BaseModel):

--- a/src/catalog/tools/deseq2/1.42.0.yaml
+++ b/src/catalog/tools/deseq2/1.42.0.yaml
@@ -33,6 +33,6 @@ command_template: |
   --output differential_expression.tsv
 
 runtime:
-  docker: bioconductor/bioconductor_docker:RELEASE_3_18
+  docker: ghcr.io/yuanzhw/ai-bioworkflow/deseq2:1.42.0
   cpu: 4
   memory: 16G

--- a/src/catalog/tools/fastp/0.23.2.yaml
+++ b/src/catalog/tools/fastp/0.23.2.yaml
@@ -36,9 +36,13 @@ outputs:
   html_report:
     type: File
     value: '"fastp.html"'
+    tags:
+      - multiqc_input
   json_report:
     type: File
     value: '"fastp.json"'
+    tags:
+      - multiqc_input
 
 command_template: |
   fastp -i ~{r1}

--- a/src/catalog/tools/fastp/0.23.2.yaml
+++ b/src/catalog/tools/fastp/0.23.2.yaml
@@ -33,12 +33,20 @@ outputs:
   clean_r2:
     type: File
     value: '"clean_R2.fq.gz"'
+  html_report:
+    type: File
+    value: '"fastp.html"'
+  json_report:
+    type: File
+    value: '"fastp.json"'
 
 command_template: |
   fastp -i ~{r1}
   {% if r2 %}-I ~{r2}{% endif %}
   -o clean_R1.fq.gz
   {% if r2 %}-O clean_R2.fq.gz{% endif %}
+  --html fastp.html
+  --json fastp.json
   --thread ~{thread}
   --qualified_quality_phred ~{qualified_quality_phred}
 

--- a/src/catalog/tools/multiqc/1.21.yaml
+++ b/src/catalog/tools/multiqc/1.21.yaml
@@ -1,0 +1,27 @@
+id: multiqc
+version: "1.21"
+aliases:
+  - QC report
+  - workflow summary
+description: Aggregate per-step quality control files into a MultiQC HTML report.
+
+inputs:
+  report_files:
+    type: Array[File]
+    required: true
+    description: QC and summary files to include in the MultiQC report.
+
+outputs:
+  multiqc_report:
+    type: File
+    value: '"multiqc_report.html"'
+
+command_template: |
+  run_multiqc.sh
+  ~{write_lines(report_files)}
+  multiqc_report.html
+
+runtime:
+  docker: ghcr.io/yuanzhw/ai-bioworkflow/multiqc:1.21
+  cpu: 2
+  memory: 4G

--- a/src/catalog/tools/salmon/1.10.2.yaml
+++ b/src/catalog/tools/salmon/1.10.2.yaml
@@ -29,6 +29,11 @@ outputs:
   quant_file:
     type: File
     value: '"salmon_quant/quant.sf"'
+  log_file:
+    type: File
+    value: '"salmon_quant/logs/salmon_quant.log"'
+    tags:
+      - multiqc_input
 
 command_template: |
   salmon quant

--- a/src/catalog/tools/salmon/1.10.2.yaml
+++ b/src/catalog/tools/salmon/1.10.2.yaml
@@ -26,12 +26,9 @@ params:
     min: 1
 
 outputs:
-  gene_counts:
+  quant_file:
     type: File
-    value: '"gene_counts.tsv"'
-  quant_dir:
-    type: File
-    value: '"salmon_quant"'
+    value: '"salmon_quant/quant.sf"'
 
 command_template: |
   salmon quant
@@ -40,7 +37,6 @@ command_template: |
   -2 ~{r2}
   -p ~{thread}
   -o salmon_quant
-  && touch gene_counts.tsv
 
 runtime:
   docker: quay.io/biocontainers/salmon:1.10.2--h6dccd9a_2

--- a/src/catalog/tools/tximport/1.30.0.yaml
+++ b/src/catalog/tools/tximport/1.30.0.yaml
@@ -1,0 +1,37 @@
+id: tximport
+version: "1.30.0"
+aliases:
+  - transcript to gene counts
+  - Salmon aggregation
+description: Summarize Salmon transcript quantifications into a gene-level count matrix.
+
+inputs:
+  quant_files:
+    type: Array[File]
+    required: true
+    description: Salmon quant.sf files, one per sample.
+  sample_ids:
+    type: Array[String]
+    required: true
+    description: Sample identifiers matching quant_files order.
+  tx2gene:
+    type: File
+    required: true
+    description: Transcript-to-gene mapping table.
+
+outputs:
+  gene_counts:
+    type: File
+    value: '"gene_counts.tsv"'
+
+command_template: |
+  run_tximport.R
+  --quant-files ~{write_lines(quant_files)}
+  --sample-ids ~{write_lines(sample_ids)}
+  --tx2gene ~{tx2gene}
+  --output gene_counts.tsv
+
+runtime:
+  docker: ghcr.io/yuanzhw/ai-bioworkflow/tximport:1.30.0
+  cpu: 2
+  memory: 8G

--- a/src/nl_planner.py
+++ b/src/nl_planner.py
@@ -7,6 +7,7 @@ from typing import Any, Protocol
 from langchain_deepseek import ChatDeepSeek
 from pydantic import SecretStr
 
+from src.analyzer import analyze_workflow_ir
 from src.catalog.loader import ToolCatalog, load_tool_catalog
 from src.catalog.resolver import ToolCallPlan, resolve_tool_plan
 from src.prompts import render_natural_language_planner_prompt
@@ -90,7 +91,11 @@ def create_natural_language_plan(
         raise PlannerSchemaError(f"LLM planner plan schema validation failed: {exc}") from exc
 
     try:
-        resolve_tool_plan(plan, recipe_catalog, tool_catalog)
+        workflow_ir = resolve_tool_plan(plan, recipe_catalog, tool_catalog)
+        analysis_report = analyze_workflow_ir(workflow_ir)
+        if not analysis_report.is_valid:
+            joined_errors = "; ".join(analysis_report.errors)
+            raise ValueError(joined_errors)
     except Exception as exc:
         raise PlannerCatalogError(f"LLM planner recipe/catalog validation failed: {exc}") from exc
 

--- a/src/nl_planner.py
+++ b/src/nl_planner.py
@@ -121,6 +121,7 @@ def build_planner_prompt(
                         "id": step.id,
                         "role": step.role,
                         "optional": step.optional,
+                        "scatter": step.scatter.model_dump(exclude_none=True) if step.scatter else None,
                         "allowed_tools": step.allowed_tools,
                     }
                     for step in recipe.steps

--- a/src/prompts.py
+++ b/src/prompts.py
@@ -14,6 +14,8 @@ def render_natural_language_planner_prompt(
         "- Prefer an existing recipe from the catalog.\n"
         "- Use only tools and versions listed in the catalog.\n"
         "- Use workflow input names from the recipe required_inputs when possible.\n"
+        "- For per-sample scatter steps, connect tool inputs to the array workflow input names; "
+        "the compiler will index them inside scatter.\n"
         "- Use call ids that are valid WDL identifiers.\n"
         "- Connect upstream tool outputs with call_id.output_name expressions.\n"
         "- Include explicit workflow outputs requested by the user, or the final useful output.\n\n"

--- a/src/prompts.py
+++ b/src/prompts.py
@@ -18,6 +18,10 @@ def render_natural_language_planner_prompt(
         "the compiler will index them inside scatter.\n"
         "- Use call ids that are valid WDL identifiers.\n"
         "- Connect upstream tool outputs with call_id.output_name expressions.\n"
+        "- For Array inputs, use JSON arrays of expressions like "
+        '["qc.html_report", "qc.json_report"]; do not join expressions with +.\n'
+        "- For MultiQC report_files, provide a JSON array of QC output expressions or omit it "
+        "so tagged QC outputs can be collected automatically.\n"
         "- Include explicit workflow outputs requested by the user, or the final useful output.\n\n"
         "Output shape:\n"
         "{\n"

--- a/src/recipes/definitions/rnaseq_differential_expression.yaml
+++ b/src/recipes/definitions/rnaseq_differential_expression.yaml
@@ -8,15 +8,21 @@ aliases:
   - transcriptome differential expression
 
 required_inputs:
-  raw_r1:
-    type: File
-    description: First FASTQ read file.
-  raw_r2:
-    type: File
-    description: Second FASTQ read file.
+  sample_ids:
+    type: Array[String]
+    description: Sample identifiers in the same order as the FASTQ arrays.
+  raw_r1s:
+    type: Array[File]
+    description: First FASTQ read files.
+  raw_r2s:
+    type: Array[File]
+    description: Second FASTQ read files.
   transcriptome_index:
     type: File
     description: Salmon transcriptome index archive or directory.
+  tx2gene:
+    type: File
+    description: Transcript-to-gene mapping table.
   sample_groups:
     type: File
     description: Sample metadata table with group labels.
@@ -24,15 +30,34 @@ required_inputs:
 steps:
   - id: qc
     role: read_quality_control
+    scatter:
+      id: per_sample
+      item: i
+      over: range(length(sample_ids))
     allowed_tools:
       - fastp
 
   - id: quantify
     role: expression_quantification
+    scatter:
+      id: per_sample
+      item: i
+      over: range(length(sample_ids))
     allowed_tools:
       - salmon
+
+  - id: summarize_transcripts
+    role: transcript_to_gene_count_summary
+    allowed_tools:
+      - tximport
 
   - id: differential_expression
     role: differential_expression
     allowed_tools:
       - deseq2
+
+  - id: qc_report
+    role: quality_control_summary
+    optional: true
+    allowed_tools:
+      - multiqc

--- a/src/recipes/schema.py
+++ b/src/recipes/schema.py
@@ -10,12 +10,27 @@ class RequiredInputSpec(BaseModel):
     description: str | None = None
 
 
+class RecipeScatterSpec(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    item: str
+    over: str
+
+    @field_validator("id", "item")
+    @classmethod
+    def validate_scatter_ids(cls, value: str) -> str:
+        validate_identifier(value, "recipe scatter identifier")
+        return value
+
+
 class RecipeStepSpec(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     id: str
     role: str
     optional: bool = False
+    scatter: RecipeScatterSpec | None = None
     allowed_tools: list[str] = Field(default_factory=list)
 
     @field_validator("id")

--- a/src/renderers/templates/workflow.wdl.j2
+++ b/src/renderers/templates/workflow.wdl.j2
@@ -9,19 +9,7 @@ workflow {{ ir.workflow.name }} {
   }
 
 {% endif %}
-{% for call in ir.workflow.calls %}
-  call {{ call.task }}{{ (" as " ~ call.id) if call.id != call.task else "" }} {
-{% if call.inputs %}
-    input:
-{% for input_name, expression in call.inputs.items() %}
-      {{ input_name }} = {{ expression }}{{ "," if not loop.last else "" }}
-{% endfor %}
-{% endif %}
-  }
-{% if not loop.last %}
-
-{% endif %}
-{% endfor %}
+{{ workflow_steps }}
 {% if workflow_outputs %}
 
   output {

--- a/src/renderers/wdl.py
+++ b/src/renderers/wdl.py
@@ -5,7 +5,7 @@ from typing import Any
 from jinja2 import Environment, FileSystemLoader, StrictUndefined
 
 from src.analyzer import resolve_workflow_output_type
-from src.schema import WorkflowIR, coerce_workflow_ir
+from src.schema import CallSpec, ScatterSpec, WorkflowIR, coerce_workflow_ir
 
 
 TEMPLATE_DIR = Path(__file__).parent / "templates"
@@ -26,6 +26,7 @@ def render_wdl(workflow_ir: WorkflowIR | dict[str, Any]) -> str:
     return template.render(
         ir=ir,
         runtime_items=_runtime_items,
+        workflow_steps=_render_workflow_steps(ir.workflow.steps),
         workflow_outputs=_workflow_outputs(ir),
     ).strip() + "\n"
 
@@ -46,6 +47,52 @@ def _workflow_outputs(ir: WorkflowIR) -> list[dict[str, str]]:
 def _runtime_items(runtime: Any) -> list[tuple[str, Any]]:
     values = runtime.model_dump(exclude_none=True)
     return sorted(values.items())
+
+
+def _render_workflow_steps(steps: list[CallSpec | ScatterSpec], indent: int = 2) -> str:
+    rendered = []
+    for step in steps:
+        if isinstance(step, CallSpec):
+            rendered.append(_render_call_step(step, indent))
+        else:
+            rendered.append(_render_scatter_step(step, indent))
+    return "\n\n".join(rendered)
+
+
+def _render_call_step(call: CallSpec, indent: int) -> str:
+    prefix = " " * indent
+    nested = " " * (indent + 2)
+    input_prefix = " " * (indent + 4)
+    alias = f" as {call.id}" if call.id != call.task else ""
+    lines = [f"{prefix}call {call.task}{alias} {{"]
+
+    if call.inputs:
+        lines.append(f"{nested}input:")
+        for index, (input_name, expression) in enumerate(call.inputs.items()):
+            comma = "," if index < len(call.inputs) - 1 else ""
+            lines.append(f"{input_prefix}{input_name} = {expression}{comma}")
+
+    lines.append(f"{prefix}}}")
+    return "\n".join(lines)
+
+
+def _render_scatter_step(scatter: ScatterSpec, indent: int) -> str:
+    prefix = " " * indent
+    body = _render_workflow_steps(scatter.body, indent + 2)
+    if body:
+        return "\n".join(
+            [
+                f"{prefix}scatter ({scatter.item} in {scatter.over}) {{",
+                body,
+                f"{prefix}}}",
+            ]
+        )
+    return "\n".join(
+        [
+            f"{prefix}scatter ({scatter.item} in {scatter.over}) {{",
+            f"{prefix}}}",
+        ]
+    )
 
 
 def _format_wdl_literal(value: Any) -> str:

--- a/src/renderers/wdl.py
+++ b/src/renderers/wdl.py
@@ -4,8 +4,9 @@ from typing import Any
 
 from jinja2 import Environment, FileSystemLoader, StrictUndefined
 
-from src.analyzer import resolve_workflow_output_type
-from src.schema import CallSpec, ScatterSpec, WorkflowIR, coerce_workflow_ir
+from src.analyzer import AvailableCall, resolve_workflow_output_type
+from src.analyzer import _array_inner_type, _resolve_expression_type
+from src.schema import CallSpec, ExpressionValue, ScatterSpec, WorkflowIR, coerce_workflow_ir
 
 
 TEMPLATE_DIR = Path(__file__).parent / "templates"
@@ -23,10 +24,16 @@ def render_wdl(workflow_ir: WorkflowIR | dict[str, Any]) -> str:
     env.filters["indent_command"] = _indent_command
 
     template = env.get_template("workflow.wdl.j2")
+    workflow_steps, _ = _render_workflow_steps(
+        ir=ir,
+        steps=ir.workflow.steps,
+        available_calls={},
+        variables=dict(ir.workflow.inputs),
+    )
     return template.render(
         ir=ir,
         runtime_items=_runtime_items,
-        workflow_steps=_render_workflow_steps(ir.workflow.steps),
+        workflow_steps=workflow_steps,
         workflow_outputs=_workflow_outputs(ir),
     ).strip() + "\n"
 
@@ -49,17 +56,41 @@ def _runtime_items(runtime: Any) -> list[tuple[str, Any]]:
     return sorted(values.items())
 
 
-def _render_workflow_steps(steps: list[CallSpec | ScatterSpec], indent: int = 2) -> str:
+def _render_workflow_steps(
+    ir: WorkflowIR,
+    steps: list[CallSpec | ScatterSpec],
+    indent: int = 2,
+    available_calls: dict[str, AvailableCall] | None = None,
+    variables: dict[str, str] | None = None,
+) -> tuple[str, dict[str, AvailableCall]]:
+    scoped_calls = dict(available_calls or {})
+    scoped_variables = dict(variables or {})
     rendered = []
     for step in steps:
         if isinstance(step, CallSpec):
-            rendered.append(_render_call_step(step, indent))
+            rendered.append(_render_call_step(ir, step, indent, scoped_calls, scoped_variables))
+            if step.task in ir.tasks:
+                scoped_calls[step.id] = AvailableCall(task=step.task)
         else:
-            rendered.append(_render_scatter_step(step, indent))
-    return "\n\n".join(rendered)
+            rendered.append(_render_scatter_step(ir, step, indent, scoped_calls, scoped_variables))
+            before_body = dict(scoped_calls)
+            inner_after = _available_calls_after_rendered_steps(ir, step.body, before_body)
+            for call_id, available in inner_after.items():
+                if call_id not in before_body:
+                    scoped_calls[call_id] = AvailableCall(
+                        task=available.task,
+                        array_depth=available.array_depth + 1,
+                    )
+    return "\n\n".join(rendered), scoped_calls
 
 
-def _render_call_step(call: CallSpec, indent: int) -> str:
+def _render_call_step(
+    ir: WorkflowIR,
+    call: CallSpec,
+    indent: int,
+    available_calls: dict[str, AvailableCall],
+    variables: dict[str, str],
+) -> str:
     prefix = " " * indent
     nested = " " * (indent + 2)
     input_prefix = " " * (indent + 4)
@@ -70,15 +101,30 @@ def _render_call_step(call: CallSpec, indent: int) -> str:
         lines.append(f"{nested}input:")
         for index, (input_name, expression) in enumerate(call.inputs.items()):
             comma = "," if index < len(call.inputs) - 1 else ""
-            lines.append(f"{input_prefix}{input_name} = {expression}{comma}")
+            rendered_expression = _render_expression(ir, expression, available_calls, variables)
+            lines.append(f"{input_prefix}{input_name} = {rendered_expression}{comma}")
 
     lines.append(f"{prefix}}}")
     return "\n".join(lines)
 
 
-def _render_scatter_step(scatter: ScatterSpec, indent: int) -> str:
+def _render_scatter_step(
+    ir: WorkflowIR,
+    scatter: ScatterSpec,
+    indent: int,
+    available_calls: dict[str, AvailableCall],
+    variables: dict[str, str],
+) -> str:
     prefix = " " * indent
-    body = _render_workflow_steps(scatter.body, indent + 2)
+    inner_variables = dict(variables)
+    inner_variables[scatter.item] = "Int"
+    body, _ = _render_workflow_steps(
+        ir=ir,
+        steps=scatter.body,
+        indent=indent + 2,
+        available_calls=dict(available_calls),
+        variables=inner_variables,
+    )
     if body:
         return "\n".join(
             [
@@ -93,6 +139,66 @@ def _render_scatter_step(scatter: ScatterSpec, indent: int) -> str:
             f"{prefix}}}",
         ]
     )
+
+
+def _render_expression(
+    ir: WorkflowIR,
+    expression: ExpressionValue,
+    available_calls: dict[str, AvailableCall],
+    variables: dict[str, str],
+) -> str:
+    if isinstance(expression, str):
+        return expression
+    return _render_array_expression(ir, expression, available_calls, variables)
+
+
+def _render_array_expression(
+    ir: WorkflowIR,
+    expressions: list[str],
+    available_calls: dict[str, AvailableCall],
+    variables: dict[str, str],
+) -> str:
+    if not expressions:
+        return "[]"
+
+    item_types = []
+    for item in expressions:
+        item_type = _resolve_expression_type(ir, item, available_calls, variables)
+        item_types.append(item_type)
+
+    if not any(item_type and _array_inner_type(item_type) is not None for item_type in item_types):
+        return f"[{', '.join(expressions)}]"
+
+    flattened_items = []
+    for item, item_type in zip(expressions, item_types, strict=True):
+        if item_type and _array_inner_type(item_type) is not None:
+            flattened_items.append(item)
+        else:
+            flattened_items.append(f"[{item}]")
+    return f"flatten([{', '.join(flattened_items)}])"
+
+
+def _available_calls_after_rendered_steps(
+    ir: WorkflowIR,
+    steps: list[CallSpec | ScatterSpec],
+    available_calls: dict[str, AvailableCall],
+) -> dict[str, AvailableCall]:
+    scoped_calls = dict(available_calls)
+    for step in steps:
+        if isinstance(step, CallSpec):
+            if step.task in ir.tasks:
+                scoped_calls[step.id] = AvailableCall(task=step.task)
+            continue
+
+        before_body = dict(scoped_calls)
+        inner_after = _available_calls_after_rendered_steps(ir, step.body, before_body)
+        for call_id, available in inner_after.items():
+            if call_id not in before_body:
+                scoped_calls[call_id] = AvailableCall(
+                    task=available.task,
+                    array_depth=available.array_depth + 1,
+                )
+    return scoped_calls
 
 
 def _format_wdl_literal(value: Any) -> str:

--- a/src/repairer.py
+++ b/src/repairer.py
@@ -3,7 +3,7 @@ import re
 from dataclasses import dataclass, field
 from typing import Any
 
-from src.schema import IDENTIFIER_PATTERN, WorkflowIR, coerce_workflow_ir
+from src.schema import IDENTIFIER_PATTERN, CallSpec, ScatterSpec, WorkflowIR, coerce_workflow_ir
 
 
 CALL_OUTPUT_PATTERN = re.compile(r"^([A-Za-z_][A-Za-z0-9_]*)\.([A-Za-z_][A-Za-z0-9_]*)$")
@@ -32,53 +32,117 @@ def repair_workflow_ir(workflow_ir: WorkflowIR | dict[str, Any]) -> RepairReport
 
 
 def _repair_call_order(ir: WorkflowIR, actions: list[str]) -> None:
-    calls = list(ir.workflow.calls)
-    if len(calls) < 2:
+    repaired_steps, changed = _repair_step_order(list(ir.workflow.steps))
+    if not changed:
         return
 
-    call_by_id = {call.id: call for call in calls}
-    original_order = [call.id for call in calls]
-    dependencies_by_call = {
-        call.id: _call_dependencies(call.inputs.values(), call_by_id)
-        for call in calls
-    }
+    ir.workflow.steps = repaired_steps
+    ir.workflow.calls = _flatten_calls(repaired_steps)
+    actions.append(
+        "Reordered workflow steps to satisfy upstream output dependencies: "
+        f"{' -> '.join(_step_labels(repaired_steps))}"
+    )
 
-    ordered_calls = []
-    ordered_ids = set()
-    remaining_ids = list(original_order)
 
-    while remaining_ids:
-        ready_id = next(
+def _repair_step_order(steps: list[CallSpec | ScatterSpec]) -> tuple[list[CallSpec | ScatterSpec], bool]:
+    if not steps:
+        return steps, False
+
+    changed = False
+    repaired_steps = []
+    for step in steps:
+        if isinstance(step, ScatterSpec):
+            repaired_body, body_changed = _repair_step_order(list(step.body))
+            if body_changed:
+                step.body = repaired_body
+                changed = True
+        repaired_steps.append(step)
+
+    if len(repaired_steps) < 2:
+        return repaired_steps, changed
+
+    produced_by_step = [_step_produced_calls(step) for step in repaired_steps]
+    all_produced = set().union(*produced_by_step)
+    dependencies_by_index = []
+    for index, step in enumerate(repaired_steps):
+        dependencies = _call_dependencies(_step_expressions(step), all_produced)
+        dependencies -= produced_by_step[index]
+        dependencies_by_index.append(dependencies)
+
+    ordered_steps = []
+    ordered_call_ids = set()
+    remaining_indexes = list(range(len(repaired_steps)))
+
+    while remaining_indexes:
+        ready_index = next(
             (
-                call_id
-                for call_id in remaining_ids
-                if dependencies_by_call[call_id].issubset(ordered_ids)
+                index
+                for index in remaining_indexes
+                if dependencies_by_index[index].issubset(ordered_call_ids)
             ),
             None,
         )
-        if ready_id is None:
-            return
+        if ready_index is None:
+            return repaired_steps, changed
 
-        ordered_calls.append(call_by_id[ready_id])
-        ordered_ids.add(ready_id)
-        remaining_ids.remove(ready_id)
+        ordered_steps.append(repaired_steps[ready_index])
+        ordered_call_ids.update(produced_by_step[ready_index])
+        remaining_indexes.remove(ready_index)
 
-    repaired_order = [call.id for call in ordered_calls]
-    if repaired_order != original_order:
-        ir.workflow.calls = ordered_calls
-        actions.append(
-            "Reordered workflow calls to satisfy upstream output dependencies: "
-            f"{' -> '.join(repaired_order)}"
-        )
+    if _step_labels(ordered_steps) != _step_labels(repaired_steps):
+        changed = True
+        repaired_steps = ordered_steps
+
+    return repaired_steps, changed
 
 
-def _call_dependencies(expressions, call_by_id) -> set[str]:
+def _call_dependencies(expressions, available_call_ids) -> set[str]:
     dependencies = set()
     for expression in expressions:
         match = CALL_OUTPUT_PATTERN.match(expression.strip())
-        if match and match.group(1) in call_by_id:
+        if match and match.group(1) in available_call_ids:
             dependencies.add(match.group(1))
     return dependencies
+
+
+def _step_expressions(step: CallSpec | ScatterSpec) -> list[str]:
+    if isinstance(step, CallSpec):
+        return list(step.inputs.values())
+
+    expressions = [step.over]
+    for child in step.body:
+        expressions.extend(_step_expressions(child))
+    return expressions
+
+
+def _step_produced_calls(step: CallSpec | ScatterSpec) -> set[str]:
+    if isinstance(step, CallSpec):
+        return {step.id}
+
+    produced = set()
+    for child in step.body:
+        produced.update(_step_produced_calls(child))
+    return produced
+
+
+def _flatten_calls(steps: list[CallSpec | ScatterSpec]) -> list[CallSpec]:
+    calls = []
+    for step in steps:
+        if isinstance(step, CallSpec):
+            calls.append(step)
+        else:
+            calls.extend(_flatten_calls(step.body))
+    return calls
+
+
+def _step_labels(steps: list[CallSpec | ScatterSpec]) -> list[str]:
+    labels = []
+    for step in steps:
+        if isinstance(step, CallSpec):
+            labels.append(step.id)
+        else:
+            labels.append(step.id)
+    return labels
 
 
 def _repair_output_literals(ir: WorkflowIR, actions: list[str]) -> None:

--- a/src/repairer.py
+++ b/src/repairer.py
@@ -3,7 +3,14 @@ import re
 from dataclasses import dataclass, field
 from typing import Any
 
-from src.schema import IDENTIFIER_PATTERN, CallSpec, ScatterSpec, WorkflowIR, coerce_workflow_ir
+from src.schema import (
+    IDENTIFIER_PATTERN,
+    CallSpec,
+    ExpressionValue,
+    ScatterSpec,
+    WorkflowIR,
+    coerce_workflow_ir,
+)
 
 
 CALL_OUTPUT_PATTERN = re.compile(r"^([A-Za-z_][A-Za-z0-9_]*)\.([A-Za-z_][A-Za-z0-9_]*)$")
@@ -107,12 +114,25 @@ def _call_dependencies(expressions, available_call_ids) -> set[str]:
 
 def _step_expressions(step: CallSpec | ScatterSpec) -> list[str]:
     if isinstance(step, CallSpec):
-        return list(step.inputs.values())
+        return _flatten_expression_values(step.inputs.values())
 
     expressions = [step.over]
     for child in step.body:
         expressions.extend(_step_expressions(child))
     return expressions
+
+
+def _flatten_expression_values(expressions) -> list[str]:
+    flattened = []
+    for expression in expressions:
+        flattened.extend(_flatten_expression_value(expression))
+    return flattened
+
+
+def _flatten_expression_value(expression: ExpressionValue) -> list[str]:
+    if isinstance(expression, list):
+        return list(expression)
+    return [expression]
 
 
 def _step_produced_calls(step: CallSpec | ScatterSpec) -> set[str]:

--- a/src/schema.py
+++ b/src/schema.py
@@ -19,6 +19,8 @@ WDL_BUILTIN_IDENTIFIERS = {
     "write_lines",
 }
 
+ExpressionValue = str | list[str]
+
 
 class RuntimeSpec(BaseModel):
     model_config = ConfigDict(extra="allow")
@@ -34,6 +36,7 @@ class OutputSpec(BaseModel):
 
     type: str
     value: str
+    tags: list[str] = Field(default_factory=list)
 
 
 class TaskSpec(BaseModel):
@@ -63,7 +66,7 @@ class CallSpec(BaseModel):
     kind: Literal["call"] = "call"
     id: str
     task: str
-    inputs: dict[str, str] = Field(default_factory=dict)
+    inputs: dict[str, ExpressionValue] = Field(default_factory=dict)
 
     @field_validator("id", "task")
     @classmethod
@@ -73,7 +76,7 @@ class CallSpec(BaseModel):
 
     @field_validator("inputs")
     @classmethod
-    def validate_call_input_names(cls, value: dict[str, str]) -> dict[str, str]:
+    def validate_call_input_names(cls, value: dict[str, ExpressionValue]) -> dict[str, ExpressionValue]:
         _validate_mapping_keys(value, "call input")
         return value
 
@@ -263,7 +266,7 @@ def _normalize_task_dict(task_data: dict[str, Any]) -> dict[str, Any]:
     return normalized
 
 
-def _normalize_outputs(outputs: dict[str, Any]) -> dict[str, dict[str, str]]:
+def _normalize_outputs(outputs: dict[str, Any]) -> dict[str, dict[str, Any]]:
     normalized = {}
     for output_name, output_spec in outputs.items():
         if isinstance(output_spec, str):

--- a/src/schema.py
+++ b/src/schema.py
@@ -1,12 +1,23 @@
+from __future__ import annotations
+
 import copy
 import re
-from typing import Any
+from typing import Annotated, Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
 IDENTIFIER_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
-COMMAND_INPUT_PATTERN = re.compile(r"~\{\s*([A-Za-z_][A-Za-z0-9_]*)\s*\}")
+COMMAND_INTERPOLATION_PATTERN = re.compile(r"~\{([^}]*)\}")
+EXPRESSION_IDENTIFIER_PATTERN = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+WDL_BUILTIN_IDENTIFIERS = {
+    "false",
+    "length",
+    "range",
+    "sep",
+    "true",
+    "write_lines",
+}
 
 
 class RuntimeSpec(BaseModel):
@@ -49,6 +60,7 @@ class TaskSpec(BaseModel):
 class CallSpec(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
+    kind: Literal["call"] = "call"
     id: str
     task: str
     inputs: dict[str, str] = Field(default_factory=dict)
@@ -66,12 +78,32 @@ class CallSpec(BaseModel):
         return value
 
 
+class ScatterSpec(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    kind: Literal["scatter"] = "scatter"
+    id: str
+    item: str
+    over: str
+    body: list[WorkflowStepSpec] = Field(default_factory=list)
+
+    @field_validator("id", "item")
+    @classmethod
+    def validate_scatter_identifiers(cls, value: str) -> str:
+        _validate_identifier(value, "scatter identifier")
+        return value
+
+
+WorkflowStepSpec = Annotated[CallSpec | ScatterSpec, Field(discriminator="kind")]
+
+
 class WorkflowSpec(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     name: str
     inputs: dict[str, str] = Field(default_factory=dict)
     calls: list[CallSpec] = Field(default_factory=list)
+    steps: list[WorkflowStepSpec] = Field(default_factory=list)
     outputs: dict[str, str] = Field(default_factory=dict)
 
     @field_validator("name")
@@ -127,12 +159,18 @@ def coerce_workflow_ir(data: WorkflowIR | dict[str, Any]) -> WorkflowIR:
 
 
 def extract_command_inputs(command: str) -> set[str]:
-    return set(COMMAND_INPUT_PATTERN.findall(command or ""))
+    inputs = set()
+    for interpolation in COMMAND_INTERPOLATION_PATTERN.findall(command or ""):
+        for identifier in EXPRESSION_IDENTIFIER_PATTERN.findall(interpolation):
+            if identifier not in WDL_BUILTIN_IDENTIFIERS:
+                inputs.add(identifier)
+    return inputs
 
 
 def _normalize_ir_dict(data: dict[str, Any]) -> dict[str, Any]:
     normalized = copy.deepcopy(data)
     tasks = normalized.get("tasks", {})
+    workflow = normalized.get("workflow", {})
 
     if isinstance(tasks, list):
         normalized["tasks"] = {
@@ -144,6 +182,18 @@ def _normalize_ir_dict(data: dict[str, Any]) -> dict[str, Any]:
             task_name: _normalize_task_dict(task_data)
             for task_name, task_data in tasks.items()
         }
+
+    if isinstance(workflow, dict):
+        calls = workflow.get("calls", [])
+        steps = workflow.get("steps")
+
+        if steps is None:
+            workflow["steps"] = [_normalize_call_step(call) for call in calls]
+        else:
+            workflow["steps"] = [_normalize_step_dict(step) for step in steps]
+
+        if "calls" not in workflow:
+            workflow["calls"] = _flatten_call_steps(workflow["steps"])
 
     return normalized
 
@@ -197,6 +247,7 @@ def _legacy_to_ir_dict(data: dict[str, Any]) -> dict[str, Any]:
             "name": data["workflow_name"],
             "inputs": workflow_inputs,
             "calls": calls,
+            "steps": [_normalize_call_step(call) for call in calls],
             "outputs": workflow_outputs,
         },
         "tasks": task_defs,
@@ -231,6 +282,39 @@ def _normalize_runtime(task_data: dict[str, Any]) -> dict[str, Any]:
     if docker and "docker" not in runtime:
         runtime["docker"] = docker
     return runtime
+
+
+def _normalize_call_step(call: dict[str, Any]) -> dict[str, Any]:
+    normalized = copy.deepcopy(call)
+    normalized.setdefault("kind", "call")
+    return normalized
+
+
+def _normalize_step_dict(step: dict[str, Any]) -> dict[str, Any]:
+    normalized = copy.deepcopy(step)
+    normalized.setdefault("kind", "call")
+
+    if normalized["kind"] == "call":
+        return _normalize_call_step(normalized)
+
+    if normalized["kind"] == "scatter":
+        normalized["body"] = [
+            _normalize_step_dict(child)
+            for child in normalized.get("body", [])
+        ]
+        return normalized
+
+    return normalized
+
+
+def _flatten_call_steps(steps: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    calls = []
+    for step in steps:
+        if step.get("kind", "call") == "call":
+            calls.append(_normalize_call_step(step))
+        elif step.get("kind") == "scatter":
+            calls.extend(_flatten_call_steps(step.get("body", [])))
+    return calls
 
 
 def _infer_source_type(

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -15,9 +15,11 @@ def sample_rnaseq_tool_plan() -> dict[str, Any]:
             "name": "RNASeqDEG",
             "recipe": "rnaseq_differential_expression",
             "inputs": {
-                "raw_r1": "File",
-                "raw_r2": "File",
+                "sample_ids": "Array[String]",
+                "raw_r1s": "Array[File]",
+                "raw_r2s": "Array[File]",
                 "transcriptome_index": "File",
+                "tx2gene": "File",
                 "sample_groups": "File",
             },
             "tool_calls": [
@@ -27,8 +29,8 @@ def sample_rnaseq_tool_plan() -> dict[str, Any]:
                     "tool": "fastp",
                     "version": "0.23.2",
                     "inputs": {
-                        "r1": "raw_r1",
-                        "r2": "raw_r2",
+                        "r1": "raw_r1s",
+                        "r2": "raw_r2s",
                     },
                     "params": {
                         "thread": 4,
@@ -49,21 +51,44 @@ def sample_rnaseq_tool_plan() -> dict[str, Any]:
                     },
                 },
                 {
+                    "id": "summarize",
+                    "step": "summarize_transcripts",
+                    "tool": "tximport",
+                    "version": "1.30.0",
+                    "inputs": {
+                        "quant_files": "quantify.quant_file",
+                        "sample_ids": "sample_ids",
+                        "tx2gene": "tx2gene",
+                    },
+                    "params": {},
+                },
+                {
                     "id": "deg",
                     "step": "differential_expression",
                     "tool": "deseq2",
                     "version": "1.42.0",
                     "inputs": {
-                        "counts": "quantify.gene_counts",
+                        "counts": "summarize.gene_counts",
                         "sample_groups": "sample_groups",
                     },
                     "params": {
                         "contrast": "condition",
                     },
                 },
+                {
+                    "id": "report",
+                    "step": "qc_report",
+                    "tool": "multiqc",
+                    "version": "1.21",
+                    "inputs": {
+                        "report_files": "qc.html_report",
+                    },
+                    "params": {},
+                },
             ],
             "outputs": {
                 "deg_table": "deg.deg_table",
+                "multiqc_report": "report.multiqc_report",
             },
         }
     }
@@ -86,17 +111,27 @@ class CatalogResolutionTests(unittest.TestCase):
         self.assertEqual(workflow_ir.workflow.name, "RNASeqDEG")
         self.assertIn("fastp_qc", workflow_ir.tasks)
         self.assertIn("salmon_quantify", workflow_ir.tasks)
+        self.assertIn("tximport_summarize", workflow_ir.tasks)
         self.assertIn("deseq2_deg", workflow_ir.tasks)
+        self.assertIn("multiqc_report", workflow_ir.tasks)
+        self.assertEqual(workflow_ir.workflow.steps[0].kind, "scatter")
 
         wdl = render_wdl(workflow_ir)
+        self.assertIn("scatter (i in range(length(sample_ids)))", wdl)
         self.assertIn("call fastp_qc as qc", wdl)
         self.assertIn("call salmon_quantify as quantify", wdl)
+        self.assertIn("r1 = raw_r1s[i]", wdl)
+        self.assertIn("r2 = raw_r2s[i]", wdl)
+        self.assertIn("call tximport_summarize as summarize", wdl)
         self.assertIn("call deseq2_deg as deg", wdl)
+        self.assertIn("call multiqc_report as report", wdl)
         self.assertIn("File deg_table = deg.deg_table", wdl)
+        self.assertIn("File multiqc_report = report.multiqc_report", wdl)
+        self.assertIn("quant_files = quantify.quant_file", wdl)
         self.assertIn("--contrast ~{contrast}", wdl)
         self.assertIn('contrast = "condition"', wdl)
         self.assertIn("-I ~{r2}\n    -o clean_R1.fq.gz", wdl)
-        self.assertIn("-O clean_R2.fq.gz\n    --thread ~{thread}", wdl)
+        self.assertIn("-O clean_R2.fq.gz\n    --html fastp.html", wdl)
 
     def test_tool_spec_requires_runtime_docker(self):
         with self.assertRaisesRegex(ValueError, "must define runtime.docker"):
@@ -142,7 +177,11 @@ class CatalogResolutionTests(unittest.TestCase):
 
     def test_resolver_rejects_missing_required_recipe_step(self):
         plan = copy.deepcopy(sample_rnaseq_tool_plan())
-        plan["workflow"]["tool_calls"] = plan["workflow"]["tool_calls"][:-1]
+        plan["workflow"]["tool_calls"] = [
+            tool_call
+            for tool_call in plan["workflow"]["tool_calls"]
+            if tool_call["step"] != "differential_expression"
+        ]
 
         with self.assertRaisesRegex(ValueError, "missing required recipe step\\(s\\): differential_expression"):
             resolve_tool_plan(plan, self.recipe_catalog, self.tool_catalog)

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -81,7 +81,11 @@ def sample_rnaseq_tool_plan() -> dict[str, Any]:
                     "tool": "multiqc",
                     "version": "1.21",
                     "inputs": {
-                        "report_files": "qc.html_report",
+                        "report_files": [
+                            "qc.html_report",
+                            "qc.json_report",
+                            "quantify.log_file",
+                        ],
                     },
                     "params": {},
                 },
@@ -125,6 +129,7 @@ class CatalogResolutionTests(unittest.TestCase):
         self.assertIn("call tximport_summarize as summarize", wdl)
         self.assertIn("call deseq2_deg as deg", wdl)
         self.assertIn("call multiqc_report as report", wdl)
+        self.assertIn("report_files = flatten([qc.html_report, qc.json_report, quantify.log_file])", wdl)
         self.assertIn("File deg_table = deg.deg_table", wdl)
         self.assertIn("File multiqc_report = report.multiqc_report", wdl)
         self.assertIn("quant_files = quantify.quant_file", wdl)
@@ -218,6 +223,26 @@ class CatalogResolutionTests(unittest.TestCase):
 
         with self.assertRaisesRegex(ValueError, "unknown param 'magic'"):
             resolve_tool_plan(plan, self.recipe_catalog, self.tool_catalog)
+
+    def test_multiqc_report_files_can_be_auto_collected_from_output_tags(self):
+        plan = copy.deepcopy(sample_rnaseq_tool_plan())
+        report_call = plan["workflow"]["tool_calls"][-1]
+        report_call["inputs"] = {}
+
+        workflow_ir = resolve_tool_plan(
+            plan,
+            self.recipe_catalog,
+            self.tool_catalog,
+        )
+        report = analyze_workflow_ir(workflow_ir)
+        wdl = render_wdl(workflow_ir)
+
+        self.assertTrue(report.is_valid, report.errors)
+        self.assertEqual(
+            workflow_ir.workflow.calls[-1].inputs["report_files"],
+            ["qc.html_report", "qc.json_report", "quantify.log_file"],
+        )
+        self.assertIn("report_files = flatten([qc.html_report, qc.json_report, quantify.log_file])", wdl)
 
 
 if __name__ == "__main__":

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -92,9 +92,11 @@ def sample_rnaseq_tool_plan() -> dict[str, Any]:
             "name": "RNASeqDEG",
             "recipe": "rnaseq_differential_expression",
             "inputs": {
-                "raw_r1": "File",
-                "raw_r2": "File",
+                "sample_ids": "Array[String]",
+                "raw_r1s": "Array[File]",
+                "raw_r2s": "Array[File]",
                 "transcriptome_index": "File",
+                "tx2gene": "File",
                 "sample_groups": "File",
             },
             "tool_calls": [
@@ -104,8 +106,8 @@ def sample_rnaseq_tool_plan() -> dict[str, Any]:
                     "tool": "fastp",
                     "version": "0.23.2",
                     "inputs": {
-                        "r1": "raw_r1",
-                        "r2": "raw_r2",
+                        "r1": "raw_r1s",
+                        "r2": "raw_r2s",
                     },
                     "params": {
                         "thread": 4,
@@ -126,21 +128,44 @@ def sample_rnaseq_tool_plan() -> dict[str, Any]:
                     },
                 },
                 {
+                    "id": "summarize",
+                    "step": "summarize_transcripts",
+                    "tool": "tximport",
+                    "version": "1.30.0",
+                    "inputs": {
+                        "quant_files": "quantify.quant_file",
+                        "sample_ids": "sample_ids",
+                        "tx2gene": "tx2gene",
+                    },
+                    "params": {},
+                },
+                {
                     "id": "deg",
                     "step": "differential_expression",
                     "tool": "deseq2",
                     "version": "1.42.0",
                     "inputs": {
-                        "counts": "quantify.gene_counts",
+                        "counts": "summarize.gene_counts",
                         "sample_groups": "sample_groups",
                     },
                     "params": {
                         "contrast": "condition",
                     },
                 },
+                {
+                    "id": "report",
+                    "step": "qc_report",
+                    "tool": "multiqc",
+                    "version": "1.21",
+                    "inputs": {
+                        "report_files": "qc.html_report",
+                    },
+                    "params": {},
+                },
             ],
             "outputs": {
                 "deg_table": "deg.deg_table",
+                "multiqc_report": "report.multiqc_report",
             },
         }
     }
@@ -212,6 +237,63 @@ class WorkflowCompilationTests(unittest.TestCase):
 
         self.assertTrue(report.is_valid, report.errors)
 
+    def test_explicit_scatter_steps_analyze_and_render(self):
+        raw_ir = {
+            "workflow": {
+                "name": "ScatterQC",
+                "inputs": {
+                    "raw_fastqs": "Array[File]",
+                },
+                "steps": [
+                    {
+                        "kind": "scatter",
+                        "id": "per_sample",
+                        "item": "i",
+                        "over": "range(length(raw_fastqs))",
+                        "body": [
+                            {
+                                "kind": "call",
+                                "id": "qc",
+                                "task": "fastp_single",
+                                "inputs": {
+                                    "fastq": "raw_fastqs[i]",
+                                },
+                            }
+                        ],
+                    }
+                ],
+                "outputs": {
+                    "clean_fastqs": "qc.clean_fastq",
+                },
+            },
+            "tasks": {
+                "fastp_single": {
+                    "inputs": {
+                        "fastq": "File",
+                    },
+                    "command": "cp ~{fastq} clean.fq.gz",
+                    "outputs": {
+                        "clean_fastq": {
+                            "type": "File",
+                            "value": '"clean.fq.gz"',
+                        }
+                    },
+                    "runtime": {
+                        "docker": "ubuntu:22.04",
+                    },
+                }
+            },
+        }
+
+        workflow_ir = coerce_workflow_ir(raw_ir)
+        report = analyze_workflow_ir(workflow_ir)
+        wdl = render_wdl(workflow_ir)
+
+        self.assertTrue(report.is_valid, report.errors)
+        self.assertIn("scatter (i in range(length(raw_fastqs)))", wdl)
+        self.assertIn("fastq = raw_fastqs[i]", wdl)
+        self.assertIn("Array[File] clean_fastqs = qc.clean_fastq", wdl)
+
     def test_legacy_json_is_normalized_to_ir(self):
         legacy_json = {
             "workflow_name": "SimpleQC",
@@ -263,10 +345,16 @@ class WorkflowCompilationTests(unittest.TestCase):
 
         self.assertTrue(final_state["is_valid"], final_state["validation_message"])
         self.assertEqual(final_state["analysis_errors"], [])
+        self.assertEqual(final_state["workflow_ir"]["workflow"]["steps"][0]["kind"], "scatter")
+        self.assertIn("scatter (i in range(length(sample_ids)))", final_state["current_wdl"])
         self.assertIn("call fastp_qc as qc", final_state["current_wdl"])
         self.assertIn("call salmon_quantify as quantify", final_state["current_wdl"])
+        self.assertIn("call tximport_summarize as summarize", final_state["current_wdl"])
         self.assertIn("call deseq2_deg as deg", final_state["current_wdl"])
+        self.assertIn("call multiqc_report as report", final_state["current_wdl"])
+        self.assertIn("Array[File] quant_files", final_state["current_wdl"])
         self.assertIn("File deg_table = deg.deg_table", final_state["current_wdl"])
+        self.assertIn("File multiqc_report = report.multiqc_report", final_state["current_wdl"])
 
 
 if __name__ == "__main__":

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -158,7 +158,11 @@ def sample_rnaseq_tool_plan() -> dict[str, Any]:
                     "tool": "multiqc",
                     "version": "1.21",
                     "inputs": {
-                        "report_files": "qc.html_report",
+                        "report_files": [
+                            "qc.html_report",
+                            "qc.json_report",
+                            "quantify.log_file",
+                        ],
                     },
                     "params": {},
                 },
@@ -294,6 +298,89 @@ class WorkflowCompilationTests(unittest.TestCase):
         self.assertIn("fastq = raw_fastqs[i]", wdl)
         self.assertIn("Array[File] clean_fastqs = qc.clean_fastq", wdl)
 
+    def test_array_call_inputs_can_collect_scatter_outputs(self):
+        raw_ir = {
+            "workflow": {
+                "name": "ScatterReport",
+                "inputs": {
+                    "raw_fastqs": "Array[File]",
+                    "extra_report": "File",
+                },
+                "steps": [
+                    {
+                        "kind": "scatter",
+                        "id": "per_sample",
+                        "item": "i",
+                        "over": "range(length(raw_fastqs))",
+                        "body": [
+                            {
+                                "kind": "call",
+                                "id": "qc",
+                                "task": "qc_task",
+                                "inputs": {
+                                    "fastq": "raw_fastqs[i]",
+                                },
+                            }
+                        ],
+                    },
+                    {
+                        "kind": "call",
+                        "id": "report",
+                        "task": "report_task",
+                        "inputs": {
+                            "files": ["qc.html_report", "qc.json_report", "extra_report"],
+                        },
+                    },
+                ],
+                "outputs": {
+                    "report": "report.html",
+                },
+            },
+            "tasks": {
+                "qc_task": {
+                    "inputs": {
+                        "fastq": "File",
+                    },
+                    "command": "touch report.html report.json",
+                    "outputs": {
+                        "html_report": {
+                            "type": "File",
+                            "value": '"report.html"',
+                        },
+                        "json_report": {
+                            "type": "File",
+                            "value": '"report.json"',
+                        },
+                    },
+                    "runtime": {
+                        "docker": "ubuntu:22.04",
+                    },
+                },
+                "report_task": {
+                    "inputs": {
+                        "files": "Array[File]",
+                    },
+                    "command": "touch combined.html",
+                    "outputs": {
+                        "html": {
+                            "type": "File",
+                            "value": '"combined.html"',
+                        }
+                    },
+                    "runtime": {
+                        "docker": "ubuntu:22.04",
+                    },
+                },
+            },
+        }
+
+        workflow_ir = coerce_workflow_ir(raw_ir)
+        report = analyze_workflow_ir(workflow_ir)
+        wdl = render_wdl(workflow_ir)
+
+        self.assertTrue(report.is_valid, report.errors)
+        self.assertIn("files = flatten([qc.html_report, qc.json_report, [extra_report]])", wdl)
+
     def test_legacy_json_is_normalized_to_ir(self):
         legacy_json = {
             "workflow_name": "SimpleQC",
@@ -353,6 +440,10 @@ class WorkflowCompilationTests(unittest.TestCase):
         self.assertIn("call deseq2_deg as deg", final_state["current_wdl"])
         self.assertIn("call multiqc_report as report", final_state["current_wdl"])
         self.assertIn("Array[File] quant_files", final_state["current_wdl"])
+        self.assertIn(
+            "report_files = flatten([qc.html_report, qc.json_report, quantify.log_file])",
+            final_state["current_wdl"],
+        )
         self.assertIn("File deg_table = deg.deg_table", final_state["current_wdl"])
         self.assertIn("File multiqc_report = report.multiqc_report", final_state["current_wdl"])
 

--- a/tests/test_nl_planner.py
+++ b/tests/test_nl_planner.py
@@ -22,9 +22,11 @@ def sample_rnaseq_tool_plan():
             "name": "RNASeqDEG",
             "recipe": "rnaseq_differential_expression",
             "inputs": {
-                "raw_r1": "File",
-                "raw_r2": "File",
+                "sample_ids": "Array[String]",
+                "raw_r1s": "Array[File]",
+                "raw_r2s": "Array[File]",
                 "transcriptome_index": "File",
+                "tx2gene": "File",
                 "sample_groups": "File",
             },
             "tool_calls": [
@@ -34,8 +36,8 @@ def sample_rnaseq_tool_plan():
                     "tool": "fastp",
                     "version": "0.23.2",
                     "inputs": {
-                        "r1": "raw_r1",
-                        "r2": "raw_r2",
+                        "r1": "raw_r1s",
+                        "r2": "raw_r2s",
                     },
                     "params": {
                         "thread": 4,
@@ -56,21 +58,44 @@ def sample_rnaseq_tool_plan():
                     },
                 },
                 {
+                    "id": "summarize",
+                    "step": "summarize_transcripts",
+                    "tool": "tximport",
+                    "version": "1.30.0",
+                    "inputs": {
+                        "quant_files": "quantify.quant_file",
+                        "sample_ids": "sample_ids",
+                        "tx2gene": "tx2gene",
+                    },
+                    "params": {},
+                },
+                {
                     "id": "deg",
                     "step": "differential_expression",
                     "tool": "deseq2",
                     "version": "1.42.0",
                     "inputs": {
-                        "counts": "quantify.gene_counts",
+                        "counts": "summarize.gene_counts",
                         "sample_groups": "sample_groups",
                     },
                     "params": {
                         "contrast": "condition",
                     },
                 },
+                {
+                    "id": "report",
+                    "step": "qc_report",
+                    "tool": "multiqc",
+                    "version": "1.21",
+                    "inputs": {
+                        "report_files": "qc.html_report",
+                    },
+                    "params": {},
+                },
             ],
             "outputs": {
                 "deg_table": "deg.deg_table",
+                "multiqc_report": "report.multiqc_report",
             },
         }
     }
@@ -108,6 +133,8 @@ class NaturalLanguagePlannerTests(unittest.TestCase):
 
         self.assertIn("rnaseq_differential_expression", prompt)
         self.assertIn("fastp", prompt)
+        self.assertIn("per_sample", prompt)
+        self.assertIn("tximport", prompt)
         self.assertIn("Run RNA-seq differential expression.", prompt)
 
     def test_plan_from_natural_language_validates_llm_plan(self):
@@ -144,7 +171,11 @@ class NaturalLanguagePlannerTests(unittest.TestCase):
 
     def test_plan_from_natural_language_reports_catalog_error(self):
         plan = sample_rnaseq_tool_plan()
-        plan["workflow"]["tool_calls"] = plan["workflow"]["tool_calls"][:-1]
+        plan["workflow"]["tool_calls"] = [
+            tool_call
+            for tool_call in plan["workflow"]["tool_calls"]
+            if tool_call["step"] != "differential_expression"
+        ]
         fake_llm = FakePlannerLlm(json.dumps(plan))
 
         with self.assertRaisesRegex(PlannerCatalogError, "recipe/catalog validation failed"):

--- a/tests/test_nl_planner.py
+++ b/tests/test_nl_planner.py
@@ -88,7 +88,11 @@ def sample_rnaseq_tool_plan():
                     "tool": "multiqc",
                     "version": "1.21",
                     "inputs": {
-                        "report_files": "qc.html_report",
+                        "report_files": [
+                            "qc.html_report",
+                            "qc.json_report",
+                            "quantify.log_file",
+                        ],
                     },
                     "params": {},
                 },
@@ -179,6 +183,19 @@ class NaturalLanguagePlannerTests(unittest.TestCase):
         fake_llm = FakePlannerLlm(json.dumps(plan))
 
         with self.assertRaisesRegex(PlannerCatalogError, "recipe/catalog validation failed"):
+            plan_from_natural_language(
+                "Run RNA-seq differential expression.",
+                llm=fake_llm,
+            )
+
+    def test_plan_from_natural_language_rejects_unanalyzable_array_concatenation(self):
+        plan = sample_rnaseq_tool_plan()
+        plan["workflow"]["tool_calls"][-1]["inputs"] = {
+            "report_files": "qc.html_report + qc.json_report",
+        }
+        fake_llm = FakePlannerLlm(json.dumps(plan))
+
+        with self.assertRaisesRegex(PlannerCatalogError, "references unavailable output"):
             plan_from_natural_language(
                 "Run RNA-seq differential expression.",
                 llm=fake_llm,

--- a/tests/test_tiny_run.py
+++ b/tests/test_tiny_run.py
@@ -1,0 +1,102 @@
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+import main as cli
+from src.tools.validator import miniwdl_available
+
+
+EXAMPLES_DIR = Path(__file__).parents[1] / "examples"
+REQUIRED_IMAGES = [
+    "quay.io/biocontainers/fastp:0.23.2",
+    "quay.io/biocontainers/salmon:1.10.2--h6dccd9a_2",
+    "ghcr.io/yuanzhw/ai-bioworkflow/tximport:1.30.0",
+    "ghcr.io/yuanzhw/ai-bioworkflow/deseq2:1.42.0",
+    "ghcr.io/yuanzhw/ai-bioworkflow/multiqc:1.21",
+]
+
+
+class OptionalTinyRunTests(unittest.TestCase):
+    def test_rnaseq_tiny_run_when_local_runtime_is_ready(self):
+        if not miniwdl_available():
+            self.skipTest("miniwdl is not installed")
+
+        container_runtime = shutil.which("docker") or shutil.which("podman")
+        if container_runtime is None:
+            self.skipTest("Docker or Podman is not installed")
+
+        missing_images = [
+            image
+            for image in REQUIRED_IMAGES
+            if not _container_image_available(container_runtime, image)
+        ]
+        if missing_images:
+            self.skipTest(f"required tiny-run images are not available locally: {missing_images}")
+
+        tiny_inputs = EXAMPLES_DIR / "tiny" / "rnaseq_deg.inputs.json"
+        if not tiny_inputs.exists():
+            self.skipTest(f"tiny run inputs are not available: {tiny_inputs}")
+
+        plan = cli.load_workflow_input(EXAMPLES_DIR / "rnaseq_deg_recipe_plan.json")
+        state = cli.compile_workflow(plan, check=True)
+        self.assertTrue(state["is_valid"], state["validation_message"])
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            wdl_path = Path(tmpdir) / "rnaseq_deg.wdl"
+            wdl_path.write_text(state["current_wdl"], encoding="utf-8")
+
+            result = subprocess.run(
+                [
+                    _miniwdl_command(),
+                    "run",
+                    str(wdl_path),
+                    "-i",
+                    str(tiny_inputs),
+                    "--dir",
+                    str(Path(tmpdir) / "run"),
+                ],
+                cwd=Path(__file__).parents[1],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        run_outputs = _last_json_object(result.stdout)
+        self.assertIn("RNASeqDEG.deg_table", run_outputs)
+        self.assertIn("RNASeqDEG.multiqc_report", run_outputs)
+
+
+def _container_image_available(runtime: str, image: str) -> bool:
+    result = subprocess.run(
+        [runtime, "image", "inspect", image],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return result.returncode == 0
+
+
+def _miniwdl_command() -> str:
+    executable = shutil.which("miniwdl")
+    if executable:
+        return executable
+    return str(Path(sys.executable).with_name("miniwdl"))
+
+
+def _last_json_object(text: str) -> dict:
+    start = text.rfind("{")
+    if start == -1:
+        return {}
+    try:
+        return json.loads(text[start:])
+    except json.JSONDecodeError:
+        return {}
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This PR builds the follow-up executable RNA-seq DEG benchmark flow on top of `catalog-docker-required`.

- Adds `workflow.steps` support with WDL scatter rendering while keeping legacy `workflow.calls` compatibility.
- Extends Analyzer and Repairer to recursively handle scatter steps and scatter output type lifting.
- Upgrades the RNA-seq DEG recipe to a multi-sample Salmon -> tximport -> DESeq2 flow.
- Adds tximport and MultiQC catalog/container scaffolding.
- Generalizes MultiQC inputs to `Array[File]`, including structured array expressions and tagged QC output collection.
- Documents the Workflow IR contract and current WDL backend mapping.

## PR Stack

This is stacked on #3 (`catalog-docker-required`). After #3 is merged into `main`, this PR can be retargeted to `main`.

## Validation

- `.venv/bin/python -m unittest discover -v` passed: 42 tests OK, 1 skipped optional tiny-run test because local images are not present.
- `.venv/bin/python main.py --input examples/rnaseq_deg_recipe_plan.json` generated WDL and passed `miniwdl check`.
- `/home/yuanzhw/.local/bin/uv run main.py --input examples/rnaseq_deg_recipe_plan.json` generated WDL and passed `miniwdl check`.

## Notes

The optional tiny-run test is intentionally skipped unless Docker/Podman and all required local images are available. This PR does not require pulling or building images during compilation.
