### PR TITLE
Add W0 workflow service layer

### DIFF
--- a/docs/test-cases.md
+++ b/docs/test-cases.md
@@ -33,7 +33,7 @@ Recipe Tool Plan / Workflow IR / Legacy JSON
 
 ```text
 uv run python -m unittest discover -v
-Ran 53 tests
+Ran 55 tests
 OK (skipped=1)
 ```
 
@@ -783,6 +783,29 @@ files = flatten([qc.html_report, qc.json_report, [extra_report]])
 - 结构化 Workflow IR 入口不会触发自然语言 planner。
 - service 能区分 Recipe Tool Plan 与标准 Workflow IR。
 
+### `test_compile_structured_workflow_without_check_does_not_invoke_graph`
+
+输入：
+
+- `examples/rnaseq_deg_recipe_plan.json`
+- `check=False`
+- mock `src.services.workflow_service.agent.invoke`，如果被调用则抛出错误。
+
+执行：
+
+- 调用 `compile_structured_workflow(plan, check=False)`。
+
+期望输出：
+
+- `result.succeeded == True`。
+- `result.check_performed == False`。
+- compiled graph 的 `agent.invoke` 未被调用。
+
+覆盖点：
+
+- `check=False` 路径走手动 deterministic compiler nodes。
+- 跳过 checker 时不会进入包含 checker 的 compiled graph。
+
 ### `test_compile_structured_workflow_returns_diagnostics_for_invalid_plan`
 
 输入：
@@ -1060,7 +1083,7 @@ qc.html_report + qc.json_report
 
 ## `tests/test_cli.py`
 
-该文件验证 `main.py` CLI 层，包括文件读取、自然语言入口、结构化输入入口、stdout/stderr 隔离和失败处理。自然语言相关测试使用 mock planner，不真实调用外部 LLM。
+该文件验证 `main.py` CLI 层，包括文件读取、自然语言入口、结构化输入入口、stdout/stderr 隔离和失败处理。自然语言相关测试 mock workflow service，不真实调用外部 LLM。
 
 ### `test_load_workflow_input_reads_recipe_plan_example`
 
@@ -1114,7 +1137,7 @@ qc.html_report + qc.json_report
 --no-check
 ```
 
-- mock `main.create_natural_language_plan` 返回合法 RNA-seq plan。
+- mock `main.plan_and_compile_workflow` 返回合法 RNA-seq plan 的编译结果。
 
 执行：
 
@@ -1123,16 +1146,46 @@ qc.html_report + qc.json_report
 期望输出：
 
 - exit code 为 `0`。
-- mock planner 被调用一次。
+- mock workflow service 被调用一次。
 - stdout 包含 plan JSON 片段 `"recipe": "rnaseq_differential_expression"`。
 - 输出文件 `<tmp>/rnaseq_deg.wdl` 包含 `workflow RNASeqDEG`。
 
 覆盖点：
 
-- 自然语言 CLI 入口可以通过 planner 产物进入编译链路。
+- 自然语言 CLI 入口通过 workflow service 进入规划和编译链路。
 - `--print-plan` 将 plan 输出到 stdout。
 - `--output` 将 WDL 写入文件。
 - `--no-check` 跳过 WDL checker。
+
+### `test_cli_structured_input_uses_structured_service_without_planner`
+
+输入：
+
+- CLI args：
+
+```text
+--input examples/rnaseq_deg_recipe_plan.json
+--no-check
+```
+
+- mock `main.compile_structured_workflow` 返回合法 RNA-seq plan 的编译结果。
+- mock `main.plan_and_compile_workflow`。
+
+执行：
+
+- 调用 `cli.main(...)`。
+
+期望输出：
+
+- exit code 为 `0`。
+- `compile_structured_workflow` 被调用一次，参数为读取到的 plan 和 `check=False`。
+- `plan_and_compile_workflow` 不被调用。
+- stdout 以 `version 1.0\n` 开头。
+
+覆盖点：
+
+- 结构化 CLI 入口直接调用 workflow service 的结构化编译接口。
+- `--input` 路径不会触发自然语言规划服务。
 
 ### `test_cli_saves_natural_language_plan_and_planner_prompt`
 
@@ -1149,7 +1202,7 @@ qc.html_report + qc.json_report
 ```
 
 - mock `build_default_planner_prompt` 返回 `planner prompt`。
-- mock `create_natural_language_plan` 返回合法 RNA-seq plan 和同一 prompt。
+- mock `plan_and_compile_workflow` 返回合法 RNA-seq plan 的编译结果。
 
 执行：
 
@@ -1179,7 +1232,7 @@ qc.html_report + qc.json_report
 --prompt "Run RNA-seq differential expression."
 ```
 
-- mock `create_natural_language_plan` 抛出 `NaturalLanguagePlanningError("LLM planner JSON parsing failed: bad json")`。
+- mock `plan_and_compile_workflow` 抛出 `NaturalLanguagePlanningError("LLM planner JSON parsing failed: bad json")`。
 
 执行：
 
@@ -1195,7 +1248,7 @@ qc.html_report + qc.json_report
 
 覆盖点：
 
-- 自然语言 planner 失败时 CLI 返回失败状态，并把错误写到 stderr。
+- 自然语言 workflow service 失败时 CLI 返回失败状态，并把错误写到 stderr。
 
 ### `test_cli_saves_planner_prompt_even_when_planning_fails`
 
@@ -1209,7 +1262,7 @@ qc.html_report + qc.json_report
 ```
 
 - mock `build_default_planner_prompt` 返回 `planner prompt`。
-- mock `create_natural_language_plan` 抛出 JSON parsing 失败。
+- mock `plan_and_compile_workflow` 抛出 JSON parsing 失败。
 
 执行：
 

--- a/docs/test-cases.md
+++ b/docs/test-cases.md
@@ -29,6 +29,16 @@ Recipe Tool Plan / Workflow IR / Legacy JSON
 - `tests/test_tools.py`：没有 WOMtool 或 miniwdl 时跳过 WDL validator 测试。
 - `tests/test_tiny_run.py`：没有 miniwdl、Docker/Podman、本地镜像或 tiny 输入文件时跳过真实 tiny run。
 
