### PR TITLE
Add orchestration state scaffold

### DIFF
--- a/docs/p1-orchestration-graph-plan.md
+++ b/docs/p1-orchestration-graph-plan.md
@@ -123,7 +123,7 @@ CLI --input / API POST /api/compile / tests
 
 目标：建立上层图状态，避免自然语言编排字段污染 `WorkflowState`。
 
-建议字段：
+已落地字段（`src/orchestration/state.py`）：
 
 | 字段 | 类型 | 说明 |
 | --- | --- | --- |
@@ -136,6 +136,12 @@ CLI --input / API POST /api/compile / tests
 | `compiler_result` | `WorkflowCompilationResult \| None` | 下层编译结果 |
 | `errors` | `list[str]` | 上层编排错误 |
 | `events` | `list[dict[str, Any]]` | 可选的图内事件记录，具体持久化仍由 service/run layer 管理 |
+
+已落地辅助函数：
+
+- `build_initial_orchestration_state(...)`：为自然语言编排 run 创建初始状态。
+- `orchestration_succeeded(...)`：只有上层没有错误且下层 compiler result 成功时返回 `True`。
+- `orchestration_failure_stage(...)`：区分失败发生在上层 orchestration 还是下层 compiler。
 
 验收：
 
@@ -384,7 +390,7 @@ run.completed
 
 - [x] `compiler_graph` 成为结构化编译图的明确导出名。
 - [x] `agent` 兼容别名仍可用于旧调用，或有明确迁移说明。
-- [ ] Orchestration State 不污染 `WorkflowState`。
+- [x] Orchestration State 不污染 `WorkflowState`。
 - [ ] Planner node 只产出 Recipe Tool Plan 和 trace，不产出最终 WDL。
 - [ ] Orchestration Graph 实现 `natural_language_planner -> compiler_graph`。
 - [ ] 自然语言入口调用 Orchestration Graph。

--- a/docs/test-cases.md
+++ b/docs/test-cases.md
@@ -52,7 +52,7 @@ powershell -ExecutionPolicy Bypass -File scripts\check_p0.ps1 `
 
 ```text
 .venv\Scripts\python.exe -m unittest discover -v
-Ran 146 tests
+Ran 147 tests
 OK (skipped=2)
 ```
 
@@ -1401,6 +1401,28 @@ files = flatten([qc.html_report, qc.json_report, [extra_report]])
 覆盖点：
 
 - 上层 Planner / orchestration 错误可与下层 compiler 错误区分。
+
+### `test_orchestration_failure_stage_treats_missing_compiler_result_as_orchestration`
+
+输入：
+
+- 初始 Orchestration State。
+- 不设置 `compiler_result`。
+
+执行：
+
+- 调用 `orchestration_succeeded(...)`。
+- 调用 `orchestration_failure_stage(...)`。
+
+期望输出：
+
+- `orchestration_succeeded(...) == False`。
+- `orchestration_failure_stage(...) == "orchestration"`。
+
+覆盖点：
+
+- 未委派到 Compiler Graph 或缺失 compiler result 的终态不会被误判为成功。
+- `orchestration_failure_stage(...)` 只在成功时返回 `None`。
 
 ### `test_orchestration_failure_stage_distinguishes_compiler_failure`
 

--- a/docs/test-cases.md
+++ b/docs/test-cases.md
@@ -52,7 +52,7 @@ powershell -ExecutionPolicy Bypass -File scripts\check_p0.ps1 `
 
 ```text
 .venv\Scripts\python.exe -m unittest discover -v
-Ran 140 tests
+Ran 146 tests
 OK (skipped=2)
 ```
 
@@ -1317,6 +1317,132 @@ files = flatten([qc.html_report, qc.json_report, [extra_report]])
 覆盖点：
 
 - Compiler Graph 可以直接接收 Recipe Tool Plan 并完成 normalizer -> analyzer -> renderer -> checker 流程。
