### PR TITLE
Translate supporting README docs to Chinese

### DIFF
--- a/containers/README.md
+++ b/containers/README.md
@@ -1,57 +1,47 @@
-# Workflow helper containers
+# 工作流辅助容器
 
-Catalog entries may reference helper images when a workflow task depends on
-project-maintained scripts. Build and publish images explicitly, then copy the
-final tag or digest into the Tool Catalog YAML. The compiler never searches for
-or fills in container images automatically.
+当 workflow task 依赖项目维护的辅助脚本时，Tool Catalog 条目可以引用对应的辅助镜像。镜像必须由维护者显式构建、验证和发布，然后把最终 tag 或 digest 写入 Tool Catalog YAML。编译器不会自动搜索、推断或补全容器镜像。
 
-Default tag pattern:
+默认 tag 模式：
 
 ```bash
 ghcr.io/yuanzhw/ai-bioworkflow/<tool>:<software-version>-<image-revision>
 ```
 
-For example, DESeq2 `1.42.1` with the second project-maintained image
-revision is published as:
+例如，DESeq2 `1.42.1` 的第二个项目维护镜像 revision 发布为：
 
 ```bash
 ghcr.io/yuanzhw/ai-bioworkflow/deseq2:1.42.1-r2
 ```
 
-The directory name and `TOOL_VERSION` build arg represent the upstream software
-or package version. The image revision is stored in `image_revision.txt` under
-the same container directory. Increment the revision whenever Dockerfile,
-helper scripts, pinned dependencies, or runtime behavior changes while the
-upstream tool version stays the same.
+目录名和 `TOOL_VERSION` 构建参数表示上游软件或包版本。镜像 revision 存放在同一容器目录下的 `image_revision.txt` 中。当 Dockerfile、辅助脚本、固定依赖或 runtime 行为发生变化，而上游工具版本保持不变时，需要递增该 revision。
 
-Build one image and run its smoke test:
+构建单个镜像并运行 smoke test：
 
 ```bash
 python scripts/build_container.py tximport 1.30.0
 ```
 
-Build every project-maintained image:
+构建所有项目维护镜像：
 
 ```bash
 python scripts/build_container.py --all
 ```
 
-Push after successful build and smoke test:
+构建和 smoke test 成功后推送镜像：
 
 ```bash
 docker login ghcr.io
 python scripts/build_container.py --all --push
 ```
 
-GitHub Actions can also build these images. Pull requests run only a dry-run
-validation job, so they never publish images. After the workflow file is merged
-to the default branch, run it manually from:
+GitHub Actions 也可以构建这些镜像。Pull request 只运行 dry-run 校验 job，因此不会发布镜像。workflow 文件合并到默认分支后，可以从以下入口手动运行：
 
 ```text
 Actions -> Build containers -> Run workflow
 ```
 
-Recommended first run:
+推荐首次运行：
 
 ```text
 tool=all
@@ -59,9 +49,7 @@ publish=false
 platform=linux/amd64
 ```
 
-This builds all project-maintained images and runs their smoke tests without
-pushing anything. To publish after the smoke tests pass, run the workflow again
-from the `main` branch with:
+这会构建所有项目维护镜像并运行 smoke tests，但不会推送任何镜像。smoke tests 通过后，可以再次从 `main` 分支运行 workflow，并设置：
 
 ```text
 tool=all
@@ -69,7 +57,7 @@ publish=true
 platform=linux/amd64
 ```
 
-For a single image, choose the tool and provide its version, for example:
+构建单个镜像时，选择 tool 并提供版本，例如：
 
 ```text
 tool=deseq2
@@ -78,15 +66,15 @@ publish=true
 platform=linux/amd64
 ```
 
-With `containers/deseq2/1.42.1/image_revision.txt` set to `r2`, this publishes
-`ghcr.io/yuanzhw/ai-bioworkflow/deseq2:1.42.1-r2`.
+当 `containers/deseq2/1.42.1/image_revision.txt` 设置为 `r2` 时，上述配置会发布：
 
-The workflow uses `GITHUB_TOKEN` to log in to GHCR and can only publish when
-manually triggered from `main`. After the first publish, confirm in GHCR that
-the package is associated with this repository and that its visibility is what
-you expect.
+```text
+ghcr.io/yuanzhw/ai-bioworkflow/deseq2:1.42.1-r2
+```
 
