### PR TITLE
Document P0 verification workflow

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -144,6 +144,27 @@ analyzer_node    # 修复后重新分析、渲染、校验
 - [x] **镜像修订版 tag**：项目维护镜像使用 `<software-version>-rN` tag，例如 `deseq2:1.42.1-r2`。目录版本和 Tool Catalog `version` 字段表示上游软件版本；`image_revision.txt` 表示项目镜像修订号。
 - [x] **当前辅助工具镜像**：tximport、DESeq2 与 MultiQC 已具备项目内构建定义，作为 RNA-seq DEG 可执行流程的依赖。
 
+## 已完成的 P0 执行验证边界
+
+- [x] **Execution Backend 抽象**：默认 disabled 后端和 Cromwell REST backend 已落地，测试覆盖 availability、submit、polling、outputs、metadata 与失败语义。
+- [x] **Cromwell runner 基线**：独立 Cromwell server 已运行，Docker 与相关执行 backend 已可用。
+- [x] **e2e 镜像就绪**：RNA-seq DEG tiny e2e 所需镜像已拉取到 runner 本地。
+- [x] **真实 tiny e2e 手动验证**：已通过显式 opt-in 的 Cromwell e2e 入口手动运行真实 RNA-seq tiny workflow。
+
+P0 后续工作重点不再是证明 runner 能否运行，而是把已验证流程沉淀为便捷检查脚本、可复现验证摘要和更清晰的作品集展示材料。
+
+## 当前开发操作入口
+
+日常开发优先使用以下入口，避免绕过 service、Compiler Graph 或执行后端边界。
+
+| 场景 | 命令 | 说明 |
+| --- | --- | --- |
+| P0 本地快速检查 | `powershell -ExecutionPolicy Bypass -File scripts\check_p0.ps1` | 运行单测、代表性 RNA-seq WDL 编译和 WOMtool 校验；不触发真实 e2e。 |
+| 结构化编译 | `uv run main.py --input examples/rnaseq_deg_recipe_plan.json --output outputs/rnaseq_deg.wdl` | 直接走确定性 Recipe Tool Plan / IR 编译路径，不需要 API key。 |
+| 自然语言规划编译 | `uv run main.py --prompt-file examples/rnaseq_deg_request.txt --output outputs/rnaseq_deg.wdl` | 先生成 Recipe Tool Plan，再进入确定性编译链路；需要 `DEEPSEEK_API_KEY`。 |
+| FastAPI 开发服务 | `.\.venv\Scripts\python.exe -m src.api.server` | 默认监听 `127.0.0.1:8010`，避开 Cromwell 的 `8000`。 |
+| 真实 Cromwell tiny e2e | `powershell -ExecutionPolicy Bypass -File scripts\check_p0.ps1 -RunE2E -CromwellUrl http://localhost:8000 -WindowsFixtureRoot C:\data\ai-bioworkflow-tiny -CromwellFixtureRoot /data/ai-bioworkflow-runner/tiny` | 显式 opt-in；`check_p0.ps1` 委托 `run_cromwell_tiny_e2e.ps1` 准备 fixture、同步 runner 并运行真实 e2e。 |
+
 ## 未来架构原则（规划中）
 
 后续智能化能力遵循以下总原则：

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -159,7 +159,7 @@ P0 后续工作重点不再是证明 runner 能否运行，而是把已验证流
 
 | 场景 | 命令 | 说明 |
 | --- | --- | --- |
-| P0 本地快速检查 | `powershell -ExecutionPolicy Bypass -File scripts\check_p0.ps1` | 运行单测、代表性 RNA-seq WDL 编译和 WOMtool 校验；不触发真实 e2e。 |
+| P0 本地快速检查 | `powershell -ExecutionPolicy Bypass -File scripts\check_p0.ps1` | 运行单测、代表性 RNA-seq WDL 编译和语法校验；不触发真实 e2e。 |
 | 结构化编译 | `uv run main.py --input examples/rnaseq_deg_recipe_plan.json --output outputs/rnaseq_deg.wdl` | 直接走确定性 Recipe Tool Plan / IR 编译路径，不需要 API key。 |
 | 自然语言规划编译 | `uv run main.py --prompt-file examples/rnaseq_deg_request.txt --output outputs/rnaseq_deg.wdl` | 先生成 Recipe Tool Plan，再进入确定性编译链路；需要 `DEEPSEEK_API_KEY`。 |
 | FastAPI 开发服务 | `.\.venv\Scripts\python.exe -m src.api.server` | 默认监听 `127.0.0.1:8010`，避开 Cromwell 的 `8000`。 |

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -39,7 +39,7 @@ AI-bioworkflow/
 │   │
 │   ├── tools/            # 10. 工具箱：存放外部工具封装
 │   │   ├── __init__.py
-│   │   └── validator.py  # 生信特定工具（如 WOMtool 语法校验）
+│   │   └── validator.py  # WDL validator wrapper
 │   │
 │   ├── nodes/            # 11. 工作节点：LangGraph 的具体执行工位
 │   │   ├── __init__.py
@@ -71,7 +71,7 @@ AI-bioworkflow/
 9. **工具封装 (`tools/`)**：所有与底层操作系统或第三方生信软件的交互（如调用 `java -jar womtool.jar validate`）都必须封装为独立 Tool，确保生成代码闭环验证。
 10. **Catalog 镜像权威来源 (`catalog/`)**：每个 Tool Catalog 条目必须显式声明 `runtime.docker`。编译链路不搜索、不猜测、不联网补全镜像；新增或升级工具时由维护者明确选择镜像并写入 catalog。
 11. **辅助脚本镜像化 (`containers/`)**：tximport、DESeq2、MultiQC 等辅助脚本随项目镜像构建进入容器，不作为 WDL 输入，也不内联到 command 中。
-12. **渐进式重构**：先保证 Natural Language -> Recipe Tool Plan -> IR -> WDL -> WOMtool validate 的主链路稳定，再逐步扩展 recipe/tool catalog、可解释错误报告与 LLM repairer。
+12. **渐进式重构**：先保证 Natural Language -> Recipe Tool Plan -> IR -> WDL -> WDL syntax validation 的主链路稳定，再逐步扩展 recipe/tool catalog、可解释错误报告与 LLM repairer。
 
 ## Workflow IR 规范
 
@@ -126,7 +126,7 @@ analyzer_node    # IR 静态分析
   ↓
 renderer_node    # Workflow IR steps/scatter -> WDL
   ↓
-checker_node     # WOMtool validate
+checker_node     # WDL syntax validation
   ↓
 END
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ LLM 在这个架构中更适合承担规划、补全、修复与解释任务；�
 - **静态分析**：在渲染前检查 task/call 引用、输入完整性、上游输出引用和基础类型匹配。
 - **Recipe / Tool Catalog**：支持用预定义生信工具目录和分析配方生成 Workflow IR。
 - **Agentic 架构**：基于 LangGraph 串联 IR Normalizer、Analyzer、Repairer、Renderer 与 Checker 节点，支持继续扩展 LLM planner / repairer。