+当前 W0 服务层改动后的最近一次完整验证结果：
+
+```text
+uv run python -m unittest discover -v
+Ran 53 tests
+OK (skipped=1)
+```
+
+跳过项为 `tests/test_tiny_run.py` 中依赖 miniwdl 真实执行环境的 tiny run。
+
 ## 公共测试输入
 
 ### RNA-seq Recipe Tool Plan
@@ -329,6 +339,142 @@ report_files = flatten([qc.html_report, qc.json_report, quantify.log_file])
 
 - Catalog output tags 可以驱动 MultiQC 输入自动收集。
 
+## `tests/test_catalog_service.py`
+
+该文件验证 W0 catalog 查询服务。服务层返回 JSON-ready 的 recipe/tool 记录，供 W1 FastAPI 的 catalog 查询端点复用。
+
+### `test_list_recipes_returns_json_ready_recipe_records`
+
+输入：
+
+- 当前正式 Recipe Catalog。
+- 当前正式 Tool Catalog。
+
+执行：
+
+- 调用 `list_recipes()`。
+
+期望输出：
+
+- 返回至少一个 recipe。
+- 第一个 recipe 的 `id` 为 `rnaseq_differential_expression`。
+- 记录包含 `required_inputs` 和 `steps`。
+- 第一个 step 的 `id` 为 `qc`。
+- 第一个 step 的 `allowed_tools` 包含 `fastp`。
+
+覆盖点：
+
+- Catalog service 能返回 API 友好的 recipe 列表。
+- Recipe step 与 allowed tools 信息可直接供前端或 API 响应使用。
+
+### `test_get_recipe_returns_named_recipe`
+
+输入：
+
+- recipe id：`rnaseq_differential_expression`。
+
+执行：
+
+- 调用 `get_recipe("rnaseq_differential_expression")`。
+
+期望输出：
+
+- recipe `name` 为 `RNA-seq differential expression`。
+- `required_inputs["sample_ids"]["type"] == "Array[String]"`。
+- 第一个 step 的 scatter metadata 中 `id == "per_sample"`。
+
+覆盖点：
+
+- Catalog service 能查询单个 recipe。
+- scatter metadata 被保留为 JSON-ready dict，便于后续 DAG/API 展示。
+
+### `test_list_tools_returns_json_ready_tool_records`
+
+输入：
+
+- 当前正式 Tool Catalog。
+
+执行：
+
+- 调用 `list_tools()`。
+
+期望输出：
+
+- 返回至少 5 个 tool 记录。
+- `fastp` 记录中：
+  - `version == "0.23.2"`
+  - `runtime["docker"] == "quay.io/biocontainers/fastp:0.23.2"`
+  - `trust_status == "catalog-approved"`
+  - `outputs` 包含 `clean_r1`
+
+覆盖点：
+
+- Tool runtime docker 从 Catalog 权威来源读取。
+- API-facing tool 记录包含 container trust status。
+
+### `test_get_tool_returns_explicit_version`
+
+输入：
+
+- tool id：`salmon`
+- version：`1.10.2`
+
+执行：
+
+- 调用 `get_tool("salmon", "1.10.2")`。
+
+期望输出：
+
+- 返回 tool `id == "salmon"`。
+- 返回 tool `version == "1.10.2"`。
+- `inputs["r1"]["type"] == "File"`。
+- `versions` 包含 `1.10.2`。
+
+覆盖点：
+
+- Catalog service 支持按 tool id 和 version 精确查询。
+
+### `test_get_tool_defaults_to_highest_catalog_version`
+
+输入：
+
+- tool id：`multiqc`
+- 不指定 version。
+
+执行：
+
+- 调用 `get_tool("multiqc")`。
+
+期望输出：
+
+- 返回 tool `id == "multiqc"`。
+- 返回 tool `version == "1.21"`。
+
+覆盖点：
+
+- 未指定版本时，Catalog service 选择当前 catalog 中最高版本。
+
+### `test_unknown_recipe_and_tool_raise_key_error`
+
+输入：
+
+- recipe id：`missing_recipe`
+- tool id：`missing_tool`
+
+执行：
+
+1. 调用 `get_recipe("missing_recipe")`。
+2. 调用 `get_tool("missing_tool")`。
+
+期望输出：
+
+- 未知 recipe 抛出 `KeyError`，错误消息包含 `unknown recipe`。
+- 未知 tool 抛出 `KeyError`，错误消息包含 `unknown tool`。
+
+覆盖点：
+
+- API 层后续可以将未知 catalog 资源稳定映射为 404。
+
 ## `tests/test_graph.py`
 
 该文件验证 Compiler Graph、Analyzer、Renderer 和 deterministic repairer 的交互。
@@ -584,6 +730,133 @@ files = flatten([qc.html_report, qc.json_report, [extra_report]])
 覆盖点：
 
 - Compiler Graph 可以直接接收 Recipe Tool Plan 并完成 normalizer -> analyzer -> renderer -> checker 流程。