+
+## `tests/test_orchestration_state.py`
+
+该文件验证 P1 Orchestration State 初版。该状态用于后续自然语言上层图，
+与下层 Compiler Graph 的 `WorkflowState` 分离。
+
+### `test_initial_orchestration_state_records_request_and_planner_options`
+
+输入：
+
+- 自然语言请求：`Run bulk RNA-seq differential expression.`
+- `planner_model = DEFAULT_PLANNER_MODEL`
+- `check=False`
+
+执行：
+
+- 调用 `build_initial_orchestration_state(...)`。
+
+期望输出：
+
+- state 保存原始 `request`、`planner_model` 和 `check`。
+- `plan`、`planner_prompt`、`planner_raw_response`、`compiler_result` 初始为 `None`。
+- `errors` 和 `events` 初始为空列表。
+
+覆盖点：
+
+- 自然语言 Planner trace 和下层 compiler result 有独立承载字段。
+
+### `test_initial_orchestration_state_uses_independent_mutable_lists`
+
+输入：
+
+- 分别构造两个 Orchestration State。
+
+执行：
+
+- 向第一个 state 的 `errors` 和 `events` 追加内容。
+
+期望输出：
+
+- 第二个 state 的 `errors` 和 `events` 仍为空。
+
+覆盖点：
+
+- 初始状态不会共享可变列表。
+
+### `test_orchestration_state_does_not_pollute_compiler_workflow_state`
+
+输入：
+
+- 调用 `build_initial_state({})` 构造 Compiler Graph 的 `WorkflowState`。
+
+执行：
+
+- 检查 orchestration-only 字段是否存在于 `WorkflowState`。
+
+期望输出：
+
+- `request`、`planner_model`、`plan`、`planner_prompt`、`compiler_result` 等上层字段均不在 `WorkflowState` 中。
+
+覆盖点：
+
+- Orchestration State 与 Compiler Graph `WorkflowState` 保持分层。
+
+### `test_orchestration_failure_stage_distinguishes_top_level_errors`
+
+输入：
+
+- 初始 Orchestration State。
+- 向 `errors` 添加 Planner JSON 解析失败信息。
+
+执行：
+
+- 调用 `orchestration_succeeded(...)`。
+- 调用 `orchestration_failure_stage(...)`。
+
+期望输出：
+
+- `orchestration_succeeded(...) == False`。
+- `orchestration_failure_stage(...) == "orchestration"`。
+
+覆盖点：
+
+- 上层 Planner / orchestration 错误可与下层 compiler 错误区分。
+
+### `test_orchestration_failure_stage_distinguishes_compiler_failure`
+
+输入：
+
+- 初始 Orchestration State。
+- 设置 `compiler_result` 为 `succeeded=False` 的 `WorkflowCompilationResult`。
+
+执行：
+
+- 调用 `orchestration_succeeded(...)`。
+- 调用 `orchestration_failure_stage(...)`。
+
+期望输出：
+
+- `orchestration_succeeded(...) == False`。
+- `orchestration_failure_stage(...) == "compiler"`。
+
+覆盖点：
+
+- 下层 Compiler Graph 失败保留为 compiler failure，而不是混入上层错误。
+
+### `test_orchestration_succeeded_requires_successful_compiler_result`
+
+输入：
+
+- 初始 Orchestration State。
+- 设置 `compiler_result` 为 `succeeded=True` 的 `WorkflowCompilationResult`。
+
+执行：
+
+- 调用 `orchestration_succeeded(...)`。
+- 调用 `orchestration_failure_stage(...)`。
+
+期望输出：
+
+- `orchestration_succeeded(...) == True`。
+- `orchestration_failure_stage(...) is None`。
+
+覆盖点：
+
+- P1 上层 run 的成功语义要求 orchestration 和 delegated compiler 都成功。
 
 ## `tests/test_workflow_service.py`
 

--- a/src/orchestration/__init__.py
+++ b/src/orchestration/__init__.py
@@ -1,0 +1,17 @@
+"""Orchestration graph support package."""
+
+from src.orchestration.state import (
+    FailureStage,
+    OrchestrationState,
+    build_initial_orchestration_state,
+    orchestration_failure_stage,
+    orchestration_succeeded,
+)
+
+__all__ = [
+    "FailureStage",
+    "OrchestrationState",
+    "build_initial_orchestration_state",
+    "orchestration_failure_stage",
+    "orchestration_succeeded",
+]