+- **可复用服务与 API**：CLI 与 FastAPI 复用同一套 workflow/catalog service，避免界面层复制编译逻辑。
+- **执行后端边界**：提供可配置的 Execution Backend 抽象和 Cromwell REST client，用 contract tests 覆盖提交、轮询、outputs/metadata 与失败语义。
 - **模块化设计**：高度解耦的 State、Prompts、Nodes 与 Tools 设计，极佳的代码可维护性。
 
 ## 🛠️ 快速开始
@@ -60,7 +62,36 @@ WOMTOOL_JAR="D:/path/to/womtool.jar"
 JAVA_HOME="D:/path/to/jdk-17"
 ```
 
-### 4. 编译工作流
+### 4. 常用操作入口
+
+本地开发最常用的入口如下。默认 P0 检查不会触发真实 Cromwell e2e。
+
+```powershell
+# 本地 P0 快速检查：单测 + 代表性 WDL 编译 + WOMtool 校验
+powershell -ExecutionPolicy Bypass -File scripts\check_p0.ps1
+
+# 结构化 Recipe Tool Plan 编译
+uv run main.py --input examples/rnaseq_deg_recipe_plan.json --output outputs/rnaseq_deg.wdl
+
+# 自然语言规划并编译
+uv run main.py --prompt-file examples/rnaseq_deg_request.txt --output outputs/rnaseq_deg.wdl
+
+# 启动 FastAPI 开发服务
+.\.venv\Scripts\python.exe -m src.api.server
+```
+
+真实 Cromwell tiny e2e 需要显式 opt-in，并会委托
+`scripts\run_cromwell_tiny_e2e.ps1` 完成 fixture 准备、runner 同步和测试执行：
+
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts\check_p0.ps1 `
+  -RunE2E `
+  -CromwellUrl http://localhost:8000 `
+  -WindowsFixtureRoot C:\data\ai-bioworkflow-tiny `
+  -CromwellFixtureRoot /data/ai-bioworkflow-runner/tiny
+```
+
+### 5. 编译工作流
 
 无参数运行时会使用内置自然语言 demo，先规划成 Recipe Tool Plan，再编译并打印生成的 WDL：
 
@@ -116,7 +147,7 @@ uv run main.py \
   --output outputs/rnaseq_deg.wdl
 ```
 
-### 5. 启动 W1 FastAPI 开发服务
+### 6. 启动 W1 FastAPI 开发服务
 
 如果本地同时运行 Cromwell server，建议保留 Cromwell 使用 `8000` 端口，本项目 FastAPI 开发服务使用 `8010` 端口，避免两个服务的 `/api/...` 路径互相混淆。
 
@@ -202,6 +233,15 @@ Workflow IR 的结构、表达式规则、scatter 语义和 WDL 后端映射详�
 - [x] 闭环修复机制初版：当分析器或校验器发现可确定修复的问题时，优先修复 IR 并重新编译 WDL。
 - [x] Tool Catalog 强制显式声明 `runtime.docker`，作为镜像来源的唯一权威。
 - [x] 支持 `workflow.steps` 与 WDL scatter，RNA-seq DEG recipe 升级为多样本 Salmon -> tximport -> DESeq2 -> MultiQC。
+- [x] 抽取 workflow/catalog application service，供 CLI 与 API 复用。
+- [x] 完成 W1 FastAPI 基础接口：自然语言 run、结构化 compile、recipe/tool catalog 查询。
+- [x] 增加 Execution Backend 抽象、Cromwell REST backend contract tests 和 disabled 默认后端。
+- [x] 增加 Cromwell Compose runner 文档、tiny RNA-seq fixture 生成脚本和显式 opt-in 的真实 e2e 入口。
+- [x] 在独立 Cromwell runner 上手动跑通真实 RNA-seq tiny e2e。
+- [x] 增加 P0 快速检查脚本，默认覆盖单测和代表性 WDL 编译/校验。
+- [x] 记录一份可复现的 [Cromwell e2e 验证摘要](./docs/p0-e2e-verification.md)，包括 workflow id、最终状态和 output keys。
+- [ ] 实现 W2 run 事件、SQLite 展示级持久化和 SSE 事件流。
+- [ ] 建设 Next.js 工作台、DAG 可视化和历史详情页。
 - [ ] 扩展更多常用生信 recipe 与 tool catalog。
 
 ## 📄 许可证

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 
 AI-bioworkflow 是一个面向生物信息学工作流生成的 Agent / 编译器原型。
-项目利用 **LangGraph** 构建状态流转架构，将用户提供的结构化 JSON 标准化为内部 **Workflow IR**，再通过确定性的 Renderer 编译为标准、合规的 **WDL (Workflow Description Language) 1.0** 代码，并使用 `WOMtool` 做本地语法校验。
+项目利用 **LangGraph** 构建状态流转架构，将用户提供的结构化 JSON 标准化为内部 **Workflow IR**，再通过确定性的 Renderer 编译为标准、合规的 **WDL (Workflow Description Language) 1.0** 代码，并使用可配置 WDL validator 做本地语法校验。
 
 LLM 在这个架构中更适合承担规划、补全、修复与解释任务；从标准 IR 到 WDL 的最终生成由普通代码完成，保证输出稳定、可测试、可维护。
 
@@ -127,7 +127,7 @@ uv run main.py --input examples/rnaseq_deg_recipe_plan.json --output outputs/rna
 - `--save-plan`：将自然语言 Planner 生成的 Recipe Tool Plan 保存为 JSON 文件。
 - `--save-planner-prompt`：保存完整 Planner prompt，方便调试模型输出。
 - `--print-ir`：打印 Planner 标准化后的 Workflow IR。
-- `--no-check`：跳过 WOMtool 语法校验，仅执行 IR 分析与 WDL 渲染。
+- `--no-check`：跳过 WDL 语法校验，仅执行 IR 分析与 WDL 渲染。
 - `--planner-model`：指定自然语言 Planner 使用的模型。
 - `--verbose`：将节点进度日志输出到 stderr。
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ JAVA_HOME="D:/path/to/jdk-17"
 本地开发最常用的入口如下。默认 P0 检查不会触发真实 Cromwell e2e。
 
 ```powershell
-# 本地 P0 快速检查：单测 + 代表性 WDL 编译 + WOMtool 校验
+# 本地 P0 快速检查：单测 + 代表性 WDL 编译/语法校验
 powershell -ExecutionPolicy Bypass -File scripts\check_p0.ps1
 
 # 结构化 Recipe Tool Plan 编译

--- a/deploy/cromwell/README.md
+++ b/deploy/cromwell/README.md
@@ -2,7 +2,10 @@
 
 本目录提供 AI-bioworkflow P0 阶段使用的 Cromwell server runner 部署包。它用于 Linux、WSL、devcontainer 或小型服务器环境，是一个独立的部署辅助目录。
 
