### PR TITLE
Use WOMtool for Windows WDL validation

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -39,7 +39,7 @@ AI-bioworkflow/
 │   │
 │   ├── tools/            # 10. 工具箱：存放外部工具封装
 │   │   ├── __init__.py
-│   │   └── validator.py  # 生信特定工具（如 miniwdl 语法校验）
+│   │   └── validator.py  # 生信特定工具（如 WOMtool 语法校验）
 │   │
 │   ├── nodes/            # 11. 工作节点：LangGraph 的具体执行工位
 │   │   ├── __init__.py
@@ -47,7 +47,7 @@ AI-bioworkflow/
 │   │   ├── analyzer.py   # 调用 IR 静态分析
 │   │   ├── repairer.py   # 调用 IR repairer 并记录修复动作
 │   │   ├── renderer.py   # 调用 WDL renderer
-│   │   └── checker.py    # 调用 miniwdl validator
+│   │   └── checker.py    # 调用 WDL validator
 │   │
 │   └── graph.py          # 12. 核心图纸：组装 nodes 和 tools 的 StateGraph
 │
@@ -68,10 +68,10 @@ AI-bioworkflow/
 6. **静态分析先于渲染 (`analyzer.py`)**：在生成 WDL 前先检查 task 是否存在、输入是否齐全、上游输出引用是否有效、基础类型是否匹配。
 7. **保守修复 (`repairer.py`)**：自动修复只处理可以由 IR 本身确定的问题，例如 call 拓扑顺序和明显漏引号的 File/String 输出字面量；无法确定的错误应保留给人工或后续 LLM repairer。
 8. **确定性渲染 (`renderers/`)**：标准 IR 到 WDL 必须由模板或普通代码生成，不应依赖 LLM 的自由文本输出。
-9. **工具封装 (`tools/`)**：所有与底层操作系统或第三方生信软件的交互（如调用 `miniwdl check`）都必须封装为独立 Tool，确保生成代码闭环验证。
+9. **工具封装 (`tools/`)**：所有与底层操作系统或第三方生信软件的交互（如调用 `java -jar womtool.jar validate`）都必须封装为独立 Tool，确保生成代码闭环验证。
 10. **Catalog 镜像权威来源 (`catalog/`)**：每个 Tool Catalog 条目必须显式声明 `runtime.docker`。编译链路不搜索、不猜测、不联网补全镜像；新增或升级工具时由维护者明确选择镜像并写入 catalog。
 11. **辅助脚本镜像化 (`containers/`)**：tximport、DESeq2、MultiQC 等辅助脚本随项目镜像构建进入容器，不作为 WDL 输入，也不内联到 command 中。
-12. **渐进式重构**：先保证 Natural Language -> Recipe Tool Plan -> IR -> WDL -> miniwdl check 的主链路稳定，再逐步扩展 recipe/tool catalog、可解释错误报告与 LLM repairer。
+12. **渐进式重构**：先保证 Natural Language -> Recipe Tool Plan -> IR -> WDL -> WOMtool validate 的主链路稳定，再逐步扩展 recipe/tool catalog、可解释错误报告与 LLM repairer。
 
 ## Workflow IR 规范
 
@@ -126,7 +126,7 @@ analyzer_node    # IR 静态分析
   ↓
 renderer_node    # Workflow IR steps/scatter -> WDL
   ↓
-checker_node     # miniwdl check
+checker_node     # WOMtool validate
   ↓
 END
 
@@ -151,7 +151,7 @@ analyzer_node    # 修复后重新分析、渲染、校验
 
 已确认的设计决策：
 
-1. **Reviewer LLM 只能修改 IR**：Reviewer 可以读取当前 IR、分析错误、`miniwdl` stderr 和历史修复记录，并输出结构化 IR patch 或候选 IR；不能直接改写最终 WDL、绕过验证或引入未经准入的正式工具。
+1. **Reviewer LLM 只能修改 IR**：Reviewer 可以读取当前 IR、分析错误、WOMtool stderr 和历史修复记录，并输出结构化 IR patch 或候选 IR；不能直接改写最终 WDL、绕过验证或引入未经准入的正式工具。
 2. **Bioinfo Reviewer 只告警与建议**：科学性审查节点负责指出缺失步骤、方法学风险和推荐调整，但最终流程方案始终由 Architect Agent 决定。
 3. **Resource Agent 只处理资源字段**：该节点仅建议或覆盖 `cpu`、`memory`、`disks` 等资源字段，记录修改理由；不负责镜像选择、工具选择或分析方法选择。
 4. **Catalog 内检索优先**：Planner 不必永久读取全量正式工具库；未来由 Tool Retriever 从 approved Catalog 中高召回筛选候选工具，再由完整 Catalog 做最终校验。