--- a/src/orchestration/state.py
+++ b/src/orchestration/state.py
@@ -1,0 +1,70 @@
+"""State helpers for the natural-language orchestration graph."""
+
+from __future__ import annotations
+
+import operator
+from typing import Any, Literal, TYPE_CHECKING
+
+from typing_extensions import Annotated, TypedDict
+
+if TYPE_CHECKING:
+    from src.services.workflow_service import WorkflowCompilationResult
+
+
+FailureStage = Literal["orchestration", "compiler"]
+
+
+class OrchestrationState(TypedDict):
+    """Top-level state for natural-language planning and compiler delegation."""
+
+    request: str
+    planner_model: str
+    check: bool
+    plan: dict[str, Any] | None
+    planner_prompt: str | None
+    planner_raw_response: str | None
+    compiler_result: WorkflowCompilationResult | None
+    errors: Annotated[list[str], operator.add]
+    events: Annotated[list[dict[str, Any]], operator.add]
+
+
+def build_initial_orchestration_state(
+    request: str,
+    *,
+    planner_model: str,
+    check: bool = True,
+) -> OrchestrationState:
+    """Build the initial state for a natural-language orchestration run."""
+    return {
+        "request": request,
+        "planner_model": planner_model,
+        "check": check,
+        "plan": None,
+        "planner_prompt": None,
+        "planner_raw_response": None,
+        "compiler_result": None,
+        "errors": [],
+        "events": [],
+    }
+
+
+def orchestration_succeeded(state: OrchestrationState) -> bool:
+    """Return whether orchestration and delegated compilation both succeeded."""
+    if state["errors"]:
+        return False
+
+    compiler_result = state["compiler_result"]
+    if compiler_result is None:
+        return False
+    return compiler_result.succeeded
+
+
+def orchestration_failure_stage(state: OrchestrationState) -> FailureStage | None:
+    """Identify whether a failed run failed in orchestration or compilation."""
+    if state["errors"]:
+        return "orchestration"
+
+    compiler_result = state["compiler_result"]
+    if compiler_result is not None and not compiler_result.succeeded:
+        return "compiler"
+    return None

--- a/src/orchestration/state.py
+++ b/src/orchestration/state.py
@@ -65,6 +65,8 @@ def orchestration_failure_stage(state: OrchestrationState) -> FailureStage | Non
         return "orchestration"
 
     compiler_result = state["compiler_result"]
-    if compiler_result is not None and not compiler_result.succeeded:
+    if compiler_result is None:
+        return "orchestration"
+    if not compiler_result.succeeded:
         return "compiler"
     return None

--- a/tests/test_orchestration_state.py
+++ b/tests/test_orchestration_state.py
@@ -64,10 +64,20 @@ class OrchestrationStateTests(unittest.TestCase):
         self.assertFalse(orchestration_succeeded(state))
         self.assertEqual(orchestration_failure_stage(state), "orchestration")
 