+
+## `tests/test_workflow_service.py`
+
+该文件验证 W0 workflow application service。服务层用于让 CLI 和未来 FastAPI 复用同一套编译入口，避免 API 层复制 `main.py` 中的业务逻辑。
+
+### `test_compile_structured_workflow_compiles_recipe_plan_without_check`
+
+输入：
+
+- `examples/rnaseq_deg_recipe_plan.json`
+- `check=False`
+
+执行：
+
+- 调用 `compile_structured_workflow(plan, check=False)`。
+
+期望输出：
+
+- `result.succeeded == True`。
+- `result.plan is plan`。
+- `result.workflow_ir["workflow"]["name"] == "RNASeqDEG"`。
+- `result.wdl` 包含 `workflow RNASeqDEG`。
+- `result.validation_message == "WDL syntax validation skipped (--no-check)."`。
+- `result.check_performed == False`。
+
+覆盖点：
+
+- 结构化 Recipe Tool Plan 可以通过 service 入口完成 IR 标准化、分析和 WDL 渲染。
+- 跳过 checker 时仍返回稳定的成功状态和 validation message。
+
+### `test_compile_structured_workflow_compiles_workflow_ir_without_plan`
+
+输入：
+
+- `examples/rnaseq_workflow_ir.json`
+- `check=False`
+
+执行：
+
+- 调用 `compile_structured_workflow(workflow_ir, check=False)`。
+
+期望输出：
+
+- `result.succeeded == True`。
+- `result.plan is None`。
+- `result.workflow_ir["workflow"]["name"] == "RNASeqPipeline"`。
+- `result.wdl` 包含 `workflow RNASeqPipeline`。
+
+覆盖点：
+
+- 结构化 Workflow IR 入口不会触发自然语言 planner。
+- service 能区分 Recipe Tool Plan 与标准 Workflow IR。
+
+### `test_compile_structured_workflow_returns_diagnostics_for_invalid_plan`
+
+输入：
+
+- 复制 `examples/rnaseq_deg_recipe_plan.json`。
+- 删除 workflow input `sample_groups`。
+- `check=False`
+
+执行：
+
+- 调用 `compile_structured_workflow(plan, check=False)`。
+
+期望输出：
+
+- `result.succeeded == False`。
+- `result.wdl == ""`。
+- `result.analysis_errors` 包含 `missing required workflow input 'sample_groups'`。
+
+覆盖点：
+
+- service 不吞掉 resolver/catalog 诊断。
+- 无效 plan 不会产生 WDL。
+
+### `test_plan_and_compile_workflow_plans_then_compiles`
+
+输入：
+
+- 用户请求：`Run bulk RNA-seq differential expression.`
+- `FakePlannerLlm` 返回 RNA-seq Recipe Tool Plan JSON。
+- `check=False`
+
+执行：
+
+- 调用 `plan_and_compile_workflow(..., llm=fake_llm, check=False)`。
+
+期望输出：
+
+- `result.succeeded == True`。
+- `result.plan` 等于 mock LLM 返回的 plan。
+- `result.planner_prompt` 包含 `Catalog:`。
+- `result.planner_raw_response` 包含 `RNASeqDEG`。
+- `result.wdl` 包含 `workflow RNASeqDEG`。
+- fake LLM 只被调用一次。
+
+覆盖点：
+
+- 自然语言入口先生成 Recipe Tool Plan，再进入确定性编译链路。
+- LLM 仍不直接生成最终 WDL。
+- planner observability 信息被 service 结果保留。
+
+### `test_result_to_dict_exposes_json_ready_service_fields`
+
+输入：
+
+- `examples/rnaseq_deg_recipe_plan.json`
+- `check=False`
+
+执行：
+
+1. 调用 `compile_structured_workflow(plan, check=False)`。
+2. 调用 `result.to_dict()`。
+
+期望输出：
+
+- dict 中 `plan` 等于输入 plan。
+- dict 中 `workflow_ir` 包含 `workflow`。
+- dict 中 `wdl` 包含 `workflow RNASeqDEG`。
+- dict 中 `analysis_errors == []`。
+- dict 中 `succeeded == True`。
+
+覆盖点：
+
+- `WorkflowCompilationResult` 可以转换为 API 友好的 dict。
+- API 层后续可以稳定读取 plan、IR、WDL、diagnostics 和状态字段。
 
 ## `tests/test_nl_planner.py`
 
@@ -1166,9 +1439,11 @@ miniwdl run <tmp>/rnaseq_deg.wdl -i examples/tiny/rnaseq_deg.inputs.json --dir <
 - Recipe Tool Plan schema 与 recipe/catalog 校验。
 - Catalog runtime docker 必填约束。
 - Recipe Tool Plan 到 Workflow IR 的 resolver 主路径。
+- Catalog 查询服务的 recipe/tool JSON-ready 输出。
 - Analyzer 对引用、optional input、scatter output 类型提升的处理。
 - Renderer 对 call、scatter、array flatten、workflow output 和 task 的 WDL 渲染。
 - Deterministic repairer 对 call 顺序和 output 字面量的安全修复。
+- Workflow service 对结构化编译入口、自然语言规划后编译入口和 API 友好结果对象的封装。
 - CLI 的自然语言入口、结构化入口、文件输出、stdout/stderr 隔离和失败返回。
 - Planner 的 JSON 解析、prompt 构建、schema 错误和 catalog 错误归类。
 - WDL validator wrapper 和可选 miniwdl tiny run。

--- a/main.py
+++ b/main.py
@@ -12,9 +12,12 @@ from src.nl_planner import (
     DEFAULT_PLANNER_MODEL,
     NaturalLanguagePlanningError,
     build_default_planner_prompt,
-    create_natural_language_plan,
 )
-from src.services.workflow_service import compile_workflow, workflow_succeeded
+from src.services.workflow_service import (
+    compile_structured_workflow,
+    compile_workflow,
+    plan_and_compile_workflow,
+)
 from src.state import WorkflowState
 
 
@@ -221,24 +224,29 @@ def main(argv: list[str] | None = None) -> int:
         if args.input:
             parsed_json = load_workflow_input(args.input)
             planned_from_natural_language = False
+            result = compile_structured_workflow(
+                parsed_json,
+                check=check,
+            )
         else:
             prompt = load_prompt(args.prompt, args.prompt_file)
             if args.save_planner_prompt:
                 write_text_output(args.save_planner_prompt, build_default_planner_prompt(prompt))
                 print(f"Planner prompt written to {args.save_planner_prompt}", file=sys.stderr)
 
-            plan_result = create_natural_language_plan(prompt, model=args.planner_model)
-            parsed_json = plan_result.plan
+            result = plan_and_compile_workflow(
+                prompt,
+                model=args.planner_model,
+                check=check,
+            )
+            parsed_json = result.plan or {}
             planned_from_natural_language = True
 
             if args.save_plan:
                 write_json_output(args.save_plan, parsed_json)
                 print(f"Planner plan written to {args.save_plan}", file=sys.stderr)
 
-        final_state = compile_workflow(
-            parsed_json,
-            check=check,
-        )
+        final_state = result.state
     except NaturalLanguagePlanningError as exc:
         print(f"Natural language planning failed: {exc}", file=sys.stderr)
         return 1
@@ -251,17 +259,17 @@ def main(argv: list[str] | None = None) -> int:
     if args.print_plan and planned_from_natural_language:
         print(json.dumps(parsed_json, indent=2, ensure_ascii=False))
 
-    if args.print_ir and final_state["workflow_ir"]:
-        print(json.dumps(final_state["workflow_ir"], indent=2, ensure_ascii=False))
+    if args.print_ir and result.workflow_ir:
+        print(json.dumps(result.workflow_ir, indent=2, ensure_ascii=False))
 