-Useful options:
+该 workflow 使用 `GITHUB_TOKEN` 登录 GHCR，并且只有从 `main` 手动触发时才会发布镜像。首次发布后，需要在 GHCR 中确认 package 已关联到本仓库，并检查可见性是否符合预期。
+
+常用选项：
 
 ```bash
 python scripts/build_container.py multiqc 1.21 --dry-run
@@ -94,32 +82,22 @@ python scripts/build_container.py deseq2 1.42.1 --platform linux/amd64
 python scripts/build_container.py tximport 1.30.0 --skip-smoke
 ```
 
-The build script does not update Tool Catalog YAML files. After publishing,
-copy the chosen tag or validated digest into the matching catalog entry
-explicitly.
+构建脚本不会更新 Tool Catalog YAML 文件。镜像发布后，需要把选定的 tag 或已验证 digest 显式复制到对应 Catalog 条目中。
 
-The build script publishes revision tags, not bare software-version tags. A
-bare tag such as `deseq2:1.42.1` may be maintained as a convenience alias
-outside the formal Catalog, but Catalog entries should use revision tags first
-and eventually promote to validated digests.
+构建脚本发布 revision tags，而不是裸的软件版本 tags。类似 `deseq2:1.42.1` 的裸 tag 可以在正式 Catalog 之外作为便捷 alias 维护，但 Catalog 条目应优先使用 revision tag，并在后续迁移到已验证 digest。
 
-Each container directory should include:
+每个容器目录应包含：
 
 - `Dockerfile`
-- helper scripts copied into the image
-- `smoke_test.sh` for a fast post-build check
-- `image_revision.txt` containing a revision like `r1` or `r2`
+- 复制进镜像的辅助脚本
+- 用于快速构建后检查的 `smoke_test.sh`
+- 包含 `r1` 或 `r2` 这类 revision 的 `image_revision.txt`
 
-Version rules:
+版本规则：
 
-- Directory names and `TOOL_VERSION` build args should match the upstream
-  software version.
-- Image tags should append the project-maintained image revision, for example
-  `1.42.1-r2`.
-- Dockerfiles must install the declared top-level tool version explicitly.
-- Dockerfiles should fail during build if the installed top-level tool version
-  does not match `TOOL_VERSION`.
-- `smoke_test.sh` should verify the helper entrypoint and installed top-level
-  tool version as a second check.
-- Final reusable catalog entries should prefer a validated image digest over a
-  mutable tag once the image has been published and inspected.
+- 目录名和 `TOOL_VERSION` 构建参数应匹配上游软件版本。
+- 镜像 tag 应追加项目维护的镜像 revision，例如 `1.42.1-r2`。
+- Dockerfile 必须显式安装声明的顶层工具版本。
+- 如果安装后的顶层工具版本与 `TOOL_VERSION` 不一致，Dockerfile 应在 build 阶段失败。
+- `smoke_test.sh` 应再次验证辅助入口命令和已安装的顶层工具版本。
+- 最终可复用的 Catalog 条目应优先使用已验证 image digest，而不是可变 tag。

--- a/examples/tiny/README.md
+++ b/examples/tiny/README.md
@@ -1,4 +1,4 @@
-# Tiny RNA-seq DEG 测试数据集
+# Tiny RNA-seq DEG fixture（测试数据集）
 
 本目录保存 tiny RNA-seq DEG 端到端（e2e）测试数据集的可复现源文件。最终的 `rnaseq_deg.inputs.json` 与运行环境绑定，应该在 Cromwell runner 侧生成，不应把包含绝对路径的版本提交到仓库。
 

--- a/examples/tiny/README.md
+++ b/examples/tiny/README.md
@@ -1,10 +1,8 @@
-# Tiny RNA-seq DEG fixture
+# Tiny RNA-seq DEG 测试数据集
 
-This directory contains the reproducible source for the tiny RNA-seq DEG e2e
-fixture. The final `rnaseq_deg.inputs.json` is environment-bound and should be
-generated on the Cromwell runner side, not committed with absolute paths.
+本目录保存 tiny RNA-seq DEG 端到端（e2e）测试数据集的可复现源文件。最终的 `rnaseq_deg.inputs.json` 与运行环境绑定，应该在 Cromwell runner 侧生成，不应把包含绝对路径的版本提交到仓库。
 