+    def test_orchestration_failure_stage_treats_missing_compiler_result_as_orchestration(self):
+        state = build_initial_orchestration_state(
+            "Run bulk RNA-seq differential expression.",
+            planner_model=DEFAULT_PLANNER_MODEL,
+        )
+
+        self.assertFalse(orchestration_succeeded(state))
+        self.assertEqual(orchestration_failure_stage(state), "orchestration")
+
     def test_orchestration_failure_stage_distinguishes_compiler_failure(self):
         state = build_initial_orchestration_state(
             "Run bulk RNA-seq differential expression.",
             planner_model=DEFAULT_PLANNER_MODEL,
+            check=False,
         )
         state["compiler_result"] = WorkflowCompilationResult(
             plan=None,
@@ -90,6 +100,7 @@ class OrchestrationStateTests(unittest.TestCase):
         state = build_initial_orchestration_state(
             "Run bulk RNA-seq differential expression.",
             planner_model=DEFAULT_PLANNER_MODEL,
+            check=False,
         )
         state["compiler_result"] = WorkflowCompilationResult(
             plan={"workflow": {"recipe": "rnaseq_differential_expression"}},

--- a/tests/test_orchestration_state.py
+++ b/tests/test_orchestration_state.py
@@ -1,0 +1,115 @@
+import unittest
+
+from src.nl_planner import DEFAULT_PLANNER_MODEL
+from src.orchestration import (
+    build_initial_orchestration_state,
+    orchestration_failure_stage,
+    orchestration_succeeded,
+)
+from src.services.workflow_service import WorkflowCompilationResult, build_initial_state
+
+
+class OrchestrationStateTests(unittest.TestCase):
+    def test_initial_orchestration_state_records_request_and_planner_options(self):
+        state = build_initial_orchestration_state(
+            "Run bulk RNA-seq differential expression.",
+            planner_model=DEFAULT_PLANNER_MODEL,
+            check=False,
+        )
+
+        self.assertEqual(state["request"], "Run bulk RNA-seq differential expression.")
+        self.assertEqual(state["planner_model"], DEFAULT_PLANNER_MODEL)
+        self.assertFalse(state["check"])
+        self.assertIsNone(state["plan"])
+        self.assertIsNone(state["planner_prompt"])
+        self.assertIsNone(state["planner_raw_response"])
+        self.assertIsNone(state["compiler_result"])
+        self.assertEqual(state["errors"], [])
+        self.assertEqual(state["events"], [])
+
+    def test_initial_orchestration_state_uses_independent_mutable_lists(self):
+        first = build_initial_orchestration_state("first", planner_model=DEFAULT_PLANNER_MODEL)
+        second = build_initial_orchestration_state("second", planner_model=DEFAULT_PLANNER_MODEL)
+
+        first["errors"].append("planner failed")
+        first["events"].append({"type": "node.failed", "node": "planner"})
+
+        self.assertEqual(second["errors"], [])
+        self.assertEqual(second["events"], [])
+
+    def test_orchestration_state_does_not_pollute_compiler_workflow_state(self):
+        workflow_state = build_initial_state({})
+
+        orchestration_only_fields = {
+            "request",
+            "planner_model",
+            "check",
+            "plan",
+            "planner_prompt",
+            "planner_raw_response",
+            "compiler_result",
+            "errors",
+            "events",
+        }
+        for field in orchestration_only_fields:
+            self.assertNotIn(field, workflow_state)
+
+    def test_orchestration_failure_stage_distinguishes_top_level_errors(self):
+        state = build_initial_orchestration_state(
+            "Run bulk RNA-seq differential expression.",
+            planner_model=DEFAULT_PLANNER_MODEL,
+        )
+        state["errors"].append("LLM planner JSON parsing failed: bad json")
+
+        self.assertFalse(orchestration_succeeded(state))
+        self.assertEqual(orchestration_failure_stage(state), "orchestration")
+
+    def test_orchestration_failure_stage_distinguishes_compiler_failure(self):
+        state = build_initial_orchestration_state(
+            "Run bulk RNA-seq differential expression.",
+            planner_model=DEFAULT_PLANNER_MODEL,
+        )
+        state["compiler_result"] = WorkflowCompilationResult(
+            plan=None,
+            workflow_ir={},
+            wdl="",
+            analysis_errors=["missing required workflow input 'sample_groups'"],
+            analysis_warnings=[],
+            repair_actions=[],
+            validation_message="",
+            is_valid=False,
+            succeeded=False,
+            check_performed=False,
+            state=build_initial_state({}),
+        )
+
+        self.assertFalse(orchestration_succeeded(state))
+        self.assertEqual(orchestration_failure_stage(state), "compiler")
+
+    def test_orchestration_succeeded_requires_successful_compiler_result(self):
+        state = build_initial_orchestration_state(
+            "Run bulk RNA-seq differential expression.",
+            planner_model=DEFAULT_PLANNER_MODEL,
+        )
+        state["compiler_result"] = WorkflowCompilationResult(
+            plan={"workflow": {"recipe": "rnaseq_differential_expression"}},
+            workflow_ir={"workflow": {"name": "RNASeqDEG"}},
+            wdl="version 1.0\nworkflow RNASeqDEG {}",
+            analysis_errors=[],
+            analysis_warnings=[],
+            repair_actions=[],
+            validation_message="WDL syntax validation skipped (--no-check).",
+            is_valid=False,
+            succeeded=True,
+            check_performed=False,
+            state=build_initial_state({}),
+            planner_prompt="planner prompt",
+            planner_raw_response="{}",
+        )
+
+        self.assertTrue(orchestration_succeeded(state))
+        self.assertIsNone(orchestration_failure_stage(state))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add the `src.orchestration` package with an initial `OrchestrationState` contract.
- Add helpers for initial state creation, success evaluation, and failure-stage classification.
- Keep orchestration state separate from compiler `WorkflowState` and document the P1.2 boundary.
- Update test-case documentation for the new orchestration state coverage.

## Validation

- `git diff --check`
- `.\.venv\Scripts\python.exe -m unittest tests.test_orchestration_state -v`
- `.\.venv\Scripts\python.exe -m unittest discover -v` (147 tests, OK, skipped=2)