-    if not workflow_succeeded(final_state, check=check):
+    if not result.succeeded:
         return 1
 
     if args.output:
-        write_wdl_output(args.output, final_state["current_wdl"])
+        write_wdl_output(args.output, result.wdl)
         print(f"WDL written to {args.output}", file=sys.stderr)
     else:
-        print(final_state["current_wdl"])
+        print(result.wdl)
 
     return 0
 

--- a/main.py
+++ b/main.py
@@ -3,22 +3,18 @@ import json
 import logging
 import sys
 from pathlib import Path
-from typing import Any, Mapping, cast
+from typing import Any
 
 import yaml
 from dotenv import load_dotenv
 
-from src.graph import agent
 from src.nl_planner import (
     DEFAULT_PLANNER_MODEL,
     NaturalLanguagePlanningError,
     build_default_planner_prompt,
     create_natural_language_plan,
 )
-from src.nodes.analyzer import analyzer_node
-from src.nodes.ir_normalizer import ir_normalizer_node
-from src.nodes.renderer import renderer_node
-from src.nodes.repairer import repairer_node
+from src.services.workflow_service import compile_workflow, workflow_succeeded
 from src.state import WorkflowState
 
 
@@ -201,45 +197,6 @@ def load_prompt(prompt: str | None = None, prompt_file: Path | None = None) -> s
     return DEMO_PROMPT
 
 