-它不包含项目后端 client 联调，也不会修改 `AI_BIOWORKFLOW_RUN_BACKEND` 的行为。
+Python 侧 Cromwell client 位于 `src/execution/cromwell.py`，并通过
+`AI_BIOWORKFLOW_RUN_BACKEND=cromwell` 选择。本部署包只负责启动 Cromwell
+server 和它的本地执行环境，不会启动 AI-bioworkflow API/CLI，也不会自动修改
+调用方的环境变量。
 
 该 runner 使用：
 
@@ -10,6 +13,10 @@
 - PostgreSQL `16` 保存 workflow metadata
 - 通过 `/var/run/docker.sock` 使用 Docker-outside-of-Docker
 - 默认共享 Linux 路径 `/data/ai-bioworkflow-runner`
+
+当前 P0 runner 已完成手动验证：Cromwell server 已启动，Docker 与相关
+backend 可用，RNA-seq DEG e2e 所需镜像已拉取到本地，并已手动运行真实
+e2e 测试。
 
 ## 文件
 
@@ -112,6 +119,8 @@ docker pull ghcr.io/yuanzhw/ai-bioworkflow/deseq2:1.42.1-r2
 docker pull ghcr.io/yuanzhw/ai-bioworkflow/multiqc:1.21-r1
 ```
 
+已验证的 P0 runner 中，这些 e2e 镜像已存在于本地 Docker 环境。
+
 ## 输入路径规则
 
 Cromwell inputs JSON 中每个 `File` 值都必须是 Cromwell runner 可见的 Linux 路径。不要在 inputs JSON 中写入 `C:\Users\...` 这类 Windows 路径。
@@ -161,9 +170,10 @@ curl http://localhost:8000/api/workflows/v1/<workflow-id>/metadata
 - Cromwell 启动后不健康：查看 `docker compose logs cromwell` 和 `docker compose logs postgres`；Cromwell 会等待 Postgres 可用后再启动。
 - workflow 输出没有复制：使用 `options.example.json`，或提供等价的 workflow options 文件并设置 `final_workflow_outputs_dir`。
 
-## 本部署包不包含的内容
+## 边界
 
-- 实现 `src/execution/cromwell.py`
-- 修改 `get_execution_backend()` 行为
-- 运行真实 RNA-seq tiny e2e 测试
-- 通过 AI-bioworkflow 后端 client 提交 workflow
+- 不启动 AI-bioworkflow FastAPI 或 CLI 进程。
+- 不自动设置 `AI_BIOWORKFLOW_RUN_BACKEND`、`CROMWELL_URL` 或 e2e 测试变量。
+- 不自动拉取、构建或发布 workflow task 镜像；镜像仍由 Tool Catalog 与容器发布流程显式管理。
+- 不提交带有环境绑定绝对路径的最终 tiny inputs JSON；请使用 `examples/tiny/prepare_tiny_data.py` 在 runner 可见路径生成。
+- 不默认运行真实 RNA-seq tiny e2e；真实执行必须由调用方显式设置环境变量后运行 `tests.e2e.test_tiny_run`。

--- a/docs/p0-cromwell-execution-plan.md
+++ b/docs/p0-cromwell-execution-plan.md
@@ -17,7 +17,7 @@
 - 真实 WDL workflow 执行
 - tiny RNA-seq fixture e2e 测试
 
-Windows 开发环境继续负责确定性编译、静态分析、WDL 渲染、WOMtool 校验和快速单元测试。真实 WDL 执行应交给独立 Cromwell 环境。
+Windows 开发环境继续负责确定性编译、静态分析、WDL 渲染、WDL 语法校验和快速单元测试。真实 WDL 执行应交给独立 Cromwell 环境。
 
 ## 架构决策
 
@@ -395,7 +395,7 @@ workflow 执行，真实 e2e 必须显式 opt-in。
 
 | 场景 | 命令 | 说明 |
 | --- | --- | --- |
-| 本地 P0 快速检查 | `powershell -ExecutionPolicy Bypass -File scripts\check_p0.ps1` | 运行单测、代表性 RNA-seq WDL 编译和 WOMtool 校验。 |
+| 本地 P0 快速检查 | `powershell -ExecutionPolicy Bypass -File scripts\check_p0.ps1` | 运行单测、代表性 RNA-seq WDL 编译和语法校验。 |
 | 真实 Cromwell tiny e2e | `powershell -ExecutionPolicy Bypass -File scripts\check_p0.ps1 -RunE2E -CromwellUrl http://localhost:8000 -WindowsFixtureRoot C:\data\ai-bioworkflow-tiny -CromwellFixtureRoot /data/ai-bioworkflow-runner/tiny` | 委托 `scripts/run_cromwell_tiny_e2e.ps1` 准备 fixture、同步 runner 并运行 e2e。 |
 
 本地快速检查的多行写法：

--- a/docs/p0-cromwell-execution-plan.md
+++ b/docs/p0-cromwell-execution-plan.md
@@ -47,7 +47,7 @@ Windows/Codex 开发环境负责：
 - 运行 unit 和 compiler tests。
 - 从 Recipe Tool Plan 或 Workflow IR 生成 WDL。
 - 执行 Analyzer / Renderer / Checker 边界。
-- 运行 WOMtool validate。
+- 运行项目 WDL validator 做语法校验。
 - 通过 mock 或 fake HTTP 层运行 Cromwell backend contract tests。
 - 不要求 Docker、miniwdl、真实 Cromwell 或真实 tiny input 文件。
 
@@ -500,7 +500,7 @@ ghcr.io/yuanzhw/ai-bioworkflow/multiqc:1.21-r1
 P0 完成需要满足：
 
 - [x] Windows/Codex 普通 unit 和 compiler tests 通过。
-- [x] 代表性生成 WDL 可以通过 WOMtool validate。
+- [x] 代表性生成 WDL 可以通过项目 WDL validator（WOMtool 或 miniwdl）校验。
 - [x] `CromwellBackend` 有 submit、poll、outputs、metadata 和错误处理的 contract tests。
 - [x] 真实 RNA-seq DEG tiny workflow 可以在 Cromwell runner 中运行到 `Succeeded`。
 - [x] e2e 测试检查 Cromwell outputs 中包含 `RNASeqDEG.deg_table` 和 `RNASeqDEG.multiqc_report`。

--- a/docs/p0-cromwell-execution-plan.md
+++ b/docs/p0-cromwell-execution-plan.md
@@ -60,9 +60,16 @@ Cromwell runner 环境负责：
 - 生成与 runner 环境绑定的 inputs JSON。
 - 运行真实 RNA-seq DEG tiny workflow e2e 测试。
 
-## 当前阶段：Cromwell Compose Runner
+## 当前状态：P0 执行闭环已手动验证
 