@@ -228,7 +228,7 @@ Web 展示系统与 Agent 核心代码继续保留在同一仓库中，以便 Wo
 
 | 层级 | 选型 | 在本项目中的职责 |
 | --- | --- | --- |
-| Agent / Compiler Core | Python + LangGraph + Pydantic + Jinja2 + `miniwdl` | 维护结构化状态、规划/编译流程、确定性输出和验证闭环 |
+| Agent / Compiler Core | Python + LangGraph + Pydantic + Jinja2 + WOMtool | 维护结构化状态、规划/编译流程、确定性输出和验证闭环 |
 | Backend API | FastAPI + Pydantic | 暴露 workflow 创建、查询、catalog 读取、历史详情和事件流接口 |
 | 实时状态推送 | Server-Sent Events (SSE) | 将单次 Agent run 的节点状态、诊断与产物更新推送给工作台 |
 | 数据持久化 | SQLite（展示版）/ PostgreSQL（部署升级） | 保存 run 摘要、状态事件、结构化产物和错误记录 |
@@ -321,7 +321,7 @@ AI-bioworkflow/
   -> Analyzer
   -> Repairer（仅触发时显示）
   -> Renderer
-  -> miniwdl Checker
+  -> WOMtool Checker
   -> Validated WDL 或 Diagnostic Report
 ```
 
@@ -385,7 +385,7 @@ Web 展示轨道与后续 Multi-Agent 能力路线并行推进，优先让已经
 当前确定性 `repairer` 仍作为第一层修复机制。只有在不存在安全、确定的修复动作时，才引入 Reviewer LLM：
 
 ```text
-Analyzer / miniwdl failure
+Analyzer / WOMtool failure
   ↓
 Deterministic Repairer
   ├─ 有安全修复动作 -> 重新分析和验证

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 
 AI-bioworkflow 是一个面向生物信息学工作流生成的 Agent / 编译器原型。
-项目利用 **LangGraph** 构建状态流转架构，将用户提供的结构化 JSON 标准化为内部 **Workflow IR**，再通过确定性的 Renderer 编译为标准、合规的 **WDL (Workflow Description Language) 1.0** 代码，并使用 `miniwdl` 做本地语法校验。
+项目利用 **LangGraph** 构建状态流转架构，将用户提供的结构化 JSON 标准化为内部 **Workflow IR**，再通过确定性的 Renderer 编译为标准、合规的 **WDL (Workflow Description Language) 1.0** 代码，并使用 `WOMtool` 做本地语法校验。
 
 LLM 在这个架构中更适合承担规划、补全、修复与解释任务；从标准 IR 到 WDL 的最终生成由普通代码完成，保证输出稳定、可测试、可维护。
 
