### PR TITLE
Add container build GitHub Actions workflow

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -1,0 +1,126 @@
+name: Build containers
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/build-containers.yml"
+      - "containers/**"
+      - "scripts/build_container.py"
+  workflow_dispatch:
+    inputs:
+      tool:
+        description: "Container tool name, or all"
+        required: true
+        default: "all"
+        type: choice
+        options:
+          - all
+          - deseq2
+          - tximport
+          - multiqc
+      version:
+        description: "Tool version. Required unless tool=all."
+        required: false
+        default: ""
+        type: string
+      publish:
+        description: "Push images to GHCR after smoke tests"
+        required: true
+        default: false
+        type: boolean
+      platform:
+        description: "Docker build platform"
+        required: false
+        default: "linux/amd64"
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate container build script
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Compile build script
+        run: python -m py_compile scripts/build_container.py
+
+      - name: Dry-run all container builds
+        run: python scripts/build_container.py --all --dry-run
+
+  build:
+    name: Build containers
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    needs: validate
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Validate inputs
+        env:
+          TOOL: ${{ inputs.tool }}
+          VERSION: ${{ inputs.version }}
+          PUBLISH: ${{ inputs.publish }}
+        run: |
+          set -euo pipefail
+
+          if [[ "$TOOL" != "all" && -z "$VERSION" ]]; then
+            echo "::error::version is required when tool is not all"
+            exit 1
+          fi
+
+          if [[ "$PUBLISH" == "true" && "${GITHUB_REF}" != "refs/heads/main" ]]; then
+            echo "::error::publish=true is only allowed from refs/heads/main"
+            exit 1
+          fi
+
+      - name: Log in to GHCR
+        if: ${{ inputs.publish && github.ref == 'refs/heads/main' }}
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build, smoke-test, and optionally push
+        env:
+          TOOL: ${{ inputs.tool }}
+          VERSION: ${{ inputs.version }}
+          PUBLISH: ${{ inputs.publish }}
+          PLATFORM: ${{ inputs.platform }}
+        run: |
+          set -euo pipefail
+
+          command=(python scripts/build_container.py)
+          if [[ "$TOOL" == "all" ]]; then
+            command+=(--all)
+          else
+            command+=("$TOOL" "$VERSION")
+          fi
+
+          if [[ -n "$PLATFORM" ]]; then
+            command+=(--platform "$PLATFORM")
+          fi
+
+          if [[ "$PUBLISH" == "true" ]]; then
+            command+=(--push)
+          fi
+
+          "${command[@]}"

--- a/containers/README.md
+++ b/containers/README.md
@@ -30,6 +30,46 @@ docker login ghcr.io
 python scripts/build_container.py --all --push
 ```
 
+GitHub Actions can also build these images. Pull requests run only a dry-run
+validation job, so they never publish images. After the workflow file is merged
+to the default branch, run it manually from:
+
+```text
+Actions -> Build containers -> Run workflow
+```
+
+Recommended first run:
+
+```text
+tool=all
+publish=false
+platform=linux/amd64
+```
+
+This builds all project-maintained images and runs their smoke tests without
+pushing anything. To publish after the smoke tests pass, run the workflow again
+from the `main` branch with:
+
+```text
+tool=all
+publish=true
+platform=linux/amd64
+```
+
+For a single image, choose the tool and provide its version, for example:
+
+```text
+tool=deseq2
+version=1.42.1
+publish=true
+platform=linux/amd64
+```
+
+The workflow uses `GITHUB_TOKEN` to log in to GHCR and can only publish when
+manually triggered from `main`. After the first publish, confirm in GHCR that
+the package is associated with this repository and that its visibility is what
+you expect.
+
 Useful options:
 
 ```bash
@@ -41,6 +81,9 @@ python scripts/build_container.py tximport 1.30.0 --skip-smoke
 The build script does not update Tool Catalog YAML files. After publishing,
 copy the chosen tag or validated digest into the matching catalog entry
 explicitly.
+
+This workflow still publishes mutable version tags. Promoting catalog entries
+to validated image digests is a separate follow-up step.
 
 Each container directory should include:
 


### PR DESCRIPTION
## Summary
- Add a GitHub Actions workflow for project-maintained container images.
- Run lightweight dry-run validation on pull requests without publishing images.
- Support manual `workflow_dispatch` builds with selectable tool, version, platform, and optional GHCR publishing.
- Document manual workflow usage, publish behavior, and GHCR follow-up checks.

## Safety
- Pull requests never push images.
- `publish=true` is only allowed when manually triggered from `main`.
- GHCR login uses the repository `GITHUB_TOKEN`; no PAT secret is introduced.
- Catalog digest promotion remains a follow-up PR.

## Validation
- `git diff --check`
- `actionlint .github/workflows/build-containers.yml`
- `python -m py_compile scripts/build_container.py`
- `python scripts/build_container.py --all --dry-run`
- `python scripts/build_container.py --all --platform linux/amd64 --dry-run`
- `python scripts/build_container.py deseq2 1.42.1 --platform linux/amd64 --dry-run`

## Notes
- Real Docker build and GHCR push were not run locally.
- After this merges, the first manual Actions run should use `tool=all`, `publish=false`, `platform=linux/amd64`.