-当前阶段先交付独立 Cromwell server/runner 的 Docker Compose 部署包，不做项目后端 client 联调。
+当前 Windows/Codex 侧已经落地 Execution Backend 抽象、默认 disabled 后端、
+Cromwell REST client、mock contract tests、真实 e2e 测试入口、tiny fixture
+生成脚本，以及独立 Cromwell server/runner 的 Docker Compose 部署包。
+
+独立 Cromwell runner 环境也已完成手动验证：Cromwell server 已运行，
+Docker 与相关 backend 已可用，RNA-seq DEG e2e 所需镜像已拉取到本地，
+并已手动运行真实 e2e 测试。P0 后续重点是把这套验证沉淀成更便捷的
+快速检查脚本和可复现的验证记录。
 
 部署包位置：
 
@@ -87,16 +94,23 @@ deploy/cromwell/
 - Cromwell 容器内路径和宿主机路径必须保持一致，避免 task 容器挂载执行目录失败。
 - inputs JSON 中的 `File` 路径必须是 Cromwell runner 可见的 Linux 路径，不能使用 Windows 绝对路径。
 
-本阶段明确不包含：
+当前已人工确认的 runner 状态：
 
-- 实现或修改 `src/execution/cromwell.py`。
-- 修改 `get_execution_backend()` 中 `cromwell` 未实现的状态。
-- 运行真实 RNA-seq tiny e2e。
-- 通过 AI-bioworkflow 后端 client 提交 WDL 到 Cromwell。
+- Cromwell server 已启动并可用于真实 workflow 提交。
+- Docker 与 Cromwell 配套执行 backend 已可用。
+- RNA-seq DEG e2e 所需 workflow task 镜像已拉取到本地。
+- 已使用显式 e2e 环境变量手动运行真实 RNA-seq tiny e2e。
 
-上述联调内容应等 Cromwell runner 环境经人工确认可用后再继续。
+当前验证记录：
 
-## 计划目录结构
+- 真实 e2e 的 Cromwell workflow id、最终 status、output keys 和输出文件大小已记录在
+  `docs/p0-e2e-verification.md`。
+- Runner 快速检查步骤已收敛到 `scripts/check_p0.ps1`，真实 e2e 逻辑由
+  `scripts/run_cromwell_tiny_e2e.ps1` 统一负责。
+
+Windows/Codex 普通验证仍不要求 Docker、miniwdl、真实 Cromwell 或真实 tiny input 文件。
+
+## 当前目录结构
 
 ```text
 src/execution/
@@ -123,7 +137,9 @@ examples/tiny/
     reads/
 ```
 
-在执行后端抽象落地后，当前 `tests/test_tiny_run.py` 应迁移到 `tests/e2e/test_tiny_run.py`。
+真实 Cromwell e2e 已位于 `tests/e2e/test_tiny_run.py`，默认跳过，只有显式设置
+`AI_BIOWORKFLOW_RUN_E2E=1` 时运行。`tests/test_tiny_run.py` 保留为可选
+miniwdl tiny run 检查，不作为 P0 必需路径。
 
 ## ExecutionBackend 接口
 
@@ -374,85 +390,91 @@ Windows client 不应默认假设自己可以读取 Cromwell 返回的 output �
 
 ## P0 验证命令
 
-Windows/Codex 快速开发检查：
+P0 验证入口分为本地快速检查和真实 Cromwell e2e。默认入口不触发真实
+workflow 执行，真实 e2e 必须显式 opt-in。
+
+| 场景 | 命令 | 说明 |
+| --- | --- | --- |
+| 本地 P0 快速检查 | `powershell -ExecutionPolicy Bypass -File scripts\check_p0.ps1` | 运行单测、代表性 RNA-seq WDL 编译和 WOMtool 校验。 |
+| 真实 Cromwell tiny e2e | `powershell -ExecutionPolicy Bypass -File scripts\check_p0.ps1 -RunE2E -CromwellUrl http://localhost:8000 -WindowsFixtureRoot C:\data\ai-bioworkflow-tiny -CromwellFixtureRoot /data/ai-bioworkflow-runner/tiny` | 委托 `scripts/run_cromwell_tiny_e2e.ps1` 准备 fixture、同步 runner 并运行 e2e。 |
+
+本地快速检查的多行写法：
 
 ```powershell
-uv run python -m unittest discover -v
+powershell -ExecutionPolicy Bypass -File scripts\check_p0.ps1
 ```
 
-代表性编译和 WDL 校验：
+真实 Cromwell e2e 的多行写法：
 
 ```powershell
-uv run main.py --input examples/rnaseq_deg_recipe_plan.json --output .cache/rnaseq_deg.wdl
+powershell -ExecutionPolicy Bypass -File scripts\check_p0.ps1 `
+  -RunE2E `
+  -CromwellUrl http://localhost:8000 `
+  -WindowsFixtureRoot C:\data\ai-bioworkflow-tiny `
+  -CromwellFixtureRoot /data/ai-bioworkflow-runner/tiny
 ```
 
-Cromwell runner 上的真实 e2e：
-
-```bash
-AI_BIOWORKFLOW_RUN_E2E=1 \
-AI_BIOWORKFLOW_RUN_BACKEND=cromwell \
-CROMWELL_URL=http://localhost:8000 \
-AI_BIOWORKFLOW_TINY_INPUTS=/data/ai-bioworkflow-tiny/rnaseq_deg.inputs.json \
-uv run python -m unittest tests.e2e.test_tiny_run -v
-```
+`check_p0.ps1` 是 P0 总检查入口；真实 Cromwell e2e 的 fixture 准备、
+runner 同步和测试执行仍由 `scripts/run_cromwell_tiny_e2e.ps1` 统一负责，
+避免两份脚本维护重复的 e2e 逻辑。
 
 ## 实施计划
 
 ### 阶段 1：文档与测试边界
 
-- 更新 P0 文档，明确 miniwdl 是可选项。
-- 明确 Cromwell API execution 是 P0 runtime baseline。
-- 固定 Windows/Codex 与 Cromwell runner 的职责边界。
-- 将本文档作为独立计划文档。
+- [x] 更新 P0 文档，明确 miniwdl 是可选项。
+- [x] 明确 Cromwell API execution 是 P0 runtime baseline。
+- [x] 固定 Windows/Codex 与 Cromwell runner 的职责边界。
+- [x] 将本文档作为独立计划文档。
 
 ### 阶段 2：Execution Backend 核心
 
-- 新增 `src/execution/protocol.py`。
-- 新增 `BackendAvailability`。
-- 新增 `ExecutionResult`。
-- 新增 `ExecutionBackend` protocol。
-- 新增 `src/execution/disabled.py`。
-- 新增 `src/execution/factory.py`。
-- 添加 backend selection 单元测试。
+- [x] 新增 `src/execution/protocol.py`。
+- [x] 新增 `BackendAvailability`。
+- [x] 新增 `ExecutionResult`。
+- [x] 新增 `ExecutionBackend` protocol。
+- [x] 新增 `src/execution/disabled.py`。
+- [x] 新增 `src/execution/factory.py`。
+- [x] 添加 backend selection 单元测试。
 
 ### 阶段 3：Cromwell Backend
 