@@ -29,6 +29,7 @@ LLM 在这个架构中更适合承担规划、补全、修复与解释任务；�
 确保你的本地开发环境已安装以下基础工具：
 - Python 3.13+
 - [uv](https://github.com/astral-sh/uv) (极速的 Python 包管理器)
+- Java 17+（WOMtool 91 需要 Java 17 或更新版本）
 
 ### 2. 克隆与安装
 
@@ -39,6 +40,10 @@ cd AI-bioworkflow
 
 # 使用 uv 同步依赖并创建虚拟环境
 uv sync
+
+# Windows / 本地校验环境：下载项目本地 Java 与 WOMtool
+powershell -ExecutionPolicy Bypass -File scripts/install_java.ps1
+powershell -ExecutionPolicy Bypass -File scripts/install_womtool.ps1
 ```
 
 ### 3. 配置环境变量
@@ -49,6 +54,10 @@ uv sync
 ```env
 # .env 文件内容
 DEEPSEEK_API_KEY="sk-你的真实API密钥"
+
+# 可选：仅当工具不在默认 .cache 路径时需要设置
+WOMTOOL_JAR="D:/path/to/womtool.jar"
+JAVA_HOME="D:/path/to/jdk-17"
 ```
 
 ### 4. 编译工作流
@@ -87,7 +96,7 @@ uv run main.py --input examples/rnaseq_deg_recipe_plan.json --output outputs/rna
 - `--save-plan`：将自然语言 Planner 生成的 Recipe Tool Plan 保存为 JSON 文件。
 - `--save-planner-prompt`：保存完整 Planner prompt，方便调试模型输出。
 - `--print-ir`：打印 Planner 标准化后的 Workflow IR。
-- `--no-check`：跳过 `miniwdl` 语法校验，仅执行 IR 分析与 WDL 渲染。
+- `--no-check`：跳过 WOMtool 语法校验，仅执行 IR 分析与 WDL 渲染。
 - `--planner-model`：指定自然语言 Planner 使用的模型。
 - `--verbose`：将节点进度日志输出到 stderr。
 
@@ -166,7 +175,7 @@ Workflow IR 的结构、表达式规则、scatter 语义和 WDL 后端映射详�
 
 - [x] 搭建基础 LangGraph 状态机。
 - [x] 实现从结构化 JSON 到 WDL 的单向代码生成。
-- [x] 引入 `miniwdl` / `womtool` 作为 Tool 节点，实现生成的 WDL 自动化本地校验。
+- [x] 引入 WOMtool 作为 Tool 节点，实现生成的 WDL 自动化本地校验。
 - [x] 引入 Workflow IR、静态分析器与确定性 WDL Renderer。
 - [x] 接入 Recipe / Tool Catalog 输入到 LangGraph Planner。
 - [x] 闭环修复机制初版：当分析器或校验器发现可确定修复的问题时，优先修复 IR 并重新编译 WDL。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,9 +11,13 @@ dependencies = [
     "langchain-deepseek>=1.0.1",
     "langchain-openai>=1.2.1",
     "langgraph>=1.1.10",
-    "miniwdl>=1.14.2",
     "python-dotenv>=1.2.2",
     "pyyaml>=6.0.3",
+]
+
+[project.optional-dependencies]
+miniwdl = [
+    "miniwdl>=1.14.2",
 ]
 
 [dependency-groups]

--- a/scripts/install_java.ps1
+++ b/scripts/install_java.ps1
@@ -1,0 +1,35 @@
+param(
+    [string]$MajorVersion = "17",
+    [string]$InstallDir = ".cache/java/temurin-17"
+)
+
+$ErrorActionPreference = "Stop"
+
+$root = Resolve-Path "."
+$targetRoot = Join-Path $root $InstallDir
+$archive = Join-Path $targetRoot "temurin-$MajorVersion-jdk.zip"
+$url = "https://api.adoptium.net/v3/binary/latest/$MajorVersion/ga/windows/x64/jdk/hotspot/normal/eclipse?project=jdk"
+
+New-Item -ItemType Directory -Force -Path $targetRoot | Out-Null
+
+Write-Host "Downloading Temurin JDK $MajorVersion..."
+Invoke-WebRequest -Uri $url -OutFile $archive
+
+$extractDir = Join-Path $targetRoot "extract"
+if (Test-Path $extractDir) {
+    Remove-Item -LiteralPath $extractDir -Recurse -Force
+}
+New-Item -ItemType Directory -Force -Path $extractDir | Out-Null
+
+Write-Host "Extracting Temurin JDK $MajorVersion..."
+Expand-Archive -LiteralPath $archive -DestinationPath $extractDir -Force
+
+$java = Get-ChildItem -Path $extractDir -Recurse -Filter "java.exe" | Select-Object -First 1
+if (-not $java) {
+    throw "java.exe was not found after extraction."
+}
+
+$jdkHome = Split-Path -Parent (Split-Path -Parent $java.FullName)
+Write-Host "JAVA_HOME=$jdkHome"
+Write-Host "JAVA_EXE=$($java.FullName)"
+& $java.FullName -version

--- a/scripts/install_womtool.ps1
+++ b/scripts/install_womtool.ps1
@@ -1,0 +1,21 @@
+param(
+    [string]$Version = "91",
+    [string]$InstallDir = ".cache/womtool"
+)
+
+$ErrorActionPreference = "Stop"
+
+$root = Resolve-Path "."
+$targetDir = Join-Path $root $InstallDir
+$versionedJar = Join-Path $targetDir "womtool-$Version.jar"
+$defaultJar = Join-Path $targetDir "womtool.jar"
+$url = "https://github.com/broadinstitute/cromwell/releases/download/$Version/womtool-$Version.jar"
+
+New-Item -ItemType Directory -Force -Path $targetDir | Out-Null
+
+Write-Host "Downloading WOMtool $Version..."
+Invoke-WebRequest -Uri $url -OutFile $versionedJar
+Copy-Item -LiteralPath $versionedJar -Destination $defaultJar -Force
+
+Write-Host "WOMTOOL_JAR=$defaultJar"
+Write-Host "Downloaded $versionedJar"

--- a/src/graph.py
+++ b/src/graph.py
@@ -5,10 +5,10 @@ from langgraph.graph import END, START, StateGraph
 from src.nodes.analyzer import analyzer_node
 from src.nodes.checker import checker_node
 from src.nodes.ir_normalizer import ir_normalizer_node
-from src.nodes.repairer import repairer_node
 from src.nodes.renderer import renderer_node
+from src.nodes.repairer import repairer_node
 from src.state import WorkflowState
-
+from src.tools.validator import VALIDATOR_MISSING_MARKER
 
 MAX_REPAIR_ATTEMPTS = 2
 logger = logging.getLogger(__name__)
@@ -49,7 +49,7 @@ def _can_attempt_repair(state: WorkflowState) -> bool:
 
 
 def _missing_local_validator(state: WorkflowState) -> bool:
-    return "未找到 miniwdl" in state.get("validation_message", "")
+    return VALIDATOR_MISSING_MARKER in state.get("validation_message", "")
 
 
 # 1. 实例化状态图，传入我们的 WorkflowState 笔记本

--- a/src/nodes/checker.py
+++ b/src/nodes/checker.py
@@ -5,15 +5,14 @@ from langchain_core.messages import HumanMessage
 from src.state import WorkflowState
 from src.tools.validator import wdl_validator
 
-
 logger = logging.getLogger(__name__)
 
 
 def checker_node(state: WorkflowState):
     """
-    负责调用 miniwdl 工具校验代码的节点
+    负责调用 WDL 校验工具校验代码的节点
     """
-    logger.info("Checker node is running miniwdl validation.")
+    logger.info("Checker node is running WDL validation.")
     
     wdl_code = state.get("current_wdl", "")
     current_error_count = state.get("error_count", 0)

--- a/src/state.py
+++ b/src/state.py
@@ -23,7 +23,7 @@ class WorkflowState(TypedDict):
     # 存放模型生成的 WDL 代码（用于后续验证器检查）
     current_wdl: str 
 
-    # miniwdl 或系统校验阶段返回的最后一条消息
+    # WDL validator 或系统校验阶段返回的最后一条消息
     validation_message: str
     
     # 记录当前重试或循环的次数，防止死循环

--- a/src/tools/validator.py
+++ b/src/tools/validator.py
@@ -1,59 +1,95 @@
 import logging
 import os
+import re
 import shutil
 import subprocess
 import sys
 import tempfile
+from dataclasses import dataclass
 from pathlib import Path
 
 from langchain_core.tools import tool
 
-
 logger = logging.getLogger(__name__)
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+VALIDATOR_MISSING_MARKER = "未找到可用的 WDL 校验器"
+MIN_WOMTOOL_JAVA_MAJOR = 17
+
+
+@dataclass(frozen=True)
+class ValidatorCommand:
+    name: str
+    label: str
+    command: list[str]
 
 
 def miniwdl_available() -> bool:
-    return _miniwdl_executable() is not None
+    executable = _miniwdl_executable()
+    if executable is None:
+        return False
+    try:
+        result = subprocess.run(
+            [executable, "--version"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=10,
+        )
+    except (FileNotFoundError, subprocess.SubprocessError, OSError):
+        return False
+    return result.returncode == 0
+
+
+def womtool_available() -> bool:
+    return _womtool_command() is not None
+
+
+def wdl_validator_available() -> bool:
+    return _selected_validator() is not None
 
 
 @tool
 def wdl_validator(wdl_code: str) -> dict:
     """
-    使用 miniwdl 校验 WDL 代码语法的合法性。
+    使用 WOMtool（优先）或 miniwdl 校验 WDL 代码语法的合法性。
     如果代码有错，会返回具体的错误行号和原因。
     """
     logger.info("Validator tool is checking WDL syntax.")
     
     # 1. 创建一个安全的临时文件来存放 WDL 代码
     # delete=False 是因为 subprocess 需要在外部读取它，我们稍后手动删除
-    with tempfile.NamedTemporaryFile(mode='w', suffix='.wdl', delete=False) as temp_file:
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".wdl", delete=False, encoding="utf-8") as temp_file:
         temp_file.write(wdl_code)
         temp_file_path = temp_file.name
 
     try:
-        # 2. 使用子进程在命令行中运行 `miniwdl check`
-        miniwdl_executable = _miniwdl_executable()
-        if miniwdl_executable is None:
-            return _missing_miniwdl_result()
+        # 2. 使用子进程运行 WDL 校验器。Windows 下默认使用 Java/WOMtool。
+        validator = _selected_validator()
+        if validator is None:
+            return _missing_validator_result()
 
         try:
             result = subprocess.run(
-                [miniwdl_executable, "check", temp_file_path],
+                [*validator.command, temp_file_path],
                 capture_output=True,
                 text=True,
-                check=False  # 设置为 False，这样报错时 Python 不会崩溃，而是让我们自己处理
+                check=False,  # 设置为 False，这样报错时 Python 不会崩溃，而是让我们自己处理
+                timeout=120,
             )
-        except FileNotFoundError:
-            return _missing_miniwdl_result()
+        except (FileNotFoundError, subprocess.SubprocessError, OSError) as exc:
+            return {
+                "is_valid": False,
+                "message": f"❌ WDL 校验器执行失败 ({validator.label})：{exc}",
+            }
 
         # 3. 解析执行结果
         if result.returncode == 0:
             return {
                 "is_valid": True,
-                "message": "✅ WDL 语法校验通过！没有发现任何错误。"
+                "message": f"✅ WDL 语法校验通过！{validator.label} 没有发现任何错误。"
             }
         else:
-            # 提取报错信息（miniwdl 的主要报错通常在 stderr 中）
+            # 提取报错信息（WDL 校验器的主要报错通常在 stderr 中）
             error_msg = result.stderr.strip() if result.stderr else result.stdout.strip()
             
             # 【高级工程技巧】
@@ -63,13 +99,149 @@ def wdl_validator(wdl_code: str) -> dict:
             
             return {
                 "is_valid": False,
-                "message": f"❌ WDL 语法校验失败！请根据以下错误信息反思并重新输出修改后的完整代码：\n\n{clean_error_msg}"
+                "message": f"❌ WDL 语法校验失败！校验器：{validator.label}。请根据以下错误信息反思并重新输出修改后的完整代码：\n\n{clean_error_msg}"
             }
 
     finally:
         # 4. 无论成功还是失败，都必须清理系统垃圾（删除临时文件）
         if os.path.exists(temp_file_path):
             os.remove(temp_file_path)
+
+
+def _selected_validator() -> ValidatorCommand | None:
+    requested = os.environ.get("WDL_VALIDATOR", "auto").strip().lower()
+    if requested in {"womtool", "wom"}:
+        return _womtool_command()
+    if requested == "miniwdl":
+        return _miniwdl_command()
+    if requested not in {"", "auto"}:
+        logger.warning("Unknown WDL_VALIDATOR=%s; falling back to auto.", requested)
+
+    return _womtool_command() or _miniwdl_command()
+
+
+def _womtool_command() -> ValidatorCommand | None:
+    jar_path = _womtool_jar()
+    if jar_path is None:
+        return None
+
+    for java_executable in _java_candidates():
+        major = _java_major_version(java_executable)
+        if major is not None and major < MIN_WOMTOOL_JAVA_MAJOR:
+            logger.warning(
+                "Ignoring Java %s for WOMtool; Java %s+ is required.",
+                java_executable,
+                MIN_WOMTOOL_JAVA_MAJOR,
+            )
+            continue
+
+        return ValidatorCommand(
+            name="womtool",
+            label=f"WOMtool ({jar_path.name})",
+            command=[str(java_executable), "-jar", str(jar_path), "validate"],
+        )
+
+    return None
+
+
+def _womtool_jar() -> Path | None:
+    configured = os.environ.get("WOMTOOL_JAR")
+    if configured:
+        configured_path = Path(configured).expanduser()
+        if configured_path.exists():
+            return configured_path
+        logger.warning("WOMTOOL_JAR points to a missing file: %s", configured_path)
+
+    cache_dir = PROJECT_ROOT / ".cache" / "womtool"
+    preferred = cache_dir / "womtool.jar"
+    if preferred.exists():
+        return preferred
+
+    jars = sorted(cache_dir.glob("womtool-*.jar"), key=lambda path: path.stat().st_mtime, reverse=True)
+    return jars[0] if jars else None
+
+
+def _java_executable() -> Path | None:
+    for candidate in _java_candidates():
+        return candidate
+    return None
+
+
+def _java_candidates() -> list[Path]:
+    java_name = "java.exe" if os.name == "nt" else "java"
+    candidates: list[Path] = []
+
+    java_exe = os.environ.get("JAVA_EXE")
+    if java_exe:
+        java_path = Path(java_exe).expanduser()
+        if java_path.exists():
+            candidates.append(java_path)
+
+    java_home = os.environ.get("JAVA_HOME")
+    if java_home:
+        java_path = Path(java_home).expanduser() / "bin" / java_name
+        if java_path.exists():
+            candidates.append(java_path)
+
+    local_cache = PROJECT_ROOT / ".cache" / "java"
+    local_candidates = [candidate for candidate in local_cache.glob(f"**/bin/{java_name}") if candidate.exists()]
+    if os.name != "nt":
+        local_candidates.extend(
+            candidate for candidate in local_cache.glob("**/bin/java.exe") if candidate.exists()
+        )
+    local_candidates.sort(key=lambda candidate: _java_major_version(candidate) or 0, reverse=True)
+    candidates.extend(local_candidates)
+
+    path_java = shutil.which("java")
+    if path_java:
+        candidates.append(Path(path_java))
+
+    deduped: list[Path] = []
+    seen: set[Path] = set()
+    for candidate in candidates:
+        resolved = candidate.resolve()
+        if resolved not in seen:
+            deduped.append(candidate)
+            seen.add(resolved)
+
+    return deduped
+
+
+def _java_major_version(java_executable: Path) -> int | None:
+    try:
+        result = subprocess.run(
+            [str(java_executable), "-version"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=10,
+        )
+    except (FileNotFoundError, subprocess.SubprocessError, OSError):
+        return None
+
+    version_output = result.stderr or result.stdout
+    match = re.search(r'version "(?P<version>[^"]+)"', version_output)
+    if not match:
+        return None
+
+    version = match.group("version")
+    if version.startswith("1."):
+        parts = version.split(".")
+        return int(parts[1]) if len(parts) > 1 and parts[1].isdigit() else None
+
+    major = version.split(".", 1)[0]
+    return int(major) if major.isdigit() else None
+
+
+def _miniwdl_command() -> ValidatorCommand | None:
+    executable = _miniwdl_executable()
+    if executable is None or not miniwdl_available():
+        return None
+    return ValidatorCommand(
+        name="miniwdl",
+        label="miniwdl",
+        command=[executable, "check"],
+    )
 
 
 def _miniwdl_executable() -> str | None:
@@ -84,8 +256,12 @@ def _miniwdl_executable() -> str | None:
     return None
 
 
-def _missing_miniwdl_result() -> dict:
+def _missing_validator_result() -> dict:
     return {
         "is_valid": False,
-        "message": "❌ 未找到 miniwdl 可执行文件，请先安装依赖或使用 `uv run` 执行。"
+        "message": (
+            f"❌ {VALIDATOR_MISSING_MARKER}。请运行 `scripts/install_java.ps1` 和 "
+            "`scripts/install_womtool.ps1` 下载 Java 17+ 与 WOMtool，或设置 "
+            "`JAVA_HOME` / `JAVA_EXE` / `WOMTOOL_JAR` 指向本地工具。"
+        ),
     }

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,7 +1,6 @@
 import unittest
 
-from src.tools.validator import miniwdl_available, wdl_validator
-
+from src.tools.validator import wdl_validator, wdl_validator_available
 
 VALID_WDL = """
 version 1.0
@@ -42,13 +41,13 @@ task fastp_qc {
 
 
 class ValidatorTests(unittest.TestCase):
-    @unittest.skipIf(not miniwdl_available(), "miniwdl is not installed")
+    @unittest.skipIf(not wdl_validator_available(), "WDL validator is not installed")
     def test_validator_accepts_valid_wdl(self):
         result = wdl_validator.invoke({"wdl_code": VALID_WDL})
 
         self.assertTrue(result["is_valid"], result["message"])
 
-    @unittest.skipIf(not miniwdl_available(), "miniwdl is not installed")
+    @unittest.skipIf(not wdl_validator_available(), "WDL validator is not installed")
     def test_validator_rejects_invalid_wdl(self):
         result = wdl_validator.invoke({"wdl_code": "workflow Bad {"})
 

--- a/tools/womtool/README.md
+++ b/tools/womtool/README.md
@@ -1,0 +1,31 @@
+# WOMtool
+
+This directory documents the local WOMtool setup. Do not commit the WOMtool
+JAR into the repository.
+
+Use the installer script from the repository root:
+
+```powershell
+scripts/install_womtool.ps1
+```
+
+By default it downloads `womtool-91.jar` from the Broad Institute Cromwell
+GitHub releases and stores it under:
+
+```text
+.cache/womtool/womtool.jar
+```
+
+The validator discovers the JAR automatically from that cache path. You can
+override it with:
+
+```env
+WOMTOOL_JAR="D:/path/to/womtool.jar"
+```
+
+The default WOMtool 91 release needs Java 17 or newer. For a project-local
+Temurin JDK:
+
+```powershell
+scripts/install_java.ps1
+```

--- a/uv.lock
+++ b/uv.lock
@@ -13,9 +13,13 @@ dependencies = [
     { name = "langchain-deepseek" },
     { name = "langchain-openai" },
     { name = "langgraph" },
-    { name = "miniwdl" },
     { name = "python-dotenv" },
     { name = "pyyaml" },
+]
+
+[package.optional-dependencies]
+miniwdl = [
+    { name = "miniwdl" },
 ]
 
 [package.dev-dependencies]
@@ -31,10 +35,11 @@ requires-dist = [
     { name = "langchain-deepseek", specifier = ">=1.0.1" },
     { name = "langchain-openai", specifier = ">=1.2.1" },
     { name = "langgraph", specifier = ">=1.1.10" },
-    { name = "miniwdl", specifier = ">=1.14.2" },
+    { name = "miniwdl", marker = "extra == 'miniwdl'", specifier = ">=1.14.2" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "pyyaml", specifier = ">=6.0.3" },
 ]
+provides-extras = ["miniwdl"]
 
 [package.metadata.requires-dev]
 dev = [{ name = "isort", specifier = ">=8.0.1" }]


### PR DESCRIPTION
## Summary

- Switch the default WDL validation path from miniwdl to WOMtool so Windows-native development can validate generated WDL without the miniwdl `fcntl` failure.
- Add PowerShell installers for project-local Temurin Java 17 and WOMtool 91 under `.cache`.
- Keep miniwdl as an optional extra/fallback while updating tests and documentation for the WOMtool-first path.

## Why

miniwdl imports POSIX-only modules on Windows, so the validator can fail before it reaches WDL checking. WOMtool runs via Java and is a better Windows-native validation backend for this project.

## Validation

- `uv run python -m unittest`
- `git log -1 --show-signature --format=fuller`