### PR TITLE
Fix scatter input expression typing

### DIFF
--- a/src/catalog/resolver.py
+++ b/src/catalog/resolver.py
@@ -290,7 +290,7 @@ def _index_scatter_input_if_needed(
     if isinstance(expression, list):
         item_target_type = _array_inner_type(target_type) or target_type
         return [
-            _index_scatter_input_if_needed(
+            _index_scalar_scatter_input_if_needed(
                 expression=item,
                 target_type=item_target_type,
                 workflow_inputs=workflow_inputs,
@@ -299,6 +299,20 @@ def _index_scatter_input_if_needed(
             for item in expression
         ]
 
+    return _index_scalar_scatter_input_if_needed(
+        expression=expression,
+        target_type=target_type,
+        workflow_inputs=workflow_inputs,
+        scatter=scatter,
+    )
+
+
+def _index_scalar_scatter_input_if_needed(
+    expression: str,
+    target_type: str,
+    workflow_inputs: dict[str, str],
+    scatter,
+) -> str:
     if scatter is None:
         return expression
 


### PR DESCRIPTION
## Summary

- Fixes the `ExpressionValue` type diagnostic in `src/catalog/resolver.py`.
- Routes scalar expressions through `_index_scalar_scatter_input_if_needed()`, so the list branch is statically known to return `list[str]` instead of `list[ExpressionValue]`.
- Preserves the existing runtime behavior for both scalar and structured array inputs.

## Validation

- `.venv/bin/python -m unittest discover -v` passed: 42 tests OK, 1 optional tiny-run test skipped because local container images are unavailable.
- `.venv/bin/python main.py --input examples/rnaseq_deg_recipe_plan.json` generated WDL and passed `miniwdl check`.
- `git diff --check` passed.

## Note

No project-configured type-check command is currently available in this checkout; `pyright` is not installed on PATH. The offending return expression is now typed as `list[str]` by construction.