-- 新增 `src/execution/cromwell.py`。
-- 通过 `/engine/v1/status` 实现 health check。
-- 通过 `/api/workflows/v1` 实现 submit。
-- 使用 `workflowSource`、`workflowInputs`、`workflowOptions`、`workflowDependencies` 和 `labels`。
-- 通过 `/api/workflows/v1/{id}/status` 实现 polling。
-- 实现 outputs 和 metadata 获取。
-- 实现 timeout 和 failed status 处理。
-- 添加 mock contract tests。
+- [x] 新增 `src/execution/cromwell.py`。
+- [x] 通过 `/engine/v1/status` 实现 health check。
+- [x] 通过 `/api/workflows/v1` 实现 submit。
+- [x] 使用 `workflowSource`、`workflowInputs`、`workflowOptions`、`workflowDependencies` 和 `labels`。
+- [x] 通过 `/api/workflows/v1/{id}/status` 实现 polling。
+- [x] 实现 outputs 和 metadata 获取。
+- [x] 实现 timeout 和 failed status 处理。
+- [x] 添加 mock contract tests。
 
 ### 阶段 4：E2E 测试迁移
 
-- 创建 `tests/e2e/`。
-- 移动或替换当前 optional tiny-run 测试。
-- 保证默认 e2e 行为是 skip。
-- 保证显式开启 e2e 但 backend 不可用时 fail。
-- 断言 Cromwell status 和 output keys。
-- 不默认假设 Windows 能访问 Cromwell output 文件路径。
+- [x] 创建 `tests/e2e/`。
+- [x] 新增真实 Cromwell e2e 入口，并保留 miniwdl tiny run 为可选检查。
+- [x] 保证默认 e2e 行为是 skip。
+- [x] 保证显式开启 e2e 但 backend 不可用时 fail。
+- [x] 断言 Cromwell status 和 output keys。
+- [x] 不默认假设 Windows 能访问 Cromwell output 文件路径。
 
 ### 阶段 5：Tiny Fixture
 
-- 新增 `examples/tiny/prepare_tiny_data.py`。
-- 新增 `examples/tiny/rnaseq_deg.inputs.template.json`。
-- 如果合适，提交小型、可再分发的源 fixture 数据。
-- 在 runner 环境生成 Salmon index。
-- 在 runner 环境生成最终 `rnaseq_deg.inputs.json`。
-- 写出成功前验证所有路径存在。
+- [x] 新增 `examples/tiny/prepare_tiny_data.py`。
+- [x] 新增 `examples/tiny/rnaseq_deg.inputs.template.json`。
+- [x] 由脚本生成小型 fixture 源数据。
+- [x] 在 runner 环境生成 Salmon index。
+- [x] 在 runner 环境生成最终 `rnaseq_deg.inputs.json`。
+- [x] 写出成功前验证所有路径存在。
 
 ### 阶段 6：Cromwell Runner
 
-- 准备 Linux、WSL、devcontainer 或服务器侧 Cromwell 环境。
-- 使用 `deploy/cromwell/` 中的 Docker Compose 部署 Cromwell server mode。
-- 固定 Cromwell server 版本为 `92`。
-- 使用 PostgreSQL 16 作为 Cromwell metadata database。
-- 使用 Docker-outside-of-Docker 挂载宿主机 Docker socket，不使用 Docker-in-Docker。
-- 确保 Docker 或其他已配置 backend 可用。
-- 拉取或构建所需镜像：
+- [x] 准备 Linux、WSL、devcontainer 或服务器侧 Cromwell 环境。
+- [x] 使用 `deploy/cromwell/` 中的 Docker Compose 部署 Cromwell server mode。
+- [x] 固定 Cromwell server 版本为 `92`。
+- [x] 使用 PostgreSQL 16 作为 Cromwell metadata database。
+- [x] 使用 Docker-outside-of-Docker 挂载宿主机 Docker socket，不使用 Docker-in-Docker。
+- [x] 确保 Docker 或其他已配置 backend 可用。
+- [x] 拉取或构建所需镜像：
 
 ```text
 quay.io/biocontainers/fastp:1.3.3--h43da1c4_0
@@ -462,28 +484,28 @@ ghcr.io/yuanzhw/ai-bioworkflow/deseq2:1.42.1-r2
 ghcr.io/yuanzhw/ai-bioworkflow/multiqc:1.21-r1
 ```
 
-- 手动确认 `GET /engine/v1/status` 可用。
-- 后续阶段再运行 tiny fixture 准备脚本。
-- 后续阶段再设置 Cromwell 相关环境变量并运行 e2e 测试。
+- [x] 手动确认 `GET /engine/v1/status` 可用。
+- [x] 运行 tiny fixture 准备脚本。
+- [x] 设置 Cromwell 相关环境变量并运行 e2e 测试。
 
 ### 阶段 7：P0 便捷检查
 
-- 新增 `scripts/check_p0.ps1` 或 `scripts/check_p0.py`。
-- 默认只跑快速检查。
-- 真实 e2e 必须显式 opt-in。
-- 文档化所需环境变量。
+- [x] 新增 `scripts/check_p0.ps1`。
+- [x] 默认只跑快速检查。
+- [x] 真实 e2e 必须显式 opt-in。
+- [x] 文档化所需环境变量。
 
 ## P0 Definition of Done
 
 P0 完成需要满足：
 
-- Windows/Codex 普通 unit 和 compiler tests 通过。
-- 代表性生成 WDL 可以通过 WOMtool validate。
-- `CromwellBackend` 有 submit、poll、outputs、metadata 和错误处理的 contract tests。
-- 真实 RNA-seq DEG tiny workflow 可以在 Cromwell runner 中运行到 `Succeeded`。
-- e2e 测试检查 Cromwell outputs 中包含 `RNASeqDEG.deg_table` 和 `RNASeqDEG.multiqc_report`。
-- 最终环境绑定的 inputs JSON 由 runner 侧 fixture 脚本生成，不作为固定绝对路径文件提交。
-- README 或开发文档说明如何运行快速检查和真实 e2e 检查。
+- [x] Windows/Codex 普通 unit 和 compiler tests 通过。
+- [x] 代表性生成 WDL 可以通过 WOMtool validate。
+- [x] `CromwellBackend` 有 submit、poll、outputs、metadata 和错误处理的 contract tests。
+- [x] 真实 RNA-seq DEG tiny workflow 可以在 Cromwell runner 中运行到 `Succeeded`。
+- [x] e2e 测试检查 Cromwell outputs 中包含 `RNASeqDEG.deg_table` 和 `RNASeqDEG.multiqc_report`。
+- [x] 最终环境绑定的 inputs JSON 由 runner 侧 fixture 脚本生成，不作为固定绝对路径文件提交。
+- [x] README 或开发文档说明如何运行快速检查和真实 e2e 检查。
 
 ## P0 非目标
 
@@ -497,7 +519,5 @@ P0 完成需要满足：
 
 ## 待确认问题
 