-Generate fixture data and a Cromwell-visible inputs JSON with:
+生成测试数据和 Cromwell 可见的 inputs JSON：
 
 ```bash
 python examples/tiny/prepare_tiny_data.py \
@@ -12,11 +10,9 @@ python examples/tiny/prepare_tiny_data.py \
   --write-inputs /data/ai-bioworkflow-tiny/rnaseq_deg.inputs.json
 ```
 
-The script uses Docker or Podman to build `salmon_index/` from the Salmon image
-declared in the Tool Catalog (`src/catalog/tools/salmon/1.9.0.yaml`). The
-runner environment does not need a host-level Salmon installation.
+脚本会使用 Docker 或 Podman，从 Tool Catalog 中声明的 Salmon 镜像（`src/catalog/tools/salmon/1.9.0.yaml`）构建 `salmon_index/`。runner 环境不需要在宿主机层面安装 Salmon。
 
-The script writes:
+脚本会写出：
 
 - `data/transcripts.fa`
 - `data/tx2gene.tsv`
@@ -24,15 +20,11 @@ The script writes:
 - `data/reads/*_R1.fastq.gz`
 - `data/reads/*_R2.fastq.gz`
 - `salmon_index/`
-- `rnaseq_deg.inputs.json` when `--write-inputs` is provided
+- 提供 `--write-inputs` 时写出 `rnaseq_deg.inputs.json`
 
-The inputs JSON uses paths under `--cromwell-root` if supplied; otherwise it
-uses `--fixture-root`. Those paths must be visible to Cromwell, even if they are
-not the same paths seen by a Windows client.
+如果提供了 `--cromwell-root`，inputs JSON 会使用该路径下的文件；否则使用 `--fixture-root`。这些路径必须对 Cromwell 可见，即使它们与 Windows client 看到的路径不同。
 
-When Cromwell is running inside WSL but the test is launched from Windows, keep
-the inputs JSON on a Windows-readable path and render its contents with WSL
-paths:
+当 Cromwell 运行在 WSL 内，而测试从 Windows 启动时，inputs JSON 应保存在 Windows 可读路径中，同时把内容渲染为 WSL 路径：
 
 ```powershell
 powershell -ExecutionPolicy Bypass -File scripts\run_cromwell_tiny_e2e.ps1 `
@@ -40,11 +32,9 @@ powershell -ExecutionPolicy Bypass -File scripts\run_cromwell_tiny_e2e.ps1 `
   -CromwellFixtureRoot /data/ai-bioworkflow-runner/tiny
 ```
 
-The helper prepares the fixture on Windows, copies it into the running
-Cromwell container's runner mount, sets the Cromwell e2e environment variables,
-and runs `tests.e2e.test_tiny_run`.
+该 helper 会在 Windows 侧准备测试数据，将其同步到正在运行的 Cromwell 容器 runner mount 中，设置 Cromwell e2e 所需环境变量，并运行 `tests.e2e.test_tiny_run`。
 
-By default the helper syncs through Docker:
+默认情况下，helper 通过 Docker 同步：
 
 ```powershell
 powershell -ExecutionPolicy Bypass -File scripts\run_cromwell_tiny_e2e.ps1 `
@@ -54,11 +44,9 @@ powershell -ExecutionPolicy Bypass -File scripts\run_cromwell_tiny_e2e.ps1 `
   -CromwellContainerName cromwell-cromwell-1
 ```
 
-Use `-SyncMode wsl` if the Cromwell runner path should be populated through
-`wsl.exe` instead.
+如果希望通过 `wsl.exe` 填充 Cromwell runner 路径，可以使用 `-SyncMode wsl`。
 
-If both Docker and Podman are installed, Docker is used by default. Override the
-runtime with:
+如果 Docker 和 Podman 都已安装，默认使用 Docker。可以通过以下方式指定 runtime：
 
 ```bash
 python examples/tiny/prepare_tiny_data.py \
@@ -67,7 +55,7 @@ python examples/tiny/prepare_tiny_data.py \
   --container-runtime podman
 ```
 
-After preparing the fixture, run the real e2e only with explicit opt-in:
+测试数据准备完成后，只有显式 opt-in 时才运行真实 e2e：
 
 ```bash
 AI_BIOWORKFLOW_RUN_E2E=1 \
@@ -77,9 +65,7 @@ AI_BIOWORKFLOW_TINY_INPUTS=/data/ai-bioworkflow-tiny/rnaseq_deg.inputs.json \
 uv run python -m unittest tests.e2e.test_tiny_run -v
 ```
 