-def build_initial_state(
-    parsed_json: dict[str, Any],
-) -> WorkflowState:
-    return {
-        "parsed_json": parsed_json,
-        "workflow_ir": {},
-        "analysis_errors": [],
-        "analysis_warnings": [],
-        "messages": [],
-        "current_wdl": "",
-        "validation_message": "",
-        "error_count": 0,
-        "repair_count": 0,
-        "repair_actions": [],
-        "is_valid": False,
-    }
-
-
-def compile_workflow(
-    parsed_json: dict[str, Any],
-    check: bool = True,
-) -> WorkflowState:
-    state = build_initial_state(parsed_json)
-    if check:
-        return cast(WorkflowState, agent.invoke(state))
-
-    _merge_state(state, ir_normalizer_node(state))
-    if state["analysis_errors"]:
-        return state
-
-    _analyze_with_repair(state)
-    if state["analysis_errors"]:
-        return state
-
-    _merge_state(state, renderer_node(state))
-    state["validation_message"] = "WDL syntax validation skipped (--no-check)."
-    return state
-
-
 def write_wdl_output(path: Path, wdl_code: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(wdl_code, encoding="utf-8")
@@ -253,14 +210,6 @@ def write_json_output(path: Path, data: dict[str, Any]) -> None:
 def write_text_output(path: Path, text: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(text, encoding="utf-8")
-
-
-def workflow_succeeded(state: WorkflowState, check: bool) -> bool:
-    if state["analysis_errors"]:
-        return False
-    if not state["current_wdl"]:
-        return False
-    return state["is_valid"] if check else True
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -324,43 +273,6 @@ def configure_logging(verbose: bool = False) -> None:
         stream=sys.stderr,
         force=True,
     )
-
-
-def _analyze_with_repair(state: WorkflowState) -> None:
-    while True:
-        _merge_state(state, analyzer_node(state))
-        if not state["analysis_errors"]:
-            return
-
-        _merge_state(state, repairer_node(state))
-        if not state["repair_actions"]:
-            return
-
-
-def _merge_state(state: WorkflowState, update: Mapping[str, Any]) -> None:
-    for key, value in update.items():
-        if key == "messages":
-            state["messages"] = state["messages"] + value
-        elif key == "parsed_json":
-            state["parsed_json"] = value
-        elif key == "workflow_ir":
-            state["workflow_ir"] = value
-        elif key == "analysis_errors":
-            state["analysis_errors"] = value
-        elif key == "analysis_warnings":
-            state["analysis_warnings"] = value
-        elif key == "current_wdl":
-            state["current_wdl"] = value
-        elif key == "validation_message":
-            state["validation_message"] = value
-        elif key == "error_count":
-            state["error_count"] = value
-        elif key == "repair_count":
-            state["repair_count"] = value
-        elif key == "repair_actions":
-            state["repair_actions"] = value
-        elif key == "is_valid":
-            state["is_valid"] = value
 
 
 def _print_report(state: WorkflowState, check: bool) -> None:

--- a/src/services/__init__.py
+++ b/src/services/__init__.py
@@ -1,0 +1,17 @@
+"""Application services shared by CLI and future API layers."""
+
+from src.services.workflow_service import (
+    WorkflowCompilationResult,
+    compile_structured_workflow,
+    compile_workflow,
+    plan_and_compile_workflow,
+    workflow_succeeded,
+)
+
+__all__ = [
+    "WorkflowCompilationResult",
+    "compile_structured_workflow",
+    "compile_workflow",
+    "plan_and_compile_workflow",
+    "workflow_succeeded",
+]

--- a/src/services/__init__.py
+++ b/src/services/__init__.py
@@ -1,5 +1,6 @@
 """Application services shared by CLI and future API layers."""
 
+from src.services.catalog_service import get_recipe, get_tool, list_recipes, list_tools
 from src.services.workflow_service import (
     WorkflowCompilationResult,
     compile_structured_workflow,
@@ -12,6 +13,10 @@ __all__ = [
     "WorkflowCompilationResult",
     "compile_structured_workflow",
     "compile_workflow",
+    "get_recipe",
+    "get_tool",
+    "list_recipes",
+    "list_tools",
     "plan_and_compile_workflow",
     "workflow_succeeded",
 ]

--- a/src/services/catalog_service.py
+++ b/src/services/catalog_service.py
@@ -1,2 +1,127 @@
 """Catalog query service for recipes and approved tools."""
 
+import re
+from typing import Any
+
+from src.catalog.loader import ToolCatalog, load_tool_catalog
+from src.catalog.schema import ToolSpec
+from src.recipes.loader import RecipeCatalog, load_recipe_catalog
+from src.recipes.schema import RecipeSpec
+
+CATALOG_APPROVED_TRUST_STATUS = "catalog-approved"
+
+
+def list_recipes(
+    *,
+    recipe_catalog: RecipeCatalog | None = None,
+    tool_catalog: ToolCatalog | None = None,
+) -> list[dict[str, Any]]:
+    """Return all supported recipes as JSON-ready API records."""
+    recipe_catalog = _recipe_catalog(recipe_catalog, tool_catalog)
+    return [_recipe_to_record(recipe) for recipe in sorted(recipe_catalog.all(), key=lambda recipe: recipe.id)]
+
+
+def get_recipe(
+    recipe_id: str,
+    *,
+    recipe_catalog: RecipeCatalog | None = None,
+    tool_catalog: ToolCatalog | None = None,
+) -> dict[str, Any]:
+    """Return one supported recipe as a JSON-ready API record."""
+    recipe_catalog = _recipe_catalog(recipe_catalog, tool_catalog)
+    return _recipe_to_record(recipe_catalog.get(recipe_id))
+
+
+def list_tools(
+    *,
+    tool_catalog: ToolCatalog | None = None,
+) -> list[dict[str, Any]]:
+    """Return all approved tools as JSON-ready API records."""
+    tool_catalog = tool_catalog or load_tool_catalog()
+    tools = sorted(tool_catalog.all(), key=lambda tool: (tool.id, _version_sort_key(tool.version)))
+    return [_tool_to_record(tool, tool_catalog=tool_catalog) for tool in tools]
+
+
+def get_tool(
+    tool_id: str,
+    version: str | None = None,
+    *,
+    tool_catalog: ToolCatalog | None = None,
+) -> dict[str, Any]:
+    """Return one approved tool version as a JSON-ready API record."""
+    tool_catalog = tool_catalog or load_tool_catalog()
+    selected_version = version or _latest_tool_version(tool_catalog, tool_id)
+    return _tool_to_record(tool_catalog.get(tool_id, selected_version), tool_catalog=tool_catalog)
+
+
+def _recipe_catalog(
+    recipe_catalog: RecipeCatalog | None,
+    tool_catalog: ToolCatalog | None,
+) -> RecipeCatalog:
+    if recipe_catalog is not None:
+        return recipe_catalog
+    tool_catalog = tool_catalog or load_tool_catalog()
+    return load_recipe_catalog(tool_catalog=tool_catalog)
+
+
+def _recipe_to_record(recipe: RecipeSpec) -> dict[str, Any]:
+    return {
+        "id": recipe.id,
+        "name": recipe.name,
+        "description": recipe.description,
+        "aliases": recipe.aliases,
+        "required_inputs": {
+            input_name: spec.model_dump(mode="json", exclude_none=True)
+            for input_name, spec in sorted(recipe.required_inputs.items())
+        },
+        "steps": [
+            {
+                "id": step.id,
+                "role": step.role,
+                "optional": step.optional,
+                "scatter": step.scatter.model_dump(mode="json", exclude_none=True) if step.scatter else None,
+                "allowed_tools": sorted(step.allowed_tools),
+            }
+            for step in recipe.steps
+        ],
+    }
+
+
+def _tool_to_record(tool: ToolSpec, *, tool_catalog: ToolCatalog) -> dict[str, Any]:
+    return {
+        "id": tool.id,
+        "version": tool.version,
+        "versions": tool_catalog.versions(tool.id),
+        "aliases": tool.aliases,
+        "description": tool.description,
+        "inputs": {
+            input_name: spec.model_dump(mode="json", exclude_none=True)
+            for input_name, spec in sorted(tool.inputs.items())
+        },
+        "params": {
+            param_name: spec.model_dump(mode="json", exclude_none=True)
+            for param_name, spec in sorted(tool.params.items())
+        },
+        "outputs": {
+            output_name: spec.model_dump(mode="json", exclude_none=True)
+            for output_name, spec in sorted(tool.outputs.items())
+        },
+        "runtime": tool.runtime.model_dump(mode="json", exclude_none=True),
+        "trust_status": CATALOG_APPROVED_TRUST_STATUS,
+    }
+
+
+def _latest_tool_version(tool_catalog: ToolCatalog, tool_id: str) -> str:
+    versions = tool_catalog.versions(tool_id)
+    if not versions:
+        raise KeyError(f"unknown tool: {tool_id}")
+    return max(versions, key=_version_sort_key)
+
+
+def _version_sort_key(version: str) -> tuple[Any, ...]:
+    parts: list[Any] = []
+    for part in re.split(r"([0-9]+)", version):
+        if not part:
+            continue
+        parts.append(int(part) if part.isdigit() else part)
+    return tuple(parts)

--- a/src/services/catalog_service.py
+++ b/src/services/catalog_service.py
@@ -1,0 +1,2 @@
+"""Catalog query service for recipes and approved tools."""
+

--- a/src/services/workflow_service.py
+++ b/src/services/workflow_service.py
@@ -1,0 +1,209 @@
+"""Workflow planning and compilation service entry points."""
+
+from dataclasses import dataclass
+from typing import Any, Mapping, cast
+
+from src.catalog.loader import ToolCatalog
+from src.graph import agent
+from src.nl_planner import DEFAULT_PLANNER_MODEL, PlannerLlm, create_natural_language_plan
+from src.nodes.analyzer import analyzer_node
+from src.nodes.ir_normalizer import ir_normalizer_node
+from src.nodes.renderer import renderer_node
+from src.nodes.repairer import repairer_node
+from src.recipes.loader import RecipeCatalog
+from src.state import WorkflowState
+
+
+@dataclass(frozen=True)
+class WorkflowCompilationResult:
+    """Stable service result for CLI, API, and future UI callers."""
+
+    plan: dict[str, Any] | None
+    workflow_ir: dict[str, Any]
+    wdl: str
+    analysis_errors: list[str]
+    analysis_warnings: list[str]
+    repair_actions: list[str]
+    validation_message: str
+    is_valid: bool
+    succeeded: bool
+    check_performed: bool
+    state: WorkflowState
+    planner_prompt: str | None = None
+    planner_raw_response: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "plan": self.plan,
+            "workflow_ir": self.workflow_ir,
+            "wdl": self.wdl,
+            "analysis_errors": self.analysis_errors,
+            "analysis_warnings": self.analysis_warnings,
+            "repair_actions": self.repair_actions,
+            "validation_message": self.validation_message,
+            "is_valid": self.is_valid,
+            "succeeded": self.succeeded,
+            "check_performed": self.check_performed,
+            "planner_prompt": self.planner_prompt,
+            "planner_raw_response": self.planner_raw_response,
+        }
+
+
+def compile_structured_workflow(
+    parsed_json: dict[str, Any],
+    check: bool = True,
+) -> WorkflowCompilationResult:
+    """Compile a Recipe Tool Plan or Workflow IR without natural-language planning."""
+    state = _run_compiler(parsed_json, check=check)
+    plan = parsed_json if _is_recipe_tool_plan(parsed_json) else None
+    return _result_from_state(state, plan=plan, check=check)
+
+
+def plan_and_compile_workflow(
+    request: str,
+    *,
+    model: str = DEFAULT_PLANNER_MODEL,
+    check: bool = True,
+    llm: PlannerLlm | None = None,
+    tool_catalog: ToolCatalog | None = None,
+    recipe_catalog: RecipeCatalog | None = None,
+) -> WorkflowCompilationResult:
+    """Plan from natural language, then compile the resulting Recipe Tool Plan."""
+    plan_result = create_natural_language_plan(
+        request,
+        model=model,
+        llm=llm,
+        tool_catalog=tool_catalog,
+        recipe_catalog=recipe_catalog,
+    )
+    state = _run_compiler(plan_result.plan, check=check)
+    return _result_from_state(
+        state,
+        plan=plan_result.plan,
+        check=check,
+        planner_prompt=plan_result.planner_prompt,
+        planner_raw_response=plan_result.raw_response,
+    )
+
+
+def build_initial_state(
+    parsed_json: dict[str, Any],
+) -> WorkflowState:
+    return {
+        "parsed_json": parsed_json,
+        "workflow_ir": {},
+        "analysis_errors": [],
+        "analysis_warnings": [],
+        "messages": [],
+        "current_wdl": "",
+        "validation_message": "",
+        "error_count": 0,
+        "repair_count": 0,
+        "repair_actions": [],
+        "is_valid": False,
+    }
+
+
+def compile_workflow(
+    parsed_json: dict[str, Any],
+    check: bool = True,
+) -> WorkflowState:
+    return compile_structured_workflow(parsed_json, check=check).state
+
+
+def _run_compiler(
+    parsed_json: dict[str, Any],
+    check: bool = True,
+) -> WorkflowState:
+    state = build_initial_state(parsed_json)
+    if check:
+        return cast(WorkflowState, agent.invoke(state))
+
+    _merge_state(state, ir_normalizer_node(state))
+    if state["analysis_errors"]:
+        return state
+
+    _analyze_with_repair(state)
+    if state["analysis_errors"]:
+        return state
+
+    _merge_state(state, renderer_node(state))
+    state["validation_message"] = "WDL syntax validation skipped (--no-check)."
+    return state
+
+
+def workflow_succeeded(state: WorkflowState, check: bool) -> bool:
+    if state["analysis_errors"]:
+        return False
+    if not state["current_wdl"]:
+        return False
+    return state["is_valid"] if check else True
+
+
+def _result_from_state(
+    state: WorkflowState,
+    *,
+    plan: dict[str, Any] | None,
+    check: bool,
+    planner_prompt: str | None = None,
+    planner_raw_response: str | None = None,
+) -> WorkflowCompilationResult:
+    return WorkflowCompilationResult(
+        plan=plan,
+        workflow_ir=state["workflow_ir"],
+        wdl=state["current_wdl"],
+        analysis_errors=state["analysis_errors"],
+        analysis_warnings=state["analysis_warnings"],
+        repair_actions=state["repair_actions"],
+        validation_message=state["validation_message"],
+        is_valid=state["is_valid"],
+        succeeded=workflow_succeeded(state, check=check),
+        check_performed=check,
+        state=state,
+        planner_prompt=planner_prompt,
+        planner_raw_response=planner_raw_response,
+    )
+
+
+def _is_recipe_tool_plan(parsed_json: dict[str, Any]) -> bool:
+    workflow = parsed_json.get("workflow")
+    if not isinstance(workflow, dict):
+        return False
+    return "recipe" in workflow and "tool_calls" in workflow
+
+
+def _analyze_with_repair(state: WorkflowState) -> None:
+    while True:
+        _merge_state(state, analyzer_node(state))
+        if not state["analysis_errors"]:
+            return
+
+        _merge_state(state, repairer_node(state))
+        if not state["repair_actions"]:
+            return
+
+
+def _merge_state(state: WorkflowState, update: Mapping[str, Any]) -> None:
+    for key, value in update.items():
+        if key == "messages":
+            state["messages"] = state["messages"] + value
+        elif key == "parsed_json":
+            state["parsed_json"] = value
+        elif key == "workflow_ir":
+            state["workflow_ir"] = value
+        elif key == "analysis_errors":
+            state["analysis_errors"] = value
+        elif key == "analysis_warnings":
+            state["analysis_warnings"] = value
+        elif key == "current_wdl":
+            state["current_wdl"] = value
+        elif key == "validation_message":
+            state["validation_message"] = value
+        elif key == "error_count":
+            state["error_count"] = value
+        elif key == "repair_count":
+            state["repair_count"] = value
+        elif key == "repair_actions":
+            state["repair_actions"] = value
+        elif key == "is_valid":
+            state["is_valid"] = value

--- a/tests/test_catalog_service.py
+++ b/tests/test_catalog_service.py
@@ -1,0 +1,58 @@
+import unittest
+
+from src.services.catalog_service import get_recipe, get_tool, list_recipes, list_tools
+
+
+class CatalogServiceTests(unittest.TestCase):
+    def test_list_recipes_returns_json_ready_recipe_records(self):
+        recipes = list_recipes()
+
+        self.assertGreaterEqual(len(recipes), 1)
+        recipe = recipes[0]
+        self.assertEqual(recipe["id"], "rnaseq_differential_expression")
+        self.assertIn("required_inputs", recipe)
+        self.assertIn("steps", recipe)
+        self.assertEqual(recipe["steps"][0]["id"], "qc")
+        self.assertIn("fastp", recipe["steps"][0]["allowed_tools"])
+
+    def test_get_recipe_returns_named_recipe(self):
+        recipe = get_recipe("rnaseq_differential_expression")
+
+        self.assertEqual(recipe["name"], "RNA-seq differential expression")
+        self.assertEqual(recipe["required_inputs"]["sample_ids"]["type"], "Array[String]")
+        self.assertEqual(recipe["steps"][0]["scatter"]["id"], "per_sample")
+
+    def test_list_tools_returns_json_ready_tool_records(self):
+        tools = list_tools()
+
+        self.assertGreaterEqual(len(tools), 5)
+        fastp = next(tool for tool in tools if tool["id"] == "fastp")
+        self.assertEqual(fastp["version"], "0.23.2")
+        self.assertEqual(fastp["runtime"]["docker"], "quay.io/biocontainers/fastp:0.23.2")
+        self.assertEqual(fastp["trust_status"], "catalog-approved")
+        self.assertIn("clean_r1", fastp["outputs"])
+
+    def test_get_tool_returns_explicit_version(self):
+        tool = get_tool("salmon", "1.10.2")
+
+        self.assertEqual(tool["id"], "salmon")
+        self.assertEqual(tool["version"], "1.10.2")
+        self.assertEqual(tool["inputs"]["r1"]["type"], "File")
+        self.assertIn("1.10.2", tool["versions"])
+
+    def test_get_tool_defaults_to_highest_catalog_version(self):
+        tool = get_tool("multiqc")
+
+        self.assertEqual(tool["id"], "multiqc")
+        self.assertEqual(tool["version"], "1.21")
+
+    def test_unknown_recipe_and_tool_raise_key_error(self):
+        with self.assertRaisesRegex(KeyError, "unknown recipe"):
+            get_recipe("missing_recipe")
+
+        with self.assertRaisesRegex(KeyError, "unknown tool"):
+            get_tool("missing_tool")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,7 +7,8 @@ from pathlib import Path
 from unittest.mock import patch
 
 import main as cli
-from src.nl_planner import NaturalLanguagePlanningError, NaturalLanguagePlanResult
+from src.nl_planner import NaturalLanguagePlanningError
+from src.services.workflow_service import compile_structured_workflow
 
 
 EXAMPLES_DIR = Path(__file__).parents[1] / "examples"
@@ -27,23 +28,20 @@ class CliTests(unittest.TestCase):
 
     def test_cli_compiles_natural_language_prompt_with_mock_planner(self):
         planned = cli.load_workflow_input(EXAMPLES_DIR / "rnaseq_deg_recipe_plan.json")
-        plan_result = NaturalLanguagePlanResult(
-            plan=planned,
-            planner_prompt="planner prompt",
-            raw_response=json.dumps(planned),
-        )
+        result = compile_structured_workflow(planned, check=False)
+        request = "Run bulk RNA-seq differential expression."
 
         with tempfile.TemporaryDirectory() as tmpdir:
             output_path = Path(tmpdir) / "rnaseq_deg.wdl"
             stdout = io.StringIO()
             stderr = io.StringIO()
 
-            with patch("main.create_natural_language_plan", return_value=plan_result) as planner:
+            with patch("main.plan_and_compile_workflow", return_value=result) as service:
                 with redirect_stdout(stdout), redirect_stderr(stderr):
                     exit_code = cli.main(
                         [
                             "--prompt",
-                            "Run bulk RNA-seq differential expression.",
+                            request,
                             "--output",
                             str(output_path),
                             "--print-plan",
@@ -52,17 +50,35 @@ class CliTests(unittest.TestCase):
                     )
 
             self.assertEqual(exit_code, 0, stderr.getvalue())
-            planner.assert_called_once()
+            service.assert_called_once_with(request, model=cli.DEFAULT_PLANNER_MODEL, check=False)
             self.assertIn('"recipe": "rnaseq_differential_expression"', stdout.getvalue())
             self.assertIn("workflow RNASeqDEG", output_path.read_text(encoding="utf-8"))
 
+    def test_cli_structured_input_uses_structured_service_without_planner(self):
+        planned = cli.load_workflow_input(EXAMPLES_DIR / "rnaseq_deg_recipe_plan.json")
+        result = compile_structured_workflow(planned, check=False)
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+
+        with patch("main.compile_structured_workflow", return_value=result) as structured_service:
+            with patch("main.plan_and_compile_workflow") as natural_language_service:
+                with redirect_stdout(stdout), redirect_stderr(stderr):
+                    exit_code = cli.main(
+                        [
+                            "--input",
+                            str(EXAMPLES_DIR / "rnaseq_deg_recipe_plan.json"),
+                            "--no-check",
+                        ]
+                    )
+
+        self.assertEqual(exit_code, 0, stderr.getvalue())
+        structured_service.assert_called_once_with(planned, check=False)
+        natural_language_service.assert_not_called()
+        self.assertTrue(stdout.getvalue().startswith("version 1.0\n"))
+
     def test_cli_saves_natural_language_plan_and_planner_prompt(self):
         planned = cli.load_workflow_input(EXAMPLES_DIR / "rnaseq_deg_recipe_plan.json")
-        plan_result = NaturalLanguagePlanResult(
-            plan=planned,
-            planner_prompt="planner prompt",
-            raw_response=json.dumps(planned),
-        )
+        result = compile_structured_workflow(planned, check=False)
 
         with tempfile.TemporaryDirectory() as tmpdir:
             output_path = Path(tmpdir) / "rnaseq_deg.wdl"
@@ -72,7 +88,7 @@ class CliTests(unittest.TestCase):
             stderr = io.StringIO()
 
             with patch("main.build_default_planner_prompt", return_value="planner prompt"):
-                with patch("main.create_natural_language_plan", return_value=plan_result):
+                with patch("main.plan_and_compile_workflow", return_value=result):
                     with redirect_stdout(stdout), redirect_stderr(stderr):
                         exit_code = cli.main(
                             [
@@ -99,7 +115,7 @@ class CliTests(unittest.TestCase):
         stderr = io.StringIO()
 
         with patch(
-            "main.create_natural_language_plan",
+            "main.plan_and_compile_workflow",
             side_effect=NaturalLanguagePlanningError("LLM planner JSON parsing failed: bad json"),
         ):
             with redirect_stdout(stdout), redirect_stderr(stderr):
@@ -118,7 +134,7 @@ class CliTests(unittest.TestCase):
             prompt_path = Path(tmpdir) / "planner_prompt.txt"
             with patch("main.build_default_planner_prompt", return_value="planner prompt"):
                 with patch(
-                    "main.create_natural_language_plan",
+                    "main.plan_and_compile_workflow",
                     side_effect=NaturalLanguagePlanningError("LLM planner JSON parsing failed: bad json"),
                 ):
                     with redirect_stdout(stdout), redirect_stderr(stderr):

--- a/tests/test_workflow_service.py
+++ b/tests/test_workflow_service.py
@@ -1,0 +1,89 @@
+import json
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+from src.services.workflow_service import compile_structured_workflow, plan_and_compile_workflow
+
+
+EXAMPLES_DIR = Path(__file__).parents[1] / "examples"
+
+
+class FakePlannerLlm:
+    def __init__(self, response: str):
+        self.response = response
+        self.prompts = []
+
+    def invoke(self, prompt: str):
+        self.prompts.append(prompt)
+        return SimpleNamespace(content=self.response)
+
+
+def load_example(name: str) -> dict:
+    return json.loads((EXAMPLES_DIR / name).read_text(encoding="utf-8"))
+
+
+class WorkflowServiceTests(unittest.TestCase):
+    def test_compile_structured_workflow_compiles_recipe_plan_without_check(self):
+        plan = load_example("rnaseq_deg_recipe_plan.json")
+
+        result = compile_structured_workflow(plan, check=False)
+
+        self.assertTrue(result.succeeded, result.analysis_errors)
+        self.assertIs(result.plan, plan)
+        self.assertEqual(result.workflow_ir["workflow"]["name"], "RNASeqDEG")
+        self.assertIn("workflow RNASeqDEG", result.wdl)
+        self.assertEqual(result.validation_message, "WDL syntax validation skipped (--no-check).")
+        self.assertFalse(result.check_performed)
+
+    def test_compile_structured_workflow_compiles_workflow_ir_without_plan(self):
+        workflow_ir = load_example("rnaseq_workflow_ir.json")
+
+        result = compile_structured_workflow(workflow_ir, check=False)
+
+        self.assertTrue(result.succeeded, result.analysis_errors)
+        self.assertIsNone(result.plan)
+        self.assertEqual(result.workflow_ir["workflow"]["name"], "RNASeqPipeline")
+        self.assertIn("workflow RNASeqPipeline", result.wdl)
+
+    def test_compile_structured_workflow_returns_diagnostics_for_invalid_plan(self):
+        plan = load_example("rnaseq_deg_recipe_plan.json")
+        plan["workflow"]["inputs"].pop("sample_groups")
+
+        result = compile_structured_workflow(plan, check=False)
+
+        self.assertFalse(result.succeeded)
+        self.assertEqual(result.wdl, "")
+        self.assertIn("missing required workflow input 'sample_groups'", "\n".join(result.analysis_errors))
+
+    def test_plan_and_compile_workflow_plans_then_compiles(self):
+        plan = load_example("rnaseq_deg_recipe_plan.json")
+        fake_llm = FakePlannerLlm(json.dumps(plan))
+
+        result = plan_and_compile_workflow(
+            "Run bulk RNA-seq differential expression.",
+            llm=fake_llm,
+            check=False,
+        )
+
+        self.assertTrue(result.succeeded, result.analysis_errors)
+        self.assertEqual(result.plan, plan)
+        self.assertIn("Catalog:", result.planner_prompt or "")
+        self.assertIn("RNASeqDEG", result.planner_raw_response or "")
+        self.assertIn("workflow RNASeqDEG", result.wdl)
+        self.assertEqual(len(fake_llm.prompts), 1)
+
+    def test_result_to_dict_exposes_json_ready_service_fields(self):
+        plan = load_example("rnaseq_deg_recipe_plan.json")
+
+        result = compile_structured_workflow(plan, check=False).to_dict()
+
+        self.assertEqual(result["plan"], plan)
+        self.assertIn("workflow", result["workflow_ir"])
+        self.assertIn("workflow RNASeqDEG", result["wdl"])
+        self.assertEqual(result["analysis_errors"], [])
+        self.assertTrue(result["succeeded"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_workflow_service.py
+++ b/tests/test_workflow_service.py
@@ -2,6 +2,7 @@ import json
 import unittest
 from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import patch
 
 from src.services.workflow_service import compile_structured_workflow, plan_and_compile_workflow
 
@@ -45,6 +46,19 @@ class WorkflowServiceTests(unittest.TestCase):
         self.assertIsNone(result.plan)
         self.assertEqual(result.workflow_ir["workflow"]["name"], "RNASeqPipeline")
         self.assertIn("workflow RNASeqPipeline", result.wdl)
+
+    def test_compile_structured_workflow_without_check_does_not_invoke_graph(self):
+        plan = load_example("rnaseq_deg_recipe_plan.json")
+
+        with patch(
+            "src.services.workflow_service.agent.invoke",
+            side_effect=AssertionError("compiled graph should not run when check=False"),
+        ) as graph:
+            result = compile_structured_workflow(plan, check=False)
+
+        self.assertTrue(result.succeeded, result.analysis_errors)
+        self.assertFalse(result.check_performed)
+        graph.assert_not_called()
 
     def test_compile_structured_workflow_returns_diagnostics_for_invalid_plan(self):
         plan = load_example("rnaseq_deg_recipe_plan.json")


### PR DESCRIPTION
## Summary

- Add reusable workflow application services for structured compilation and natural-language planning followed by compilation.
- Add catalog query service functions for recipe/tool listing and lookup in preparation for W1 FastAPI endpoints.
- Refactor `main.py` so CLI natural-language and structured paths call the service layer instead of owning compilation orchestration.
- Document the new service-layer and catalog-service test cases in the existing test case document.

## Why

W0 is meant to extract a stable Python service boundary shared by CLI and the future API layer. This keeps FastAPI from shelling out to `main.py` or duplicating CLI-specific orchestration while preserving the deterministic Recipe Tool Plan / Workflow IR / WDL validation boundaries.

## Validation

- `uv run python -m unittest tests.test_cli -v`
- `uv run python -m unittest tests.test_workflow_service -v`
- `uv run python -m unittest discover -v`

Latest full run: `Ran 55 tests` / `OK (skipped=1)`.

The skipped test is the optional miniwdl tiny run when miniwdl is not installed.