-- Cromwell runner 使用 Docker local backend、WSL、devcontainer，还是一台小型持久 Linux 服务器？
-- tiny fixture 源文件是提交进仓库、从零生成，还是从固定 URL 下载？
 - output 文件存在且非空检查是否等到共享输出目录标准化后再加入？
 - 项目维护镜像是否要在 P0 前从 mutable tag 升级到 digest-pinned reference？

--- a/docs/p0-e2e-verification.md
+++ b/docs/p0-e2e-verification.md
@@ -1,0 +1,141 @@
+# P0 Cromwell Tiny E2E 验证摘要
+
+本文档记录一次真实的 P0 Cromwell e2e 验证运行，验证对象是 RNA-seq
+差异表达分析工作流。它作为可复现的里程碑记录，不替代自动化测试本身。
+
+## 摘要
+
+| 字段 | 值 |
+| --- | --- |
+| 验证日期 | 2026-06-14 Asia/Shanghai |
+| Workflow | `RNASeqDEG` |
+| Cromwell workflow id | `1ea70de2-dee2-4da9-b7ab-e6ac25e1bdf8` |
+| 最终状态 | `Succeeded` |
+| Cromwell URL | `http://localhost:8000` |
+| Windows fixture root | `C:\data\ai-bioworkflow-tiny` |
+| Cromwell fixture root | `/data/ai-bioworkflow-runner/tiny` |
+| 同步模式 | `docker` |
+| Cromwell 容器 | `cromwell-cromwell-1` |
+
+## 运行命令
+
+本次运行通过 P0 检查入口触发，并只启用真实 e2e 路径：
+
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts\check_p0.ps1 `
+  -SkipUnitTests `
+  -SkipCompile `
+  -RunE2E `
+  -CromwellUrl http://localhost:8000 `
+  -WindowsFixtureRoot C:\data\ai-bioworkflow-tiny `
+  -CromwellFixtureRoot /data/ai-bioworkflow-runner/tiny
+```
+
+`check_p0.ps1 -RunE2E` 会将 fixture 准备、runner 同步、环境变量设置和
+测试执行委托给 `scripts\run_cromwell_tiny_e2e.ps1`。
+
+## 测试结果
+
+```text
+test_rnaseq_tiny_run_when_e2e_is_enabled (...) ... ok
+
+Ran 1 test in 76.821s
+
+OK
+```
+
+P0 wrapper 输出：
+
+```text
+OK: Cromwell tiny RNA-seq e2e (79.7s)
+P0 check passed.
+```
+
+## Cromwell 记录
+
+Cromwell query 返回的最新 `RNASeqDEG` workflow 记录如下：
+
+```text
+id:         1ea70de2-dee2-4da9-b7ab-e6ac25e1bdf8
+name:       RNASeqDEG
+status:     Succeeded
+submission: 2026-06-13T16:45:51.073Z
+start:      2026-06-13T16:45:58.663Z
+end:        2026-06-13T16:47:05.179Z
+```
+
+换算为 Asia/Shanghai 时间，本次 workflow 约在 2026-06-14 00:45:58 到
+2026-06-14 00:47:05 之间运行。
+
+Metadata 中包含预期的 workflow calls：
+
+```text
+RNASeqDEG.qc
+RNASeqDEG.quantify
+RNASeqDEG.summarize
+RNASeqDEG.deg
+RNASeqDEG.report
+```
+
+## 输入
+
+e2e helper 在 Windows 可读路径生成 inputs JSON：
+
+```text
+C:\data\ai-bioworkflow-tiny\rnaseq_deg.inputs.json
+```
+
+该 JSON 使用 Cromwell runner 可见路径：
+
+```text
+/data/ai-bioworkflow-runner/tiny
+```
+
+本次 workflow 输入包含 4 个 tiny samples：
+
+```text
+ctrl_1
+ctrl_2
+treat_1
+treat_2
+```
+
+## 输出
+
+Cromwell 返回了两个预期 workflow output keys：
+
+```text
+RNASeqDEG.deg_table
+RNASeqDEG.multiqc_report
+```
+
+返回的 output paths：
+
+```text
+RNASeqDEG.deg_table:
+/data/ai-bioworkflow-runner/executions/RNASeqDEG/1ea70de2-dee2-4da9-b7ab-e6ac25e1bdf8/call-deg/execution/differential_expression.tsv
+
+RNASeqDEG.multiqc_report:
+/data/ai-bioworkflow-runner/executions/RNASeqDEG/1ea70de2-dee2-4da9-b7ab-e6ac25e1bdf8/call-report/execution/multiqc_report.html
+```
+
+在 Cromwell runner 容器内确认两个输出文件均存在且非空：
+
+```text
+differential_expression.tsv  308 B
+multiqc_report.html          4.4M
+```
+
+## 结论
+
+P0 已具备 RNA-seq DEG 路径的真实执行基线：
+
+- Recipe Tool Plan 可以编译为通过校验的 WDL。
+- Cromwell 可以接受并运行生成的 WDL。
+- 已配置的 Docker execution backend 可以完成整个 workflow。
+- 预期 workflow outputs 已生成，并能通过 Cromwell 查询到。
+
+以下后续工作不是证明 P0 可执行性的前置条件，但可以提高可重复性和发布质量：
+
+- 评估后续 e2e 是否应在检查 Cromwell output keys 之外，同时断言输出文件存在且非空。
+- 在镜像发布流程稳定后，将可复用容器引用从 mutable tags 推进到 validated digests。

--- a/docs/test-cases.md
+++ b/docs/test-cases.md
@@ -24,7 +24,7 @@ Recipe Tool Plan / Workflow IR / Legacy JSON
 .\.venv\Scripts\python.exe -m unittest discover -v
 ```
 
-P0 快速检查脚本会运行完整单测、代表性 RNA-seq WDL 编译和 WOMtool 校验：
+P0 快速检查脚本会运行完整单测、代表性 RNA-seq WDL 编译和语法校验：
 
 ```powershell
 powershell -ExecutionPolicy Bypass -File scripts\check_p0.ps1

--- a/docs/test-cases.md
+++ b/docs/test-cases.md
@@ -24,21 +24,43 @@ Recipe Tool Plan / Workflow IR / Legacy JSON
 .\.venv\Scripts\python.exe -m unittest discover -v
 ```
 
+P0 快速检查脚本会运行完整单测、代表性 RNA-seq WDL 编译和 WOMtool 校验：
+
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts\check_p0.ps1
+```
+
+真实 Cromwell tiny e2e 需要显式 opt-in：
+
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts\check_p0.ps1 `
+  -RunE2E `
+  -WindowsFixtureRoot C:\data\ai-bioworkflow-tiny `
+  -CromwellFixtureRoot /data/ai-bioworkflow-runner/tiny
+```
+
+该 opt-in 路径会委托 `scripts/run_cromwell_tiny_e2e.ps1` 执行真实 e2e，
+因此 fixture 生成和同步逻辑只有一个维护入口。
+
 部分测试会按本地环境自动跳过：
 
 - `tests/test_tools.py`：没有 WOMtool 或 miniwdl 时跳过 WDL validator 测试。
 - `tests/test_tiny_run.py`：没有 miniwdl、Docker/Podman、本地镜像或 tiny 输入文件时跳过真实 tiny run。
 - `tests/test_container_build.py`：纯单元测试，不调用 Docker；只验证容器构建脚本的 tag contract。
 