-On Windows, the P0 check wrapper can run the same opt-in e2e. It delegates
-fixture preparation, sync, and the real e2e execution to
-`scripts\run_cromwell_tiny_e2e.ps1`:
+在 Windows 上，P0 check wrapper 可以运行同一个 opt-in e2e。它会把测试数据准备、同步和真实 e2e 执行委托给 `scripts\run_cromwell_tiny_e2e.ps1`：
 
 ```powershell
 powershell -ExecutionPolicy Bypass -File scripts\check_p0.ps1 `

--- a/examples/tiny/README.md
+++ b/examples/tiny/README.md
@@ -1,6 +1,6 @@
 # Tiny RNA-seq DEG fixture（测试数据集）
 
-本目录保存 tiny RNA-seq DEG 端到端（e2e）测试数据集的可复现源文件。最终的 `rnaseq_deg.inputs.json` 与运行环境绑定，应该在 Cromwell runner 侧生成，不应把包含绝对路径的版本提交到仓库。
+本目录保存 tiny RNA-seq DEG 端到端（e2e）fixture（测试数据集）的可复现源文件。最终的 `rnaseq_deg.inputs.json` 与运行环境绑定，应该在 Cromwell runner 侧生成，不应把包含绝对路径的版本提交到仓库。
 
 生成测试数据和 Cromwell 可见的 inputs JSON：
 

--- a/tools/womtool/README.md
+++ b/tools/womtool/README.md
@@ -1,30 +1,26 @@
 # WOMtool
 
-This directory documents the local WOMtool setup. Do not commit the WOMtool
-JAR into the repository.
+本目录记录项目本地 WOMtool 的安装约定。不要把 WOMtool JAR 提交到仓库中。
 
-Use the installer script from the repository root:
+从仓库根目录运行安装脚本：
 
 ```powershell
 scripts/install_womtool.ps1
 ```
 
-By default it downloads `womtool-91.jar` from the Broad Institute Cromwell
-GitHub releases and stores it under:
+默认情况下，脚本会从 Broad Institute Cromwell GitHub releases 下载 `womtool-91.jar`，并保存到：
 
 ```text
 .cache/womtool/womtool.jar
 ```
 
-The validator discovers the JAR automatically from that cache path. You can
-override it with:
+validator 会自动从该 cache 路径发现 JAR。也可以通过环境变量覆盖：
 
 ```env
 WOMTOOL_JAR="D:/path/to/womtool.jar"
 ```
 
-The default WOMtool 91 release needs Java 17 or newer. For a project-local
-Temurin JDK:
+默认 WOMtool 91 release 需要 Java 17 或更新版本。如需安装项目本地的 Temurin JDK：
 
 ```powershell
 scripts/install_java.ps1

--- a/tools/womtool/README.md
+++ b/tools/womtool/README.md
@@ -8,7 +8,7 @@
 scripts/install_womtool.ps1
 ```
 
-默认情况下，脚本会从 Broad Institute Cromwell GitHub releases 下载 `womtool-91.jar`，并保存到：
+默认情况下，脚本会从 Broad Institute Cromwell GitHub Releases 下载 `womtool-91.jar`，并保存到：
 
 ```text
 .cache/womtool/womtool.jar

--- a/tools/womtool/README.md
+++ b/tools/womtool/README.md
@@ -14,7 +14,7 @@ scripts/install_womtool.ps1
 .cache/womtool/womtool.jar
 ```
 
-validator 会自动从该 cache 路径发现 JAR。也可以通过环境变量覆盖：
+项目的 `WDL validator` 会自动从该 cache 路径发现 JAR。也可以通过环境变量覆盖：
 
 ```env
 WOMTOOL_JAR="D:/path/to/womtool.jar"


### PR DESCRIPTION
## Summary

- Translate the container helper README into Chinese while preserving commands, image tag rules, and Tool Catalog terminology.
- Translate the local WOMtool setup README into Chinese.
- Translate the tiny RNA-seq DEG fixture README into Chinese and align the wording with the rest of the project documentation.

## Verification

- `git diff --check`

Unit tests were not run because this change only updates documentation.