-当前 W1 API 基础阶段改动后的最近一次完整验证结果：
+当前 P0 文档同步阶段的最近一次完整验证结果：
 
 ```text
 .venv\Scripts\python.exe -m unittest discover -v
-Ran 111 tests
+Ran 114 tests
 OK (skipped=2)
 ```
 
-跳过项为依赖真实执行环境的 tiny run，包括 Cromwell e2e 开关和本地 miniwdl 环境。
+跳过项为显式 opt-in 的真实 Cromwell tiny e2e，以及本地未安装 miniwdl
+时跳过的可选 miniwdl tiny run。
+
+真实 Cromwell tiny e2e 已在独立 runner 环境中手动运行过；默认单测仍保留
+显式 opt-in 机制，避免普通 Windows/Codex 开发环境误触发真实 workflow 执行。
 
 ## 公共测试输入
 

--- a/examples/tiny/README.md
+++ b/examples/tiny/README.md
@@ -35,7 +35,7 @@ the inputs JSON on a Windows-readable path and render its contents with WSL
 paths:
 
 ```powershell
-.\scripts\run_cromwell_tiny_e2e.ps1 `
+powershell -ExecutionPolicy Bypass -File scripts\run_cromwell_tiny_e2e.ps1 `
   -WindowsFixtureRoot C:\data\ai-bioworkflow-tiny `
   -CromwellFixtureRoot /data/ai-bioworkflow-runner/tiny
 ```
@@ -47,7 +47,7 @@ and runs `tests.e2e.test_tiny_run`.
 By default the helper syncs through Docker:
 
 ```powershell
-.\scripts\run_cromwell_tiny_e2e.ps1 `
+powershell -ExecutionPolicy Bypass -File scripts\run_cromwell_tiny_e2e.ps1 `
   -WindowsFixtureRoot C:\data\ai-bioworkflow-tiny `
   -CromwellFixtureRoot /data/ai-bioworkflow-runner/tiny `
   -SyncMode docker `
@@ -75,4 +75,16 @@ AI_BIOWORKFLOW_RUN_BACKEND=cromwell \
 CROMWELL_URL=http://localhost:8000 \
 AI_BIOWORKFLOW_TINY_INPUTS=/data/ai-bioworkflow-tiny/rnaseq_deg.inputs.json \
 uv run python -m unittest tests.e2e.test_tiny_run -v
+```
+
+On Windows, the P0 check wrapper can run the same opt-in e2e. It delegates
+fixture preparation, sync, and the real e2e execution to
+`scripts\run_cromwell_tiny_e2e.ps1`:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts\check_p0.ps1 `
+  -RunE2E `
+  -CromwellUrl http://localhost:8000 `
+  -WindowsFixtureRoot C:\data\ai-bioworkflow-tiny `
+  -CromwellFixtureRoot /data/ai-bioworkflow-runner/tiny
 ```

--- a/scripts/check_p0.ps1
+++ b/scripts/check_p0.ps1
@@ -88,6 +88,10 @@ function Resolve-OutputDirectory {
 }
 
 try {
+    if ($SkipUnitTests -and $SkipCompile -and -not $RunE2E) {
+        throw "No P0 checks selected. Remove -SkipUnitTests or -SkipCompile, or add -RunE2E to run the real Cromwell e2e."
+    }
+
     Set-PythonCommand
     Push-Location $repoRoot
     $locationPushed = $true

--- a/scripts/check_p0.ps1
+++ b/scripts/check_p0.ps1
@@ -1,0 +1,172 @@
+param(
+    [string]$PythonExe = "",
+    [string]$OutputDir = ".cache\p0",
+    [switch]$SkipUnitTests,
+    [switch]$SkipCompile,
+    [switch]$RunE2E,
+    [string]$WindowsFixtureRoot = "C:\data\ai-bioworkflow-tiny",
+    [string]$CromwellFixtureRoot = "/data/ai-bioworkflow-runner/tiny",
+    [string]$CromwellUrl = "http://localhost:8000",
+    [string]$ContainerRuntime = "docker",
+    [ValidateSet("docker", "wsl")]
+    [string]$SyncMode = "docker",
+    [string]$CromwellContainerName = "cromwell-cromwell-1",
+    [string]$WslDistro = "",
+    [switch]$SkipPrepare,
+    [switch]$SkipWslSync
+)
+
+$ErrorActionPreference = "Stop"
+
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot "..")
+$locationPushed = $false
+$pythonCommand = @()
+$pythonExeForScripts = ""
+
+function Set-PythonCommand {
+    if ($PythonExe) {
+        if (-not (Test-Path -LiteralPath $PythonExe)) {
+            throw "Python executable not found: $PythonExe"
+        }
+        $script:pythonCommand = @($PythonExe)
+        $script:pythonExeForScripts = $PythonExe
+        return
+    }
+
+    $venvPython = Join-Path $repoRoot ".venv\Scripts\python.exe"
+    if (Test-Path -LiteralPath $venvPython) {
+        $script:pythonCommand = @($venvPython)
+        $script:pythonExeForScripts = $venvPython
+        return
+    }
+
+    if (Get-Command uv -ErrorAction SilentlyContinue) {
+        $script:pythonCommand = @("uv", "run", "python")
+        $script:pythonExeForScripts = ""
+        return
+    }
+
+    throw "No Python runtime found. Expected .venv\Scripts\python.exe or uv on PATH."
+}
+
+function Invoke-Python {
+    param([Parameter(Mandatory = $true)][string[]]$Arguments)
+
+    $command = $script:pythonCommand[0]
+    $commandArgs = @()
+    if ($script:pythonCommand.Count -gt 1) {
+        $commandArgs += $script:pythonCommand[1..($script:pythonCommand.Count - 1)]
+    }
+    $commandArgs += $Arguments
+
+    & $command @commandArgs
+    if ($LASTEXITCODE -ne 0) {
+        throw "Python command failed with exit code ${LASTEXITCODE}: $($Arguments -join ' ')"
+    }
+}
+
+function Invoke-Step {
+    param(
+        [Parameter(Mandatory = $true)][string]$Name,
+        [Parameter(Mandatory = $true)][scriptblock]$Action
+    )
+
+    Write-Host ""
+    Write-Host "==> $Name"
+    $timer = [System.Diagnostics.Stopwatch]::StartNew()
+    & $Action
+    $timer.Stop()
+    Write-Host "OK: $Name ($([Math]::Round($timer.Elapsed.TotalSeconds, 1))s)"
+}
+
+function Resolve-OutputDirectory {
+    if ([System.IO.Path]::IsPathRooted($OutputDir)) {
+        return [System.IO.Path]::GetFullPath($OutputDir)
+    }
+    return [System.IO.Path]::GetFullPath((Join-Path $repoRoot $OutputDir))
+}
+
+try {
+    Set-PythonCommand
+    Push-Location $repoRoot
+    $locationPushed = $true
+
+    Write-Host "P0 check root: $repoRoot"
+    Write-Host "Python: $($pythonCommand -join ' ')"
+
+    if (-not $SkipUnitTests) {
+        Invoke-Step "Unit and compiler tests" {
+            Invoke-Python @("-m", "unittest", "discover", "-v")
+        }
+    }
+
+    if (-not $SkipCompile) {
+        Invoke-Step "Representative RNA-seq WDL compile and WOMtool validation" {
+            $resolvedOutputDir = Resolve-OutputDirectory
+            New-Item -ItemType Directory -Force -Path $resolvedOutputDir | Out-Null
+            $wdlPath = Join-Path $resolvedOutputDir "rnaseq_deg.wdl"
+            Invoke-Python @(
+                "main.py",
+                "--input", "examples\rnaseq_deg_recipe_plan.json",
+                "--output", $wdlPath
+            )
+            if (-not (Test-Path -LiteralPath $wdlPath)) {
+                throw "Expected WDL output was not created: $wdlPath"
+            }
+            Write-Host "WDL: $wdlPath"
+        }
+    }
+
+    if ($RunE2E) {
+        Invoke-Step "Cromwell tiny RNA-seq e2e" {
+            $e2eScript = Join-Path $PSScriptRoot "run_cromwell_tiny_e2e.ps1"
+            if (-not (Test-Path -LiteralPath $e2eScript)) {
+                throw "Cromwell tiny e2e helper not found: $e2eScript"
+            }
+
+            $e2eArgs = @(
+                "-ExecutionPolicy", "Bypass",
+                "-File", $e2eScript,
+                "-WindowsFixtureRoot", $WindowsFixtureRoot,
+                "-CromwellFixtureRoot", $CromwellFixtureRoot,
+                "-CromwellUrl", $CromwellUrl,
+                "-ContainerRuntime", $ContainerRuntime,
+                "-SyncMode", $SyncMode,
+                "-CromwellContainerName", $CromwellContainerName
+            )
+            if ($pythonExeForScripts) {
+                $e2eArgs += @("-PythonExe", $pythonExeForScripts)
+            }
+            if ($WslDistro) {
+                $e2eArgs += @("-WslDistro", $WslDistro)
+            }
+            if ($SkipPrepare) {
+                $e2eArgs += "-SkipPrepare"
+            }
+            if ($SkipWslSync) {
+                $e2eArgs += "-SkipWslSync"
+            }
+
+            & powershell @e2eArgs
+            if ($LASTEXITCODE -ne 0) {
+                throw "Cromwell tiny e2e helper failed with exit code $LASTEXITCODE"
+            }
+        }
+    }
+    else {
+        Write-Host ""
+        Write-Host "Skipping real Cromwell e2e. Re-run with -RunE2E to opt in."
+    }
+
+    Write-Host ""
+    Write-Host "P0 check passed."
+}
+catch {
+    Write-Error $_
+    exit 1
+}
+finally {
+    if ($locationPushed) {
+        Pop-Location
+    }
+}

--- a/scripts/check_p0.ps1
+++ b/scripts/check_p0.ps1
@@ -101,7 +101,7 @@ try {
     }
 
     if (-not $SkipCompile) {
-        Invoke-Step "Representative RNA-seq WDL compile and WOMtool validation" {
+        Invoke-Step "Representative RNA-seq WDL compile and syntax validation" {
             $resolvedOutputDir = Resolve-OutputDirectory
             New-Item -ItemType Directory -Force -Path $resolvedOutputDir | Out-Null
             $wdlPath = Join-Path $resolvedOutputDir "rnaseq_deg.wdl"

--- a/scripts/check_p0.ps1
+++ b/scripts/check_p0.ps1
@@ -123,6 +123,9 @@ try {
             if (-not (Test-Path -LiteralPath $e2eScript)) {
                 throw "Cromwell tiny e2e helper not found: $e2eScript"
             }
+            if (-not $pythonExeForScripts) {
+                throw "Cromwell tiny e2e requires a concrete Python executable. Create .venv\Scripts\python.exe or pass -PythonExe <path>; the uv fallback only supports local unit/compile checks."
+            }
 
             $e2eArgs = @(
                 "-ExecutionPolicy", "Bypass",

--- a/scripts/check_p0.ps1
+++ b/scripts/check_p0.ps1
@@ -7,7 +7,8 @@ param(
     [string]$WindowsFixtureRoot = "C:\data\ai-bioworkflow-tiny",
     [string]$CromwellFixtureRoot = "/data/ai-bioworkflow-runner/tiny",
     [string]$CromwellUrl = "http://localhost:8000",
-    [string]$ContainerRuntime = "docker",
+    [ValidateSet("auto", "docker", "podman")]
+    [string]$ContainerRuntime = "auto",
     [ValidateSet("docker", "wsl")]
     [string]$SyncMode = "docker",
     [string]$CromwellContainerName = "cromwell-cromwell-1",

--- a/scripts/run_cromwell_tiny_e2e.ps1
+++ b/scripts/run_cromwell_tiny_e2e.ps1
@@ -2,7 +2,8 @@ param(
     [string]$WindowsFixtureRoot = "C:\data\ai-bioworkflow-tiny",
     [string]$CromwellFixtureRoot = "/data/ai-bioworkflow-runner/tiny",
     [string]$CromwellUrl = "http://localhost:8000",
-    [string]$ContainerRuntime = "docker",
+    [ValidateSet("auto", "docker", "podman")]
+    [string]$ContainerRuntime = "auto",
     [ValidateSet("docker", "wsl")]
     [string]$SyncMode = "docker",
     [string]$CromwellContainerName = "cromwell-cromwell-1",


### PR DESCRIPTION
## Summary

- Add a P0 quick check script that runs the local unit/compiler gate and optionally delegates real Cromwell tiny e2e execution to the existing e2e helper.
- Document the verified P0 Cromwell runner state, operation entrypoints, and script responsibilities across README and development docs.
- Add a reproducible P0 Cromwell tiny e2e verification summary with workflow id, status, outputs, and output file checks.

## Validation

- `powershell -ExecutionPolicy Bypass -File scripts\check_p0.ps1`
- `powershell -ExecutionPolicy Bypass -File scripts\check_p0.ps1 -SkipUnitTests -SkipCompile -RunE2E -CromwellUrl http://localhost:8000 -WindowsFixtureRoot C:\data\ai-bioworkflow-tiny -CromwellFixtureRoot /data/ai-bioworkflow-runner/tiny`
- `git diff --check`