### PR TITLE
Implement initial W4 workflow workbench run flow

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -487,6 +487,9 @@ Web 展示轨道与后续 Multi-Agent 能力路线并行推进，优先让已经
 | W5 | DAG 与历史详情 | React Flow 工作流图、run 历史详情和失败/修复回放 | W4 |
 | W6 | 部署与作品集打磨 | 在线 demo、示例数据、架构图、截图/录屏、API 文档与 README 导航 | W5 |
 
+`W4` 的具体实施范围、任务拆分和验收口径记录在
+[W4 Workflow 生成工作台工作拆解](./docs/w4-workbench-plan.md)。
+
 求职展示的最小可发布范围为 `W0` 至 `W5`：访问者能够使用一个预置 RNA-seq 示例触发 run，看到 Agent/Compiler 的阶段过程、Workflow IR、DAG、校验后的 WDL 与历史回放。`W6` 负责将能力包装成可在简历和项目主页直接访问、快速理解的作品。
 
 ## Agent 修复闭环与职责边界（规划中）

--- a/docs/w4-workbench-plan.md
+++ b/docs/w4-workbench-plan.md
@@ -1,0 +1,187 @@
+# W4 Workflow 生成工作台工作拆解
+
+本文档记录 Web 产品化路线中 `W4` 阶段的实施范围、任务拆分和验收口径，便于后续开发按同一边界推进。
+
+## 阶段定位
+
+`W4` 的目标是把 `W3` 已搭好的静态工作台预览接入 `W2` 已落地的 run API、SQLite 持久化和 SSE 事件流，形成一个可演示的 Workflow 生成工作台。
+
+完成后，访问者应能提交一个预置 RNA-seq 示例，实时看到 Agent / Compiler 的阶段事件，并查看同一次 run 产生的 Recipe Tool Plan、Workflow IR、WDL 和 diagnostics。
+
+`W4` 是 Web 工作台与可观测性接入阶段，不改变 Compiler Graph 的职责，也不引入新的 Multi-Agent 能力。
+
+## 当前基础
+
+- 后端已有异步 run 创建接口：
+  - `POST /api/runs`：自然语言请求入口，需要 planner 环境变量可用。
+  - `POST /api/compile`：结构化 Recipe Tool Plan / Workflow IR 编译入口，不需要 API key。
+- 后端已有 run 查询和事件接口：
+  - `GET /api/runs/{run_id}`：返回 run snapshot、artifacts 和 diagnostics。
+  - `GET /api/runs/{run_id}/events`：通过 SSE 推送或回放 run events。
+- 事件 envelope 已覆盖第一版工作台所需事件类型：
+  - `run.created`
+  - `node.started`
+  - `node.completed`
+  - `node.failed`
+  - `artifact.updated`
+  - `repair.applied`
+  - `validation.completed`
+  - `run.completed`
+- 前端已有 `/workspace` 页面，但当前仍是静态预览：运行按钮禁用，timeline、artifact tabs 和 diagnostics 文案均为占位内容。
+
+## 产品行为
+
+第一版工作台建议支持两个运行路径：
+
+1. **稳定示例运行**：默认使用 `examples/rnaseq_deg_recipe_plan.json` 作为 payload 调用 `POST /api/compile`。这条路径适合本地和公开 demo，因为它不依赖 `DEEPSEEK_API_KEY`，仍然完整经过 Compiler Graph。
+2. **自然语言运行**：用户输入自然语言请求时调用 `POST /api/runs`。如果 planner 环境不可用，工作台应展示后端返回的失败诊断，而不是在前端自行模拟成功。
+
+页面需要围绕同一个 `run_id` 组织所有视图：
+
+- 输入面板展示请求文本、运行模式、`check` 开关和当前 run 状态。
+- 执行时间线展示每个阶段的 pending / running / completed / failed 状态。
+- 产物查看区展示 Plan、IR、WDL 和 Diagnostics。
+- 失败状态保留已产生的事件和 diagnostics，体现可审计失败，而不是只显示通用错误提示。
+
+## 任务拆分
+
+### 1. 前端 API client 与类型
+
+在 `web/lib/api.ts` 和 `web/lib/types.ts` 中补齐工作台所需的客户端能力：
+
+- `createNaturalLanguageRun(request, check, plannerModel?)`
+- `createStructuredCompileRun(payload, check)`
+- `getRunSnapshot(runId)`
+- `buildRunEventsUrl(eventsUrl, afterSequence?)`
+- `RunEvent`
+- `WorkflowArtifacts`
+- `DiagnosticReport`
+- `WorkflowRunSnapshotResponse`
+
+类型应与后端 Pydantic DTO 显式同步，避免在页面组件中使用松散的 `any` 拼装 run 数据。
+
+### 2. `/workspace` 页面交互化
+
+将当前静态工作台拆成 server page + client workbench 组件，或直接将交互区域封装为 client component。
+
+需要实现：
+
+- RNA-seq 示例预填充。
+- 可编辑自然语言输入。
+- 运行模式选择：结构化示例编译 / 自然语言规划编译。
+- `check` 开关。
+- 运行按钮、运行中禁用状态和当前 run id。
+- 空状态、运行中状态、成功状态和失败状态。
+
+页面不应在前端构造 Workflow IR 或 WDL；前端只提交请求、订阅事件、读取 snapshot 并展示后端产物。
+
+### 3. Run 提交与 SSE 状态机
+
+提交成功后，前端从 `RunAcceptedResponse` 获取 `run_id` 和 `events_url`，立即建立 `EventSource` 订阅。
+
+事件处理规则：
+
+- 维护 `lastSequence`，用于断线重连时追加 `?after=<lastSequence>`。
+- `node.started` 将对应节点置为 running。
+- `node.completed` 将对应节点置为 completed。
+- `node.failed` 将对应节点置为 failed，并将 run 状态转为 failed 候选状态。
+- `repair.applied` 在 timeline 中保留 repairer 事件，并更新 diagnostics 提示。
+- `validation.completed` 更新 checker 状态与 validation 摘要。
+- `artifact.updated` 只说明有产物更新；前端应再请求 `GET /api/runs/{run_id}` 获取完整 artifact 内容。
+- `run.completed` 是终态事件；收到后关闭 EventSource，并做一次最终 snapshot 拉取。
+
+SSE 断开但 run 未终态时，页面应显示连接状态，并允许自动重连或手动重新连接。
+
+### 4. 执行时间线
+
+时间线应覆盖第一版工作台重点阶段：
+
+- Planner / Recipe Tool Plan
+- IR Normalizer
+- Analyzer
+- Repairer（仅有事件时显示）
+- Renderer
+- WOMtool Checker
+- Run Completed
+
+结构化编译模式不会出现 planner 事件，页面应自然跳过或显示为不适用，而不是标成失败。
+
+### 5. 产物查看区
+
+产物区从当前静态卡片改成真实 tabs：
+
+- **Plan**：展示 Recipe Tool Plan JSON；结构化编译 payload 是 Recipe Tool Plan 时应可见。
+- **IR**：展示 Workflow IR JSON，优先使用 pretty JSON。
+- **WDL**：展示生成的 WDL 1.0 文本。
+- **Diagnostics**：展示 `analysis_errors`、`analysis_warnings`、`repair_actions`、`validation_message`、`is_valid`、`succeeded` 和 `check_performed`。
+
+每个 tab 都需要清晰的空状态。运行过程中 artifact 尚未生成时，应显示“等待对应阶段完成”，不要显示静态示例内容。
+
+### 6. 错误与边界状态
+
+至少覆盖以下用户可见状态：
+
+- FastAPI 服务不可达。
+- 请求体校验失败或 API 返回 422。
+- 自然语言 planner 缺少 API key 或 planner 失败。
+- Compiler Graph 阶段失败。
+- WDL checker 失败。
+- SSE 连接中断。
+- Run 终态为 failed，但已有部分 artifact 可查看。
+
+错误文案应说明失败发生在哪个阶段，并尽量复用后端 diagnostics 和 event summary。
+
+### 7. 文案与导航更新
+
+W4 完成后，需要把 Web 页面中 “W3 静态预览”、“运行待接入”、“W4 接入真实 run 数据” 等占位文案更新为真实工作台表述。
+
+项目介绍页可以继续强调：
+
+- 自然语言只到 Recipe Tool Plan。
+- Workflow IR 是编译契约。
+- WDL 由确定性 renderer 生成。
+- Analyzer / Repairer / Checker 过程可追踪。
+
+公共文案保持项目维护者视角，不加入工具签名、自动生成说明或 AI-assistant 品牌化措辞。
+
+## W4 不做
+
+- 不实现 React Flow DAG 可视化；该能力属于 `W5`。
+- 不实现 run 历史详情页和失败/修复回放详情；该能力属于 `W5`。
+- 不改变 Recipe Tool Plan、Workflow IR、Analyzer、Renderer 或 Checker 的架构边界。
+- 不让前端生成或修复 Plan、IR、WDL。
+- 不引入新的 Agent 节点、Reviewer LLM 或 Tool Retriever。
+- 不接入真实 WDL 执行后端；执行能力仍通过 `src.execution` 后端边界独立推进。
+
+## 建议 PR 顺序
+
+1. **W4 API client and types**：补齐前端 run DTO、API client、SSE URL helper。
+2. **W4 workbench run lifecycle**：实现提交、run 状态、EventSource 订阅和 snapshot 拉取。
+3. **W4 timeline and artifacts**：实现时间线状态映射、Plan / IR / WDL / Diagnostics tabs。
+4. **W4 failure states and polish**：补齐错误状态、空状态、占位文案替换和响应式细节。
+5. **W4 docs and verification**：更新 README / DEVELOPMENT 中的阶段状态说明，并记录验证结果。
+
+## 验收标准
+
+功能验收：
+
+- 启动 FastAPI 与 Next.js 后，访问 `/workspace?example=rnaseq-deg` 可以提交一次结构化 RNA-seq 示例 run。
+- 页面能从 `created` / `running` 推进到 `succeeded` 或 `failed`。
+- Timeline 能实时显示 Compiler Graph 节点进度。
+- Plan、Workflow IR、WDL 和 Diagnostics 来自真实 run snapshot。
+- 自然语言模式在 planner 环境可用时能走 `POST /api/runs`；环境不可用时显示明确失败诊断。
+- 失败 run 仍保留已产生事件、artifact 和 diagnostics。
+
+验证建议：
+
+```powershell
+.\.venv\Scripts\python.exe -m unittest discover -v
+```
+
+```powershell
+cd web
+npm run lint
+npm run build
+```
+
+如果 W4 只改前端展示和 API client，不改变 renderer、recipe resolution、validation path 或生成 WDL 的代码，一般不需要额外生成 WDL 并运行 `miniwdl check`。如果后续实现过程中触碰 WDL 输出路径，则需要按项目开发规则补充代表性 WDL 语法校验。

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -1,12 +1,37 @@
 """FastAPI application factory."""
 
+from __future__ import annotations
+
+import os
+
 from fastapi import FastAPI, Response
+from fastapi.middleware.cors import CORSMiddleware
 
 from src.api.routes import api_router
 
 
+DEFAULT_CORS_ORIGINS = (
+    "http://127.0.0.1:3000",
+    "http://localhost:3000",
+)
+
+
+def get_cors_origins() -> list[str]:
+    configured = os.environ.get("AI_BIOWORKFLOW_CORS_ORIGINS")
+    if configured is None:
+        return list(DEFAULT_CORS_ORIGINS)
+
+    return [origin.strip() for origin in configured.split(",") if origin.strip()]
+
+
 def create_app() -> FastAPI:
     app = FastAPI(title="AI-bioworkflow API")
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=get_cors_origins(),
+        allow_methods=["GET", "POST"],
+        allow_headers=["*"],
+    )
 
     @app.get("/", tags=["health"])
     def read_root() -> dict[str, str]:

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -21,7 +21,7 @@ def get_cors_origins() -> list[str]:
     if configured is None:
         return list(DEFAULT_CORS_ORIGINS)
 
-    return [origin.strip() for origin in configured.split(",") if origin.strip()]
+    return [origin.strip().rstrip("/") for origin in configured.split(",") if origin.strip()]
 
 
 def create_app() -> FastAPI:

--- a/tests/api/test_server.py
+++ b/tests/api/test_server.py
@@ -37,7 +37,7 @@ class ApiServerConfigTests(unittest.TestCase):
     def test_cors_origins_can_be_overridden_by_environment(self):
         with patch.dict(
             "os.environ",
-            {"AI_BIOWORKFLOW_CORS_ORIGINS": "http://127.0.0.1:3001, http://localhost:3001"},
+            {"AI_BIOWORKFLOW_CORS_ORIGINS": "http://127.0.0.1:3001/, http://localhost:3001"},
         ):
             self.assertEqual(
                 get_cors_origins(),

--- a/tests/api/test_server.py
+++ b/tests/api/test_server.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 from fastapi.testclient import TestClient
 
-from src.api.app import create_app
+from src.api.app import DEFAULT_CORS_ORIGINS, create_app, get_cors_origins
 from src.api.server import DEFAULT_API_HOST, DEFAULT_API_PORT, get_api_host, get_api_port
 
 
@@ -29,6 +29,35 @@ class ApiServerConfigTests(unittest.TestCase):
     def test_api_host_can_be_overridden_by_environment(self):
         with patch.dict("os.environ", {"AI_BIOWORKFLOW_API_HOST": "0.0.0.0"}):
             self.assertEqual(get_api_host(), "0.0.0.0")
+
+    def test_default_cors_origins_cover_next_development_server(self):
+        self.assertIn("http://127.0.0.1:3000", DEFAULT_CORS_ORIGINS)
+        self.assertIn("http://localhost:3000", DEFAULT_CORS_ORIGINS)
+
+    def test_cors_origins_can_be_overridden_by_environment(self):
+        with patch.dict(
+            "os.environ",
+            {"AI_BIOWORKFLOW_CORS_ORIGINS": "http://127.0.0.1:3001, http://localhost:3001"},
+        ):
+            self.assertEqual(
+                get_cors_origins(),
+                ["http://127.0.0.1:3001", "http://localhost:3001"],
+            )
+
+    def test_next_development_origin_can_preflight_api_requests(self):
+        client = TestClient(create_app())
+
+        response = client.options(
+            "/api/compile",
+            headers={
+                "Origin": "http://127.0.0.1:3000",
+                "Access-Control-Request-Method": "POST",
+                "Access-Control-Request-Headers": "content-type",
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.headers["access-control-allow-origin"], "http://127.0.0.1:3000")
 
     def test_root_and_health_endpoints_are_available(self):
         client = TestClient(create_app())

--- a/web/app/workspace/page.tsx
+++ b/web/app/workspace/page.tsx
@@ -6,7 +6,6 @@ import {
   Clock3,
   FileJson,
   Layers3,
-  Play,
   SquareTerminal,
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
@@ -16,6 +15,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { apiDocsUrl } from "@/lib/api";
 import { rnaseqExamplePrompt, rnaseqRecipeSteps } from "@/lib/examples";
+import { WorkspaceRunLauncher } from "./workspace-run-launcher";
 
 const timeline = [
   ["需求输入", "request", "展示自然语言请求和预期 recipe steps"],
@@ -57,20 +57,17 @@ export default async function WorkspacePage({
             </Link>
           </Button>
           <div className="flex flex-wrap items-center gap-3">
-            <h1 className="text-3xl font-semibold tracking-normal">Workflow 工作台预览</h1>
-            <Badge variant="secondary">W3 产品外壳</Badge>
+            <h1 className="text-3xl font-semibold tracking-normal">Workflow 工作台</h1>
+            <Badge variant="secondary">W4 接入中</Badge>
           </div>
           <p className="mt-3 max-w-2xl text-muted-foreground">
-            这个页面定义后续生成工作台的 review surface：需求输入、阶段时间线、
-            Plan / IR / WDL 产物和 diagnostics 会在这里形成同一次 run 的可解释视图。
-            当前以 RNA-seq 示例做静态预览，真实 run 创建与 SSE 事件将在 W4 接入。
+            这个页面正在从静态 review surface 演进为真实生成工作台。当前已接入
+            RNA-seq 结构化示例 run 创建；SSE 时间线、snapshot 产物刷新和 diagnostics
+            展示会在后续 W4 切片继续接入。
           </p>
         </div>
         <div className="flex flex-wrap gap-3">
-          <Button disabled>
-            <Play className="h-4 w-4" />
-            运行待接入
-          </Button>
+          <WorkspaceRunLauncher />
           <Button asChild variant="outline">
             <Link href={apiDocsUrl}>API 文档</Link>
           </Button>
@@ -83,7 +80,7 @@ export default async function WorkspacePage({
             <div>
               <h2 className="font-semibold">请求输入</h2>
               <p className="mt-1 text-sm text-muted-foreground">
-                自然语言需求会先进入 Recipe Tool Plan 边界，而不是直接生成 WDL。
+                运行按钮会提交结构化 Recipe Tool Plan 示例；前端不生成 IR 或 WDL。
               </p>
             </div>
             <Badge variant={isExample ? "default" : "outline"}>
@@ -110,12 +107,12 @@ export default async function WorkspacePage({
             <div>
               <h2 className="font-semibold">Run 时间线</h2>
               <p className="mt-1 text-sm text-muted-foreground">
-                使用静态示例展示事件结构；真实数据会从持久化 SSE event envelope 实时更新或回放。
+                当前保留事件结构预览；下一切片会从持久化 SSE event envelope 实时更新。
               </p>
             </div>
             <Badge variant="outline">
               <Clock3 className="mr-1 h-3.5 w-3.5" />
-              静态预览
+              等待 SSE 接入
             </Badge>
           </div>
           <div className="mt-5 grid gap-3 md:grid-cols-2">

--- a/web/app/workspace/workspace-run-launcher.tsx
+++ b/web/app/workspace/workspace-run-launcher.tsx
@@ -37,7 +37,7 @@ function formatRunError(error: unknown): string {
   if (error instanceof Error) {
     return error.message;
   }
-  return "无法创建结构化示例 run。";
+  return "请求处理失败，请稍后重试。";
 }
 
 function getStatusIcon(status: RunStatus, isPolling: boolean) {

--- a/web/app/workspace/workspace-run-launcher.tsx
+++ b/web/app/workspace/workspace-run-launcher.tsx
@@ -129,6 +129,7 @@ export function WorkspaceRunLauncher() {
 
   async function handleRunExample() {
     setIsSubmitting(true);
+    setAcceptedRun(null);
     setErrorMessage(null);
     setPollErrorMessage(null);
     setSnapshot(null);

--- a/web/app/workspace/workspace-run-launcher.tsx
+++ b/web/app/workspace/workspace-run-launcher.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { AlertCircle, CheckCircle2, Loader2, Play } from "lucide-react";
+import { useState } from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { createStructuredCompileRun } from "@/lib/api";
+import { rnaseqRecipePlan } from "@/lib/examples";
+import type { RunAcceptedResponse } from "@/lib/types";
+
+function formatRunError(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return "无法创建结构化示例 run。";
+}
+
+export function WorkspaceRunLauncher() {
+  const [acceptedRun, setAcceptedRun] = useState<RunAcceptedResponse | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  async function handleRunExample() {
+    setIsSubmitting(true);
+    setErrorMessage(null);
+
+    try {
+      const accepted = await createStructuredCompileRun(rnaseqRecipePlan, true);
+      setAcceptedRun(accepted);
+    } catch (error) {
+      setAcceptedRun(null);
+      setErrorMessage(formatRunError(error));
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="flex w-full flex-col gap-2 sm:w-auto sm:items-end">
+      <Button type="button" onClick={handleRunExample} disabled={isSubmitting}>
+        {isSubmitting ? (
+          <Loader2 className="h-4 w-4 animate-spin" />
+        ) : (
+          <Play className="h-4 w-4" />
+        )}
+        {isSubmitting ? "提交中" : acceptedRun ? "重新运行示例" : "运行示例"}
+      </Button>
+
+      {acceptedRun ? (
+        <div className="flex max-w-full flex-wrap items-center gap-2 text-xs text-muted-foreground sm:justify-end">
+          <Badge variant="secondary">
+            <CheckCircle2 className="mr-1 h-3.5 w-3.5" />
+            已创建 run
+          </Badge>
+          <span className="break-all font-mono">{acceptedRun.run_id}</span>
+          <span>状态：{acceptedRun.status}</span>
+        </div>
+      ) : null}
+
+      {errorMessage ? (
+        <div className="flex max-w-md items-start gap-2 text-xs leading-5 text-destructive sm:text-right">
+          <AlertCircle className="mt-0.5 h-3.5 w-3.5 flex-none" />
+          <span>{errorMessage}</span>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/web/app/workspace/workspace-run-launcher.tsx
+++ b/web/app/workspace/workspace-run-launcher.tsx
@@ -1,13 +1,37 @@
 "use client";
 
-import { AlertCircle, CheckCircle2, Loader2, Play } from "lucide-react";
-import { useState } from "react";
+import {
+  AlertCircle,
+  CheckCircle2,
+  Clock3,
+  FileText,
+  Loader2,
+  Play,
+  XCircle,
+} from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { createStructuredCompileRun } from "@/lib/api";
+import { createStructuredCompileRun, getRunSnapshot } from "@/lib/api";
 import { rnaseqRecipePlan } from "@/lib/examples";
-import type { RunAcceptedResponse } from "@/lib/types";
+import type { RunAcceptedResponse, RunStatus, WorkflowRunSnapshotResponse } from "@/lib/types";
+
+const POLL_INTERVAL_MS = 1200;
+
+function isTerminalRunStatus(status: RunStatus): boolean {
+  return status === "succeeded" || status === "failed";
+}
+
+function getRunStatusLabel(status: RunStatus): string {
+  const labels: Record<RunStatus, string> = {
+    created: "已创建",
+    running: "运行中",
+    succeeded: "成功",
+    failed: "失败",
+  };
+  return labels[status];
+}
 
 function formatRunError(error: unknown): string {
   if (error instanceof Error) {
@@ -16,20 +40,105 @@ function formatRunError(error: unknown): string {
   return "无法创建结构化示例 run。";
 }
 
+function getStatusIcon(status: RunStatus, isPolling: boolean) {
+  if (isPolling && !isTerminalRunStatus(status)) {
+    return <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" />;
+  }
+  if (status === "succeeded") {
+    return <CheckCircle2 className="mr-1 h-3.5 w-3.5" />;
+  }
+  if (status === "failed") {
+    return <XCircle className="mr-1 h-3.5 w-3.5" />;
+  }
+  return <Clock3 className="mr-1 h-3.5 w-3.5" />;
+}
+
+function getStatusBadgeVariant(status: RunStatus): "secondary" | "destructive" | "outline" {
+  if (status === "failed") {
+    return "destructive";
+  }
+  if (status === "succeeded") {
+    return "secondary";
+  }
+  return "outline";
+}
+
 export function WorkspaceRunLauncher() {
   const [acceptedRun, setAcceptedRun] = useState<RunAcceptedResponse | null>(null);
+  const [snapshot, setSnapshot] = useState<WorkflowRunSnapshotResponse | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [pollErrorMessage, setPollErrorMessage] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isPolling, setIsPolling] = useState(false);
+
+  useEffect(() => {
+    if (acceptedRun === null) {
+      return undefined;
+    }
+
+    const runId = acceptedRun.run_id;
+    let timeoutId: number | undefined;
+    let isCancelled = false;
+
+    async function pollSnapshot() {
+      setIsPolling(true);
+
+      try {
+        const nextSnapshot = await getRunSnapshot(runId);
+        if (isCancelled) {
+          return;
+        }
+
+        setSnapshot(nextSnapshot);
+        setPollErrorMessage(null);
+
+        if (!isTerminalRunStatus(nextSnapshot.status)) {
+          timeoutId = window.setTimeout(pollSnapshot, POLL_INTERVAL_MS);
+        }
+      } catch (error) {
+        if (isCancelled) {
+          return;
+        }
+
+        setPollErrorMessage(formatRunError(error));
+        timeoutId = window.setTimeout(pollSnapshot, POLL_INTERVAL_MS * 2);
+      } finally {
+        if (!isCancelled) {
+          setIsPolling(false);
+        }
+      }
+    }
+
+    void pollSnapshot();
+
+    return () => {
+      isCancelled = true;
+      if (timeoutId !== undefined) {
+        window.clearTimeout(timeoutId);
+      }
+    };
+  }, [acceptedRun]);
+
+  const currentStatus = snapshot?.status ?? acceptedRun?.status ?? null;
+  const wdlLineCount = useMemo(() => {
+    if (!snapshot?.artifacts.wdl) {
+      return 0;
+    }
+    return snapshot.artifacts.wdl.split(/\r?\n/).filter(Boolean).length;
+  }, [snapshot?.artifacts.wdl]);
 
   async function handleRunExample() {
     setIsSubmitting(true);
     setErrorMessage(null);
+    setPollErrorMessage(null);
+    setSnapshot(null);
 
     try {
       const accepted = await createStructuredCompileRun(rnaseqRecipePlan, true);
       setAcceptedRun(accepted);
     } catch (error) {
       setAcceptedRun(null);
+      setSnapshot(null);
       setErrorMessage(formatRunError(error));
     } finally {
       setIsSubmitting(false);
@@ -47,14 +156,46 @@ export function WorkspaceRunLauncher() {
         {isSubmitting ? "提交中" : acceptedRun ? "重新运行示例" : "运行示例"}
       </Button>
 
-      {acceptedRun ? (
-        <div className="flex max-w-full flex-wrap items-center gap-2 text-xs text-muted-foreground sm:justify-end">
-          <Badge variant="secondary">
-            <CheckCircle2 className="mr-1 h-3.5 w-3.5" />
-            已创建 run
-          </Badge>
-          <span className="break-all font-mono">{acceptedRun.run_id}</span>
-          <span>状态：{acceptedRun.status}</span>
+      {acceptedRun && currentStatus ? (
+        <div className="w-full max-w-md rounded-md border bg-background p-3 text-xs leading-5 sm:text-right">
+          <div className="flex flex-wrap items-center gap-2 sm:justify-end">
+            <Badge variant={getStatusBadgeVariant(currentStatus)}>
+              {getStatusIcon(currentStatus, isPolling)}
+              {getRunStatusLabel(currentStatus)}
+            </Badge>
+            <span className="break-all font-mono text-muted-foreground">{acceptedRun.run_id}</span>
+          </div>
+
+          <div className="mt-2 grid gap-1 text-muted-foreground sm:justify-items-end">
+            <div className="max-w-full break-words">
+              WDL：
+              {snapshot?.artifacts.wdl ? `${wdlLineCount} 行，${snapshot.artifacts.wdl.length} 字符` : "等待生成"}
+            </div>
+            <div className="max-w-full break-words">
+              校验：
+              {snapshot?.diagnostics.validation_message || "等待 checker 结果"}
+            </div>
+            {snapshot?.diagnostics.analysis_errors.length ? (
+              <div className="text-destructive">
+                分析错误：{snapshot.diagnostics.analysis_errors.length} 条
+              </div>
+            ) : null}
+            {snapshot?.diagnostics.repair_actions.length ? (
+              <div>修复记录：{snapshot.diagnostics.repair_actions.length} 条</div>
+            ) : null}
+          </div>
+
+          <div className="mt-2 flex items-center gap-1 text-muted-foreground sm:justify-end">
+            <FileText className="h-3.5 w-3.5" />
+            <span>完整 Plan / IR / WDL tabs 将在后续切片接入。</span>
+          </div>
+        </div>
+      ) : null}
+
+      {pollErrorMessage ? (
+        <div className="flex max-w-md items-start gap-2 text-xs leading-5 text-destructive sm:text-right">
+          <AlertCircle className="mt-0.5 h-3.5 w-3.5 flex-none" />
+          <span>Run 状态查询失败：{pollErrorMessage}</span>
         </div>
       ) : null}
 

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -1,4 +1,12 @@
-import type { RecipeListResponse, ToolListResponse } from "@/lib/types";
+import type {
+  CompileWorkflowRequest,
+  JsonObject,
+  NaturalLanguageRunRequest,
+  RecipeListResponse,
+  RunAcceptedResponse,
+  ToolListResponse,
+  WorkflowRunSnapshotResponse,
+} from "@/lib/types";
 
 const defaultApiBaseUrl = "http://127.0.0.1:8010";
 
@@ -7,27 +15,95 @@ export const apiBaseUrl =
 
 export const apiDocsUrl = `${apiBaseUrl}/docs`;
 
-async function requestJson<T>(path: string): Promise<T> {
+type JsonRequestInit = RequestInit & {
+  next?: {
+    revalidate?: number;
+  };
+};
+
+async function requestJson<T>(path: string, init: JsonRequestInit = {}): Promise<T> {
+  const headers = new Headers(init.headers);
+  headers.set("Accept", "application/json");
+  if (init.body !== undefined && !headers.has("Content-Type")) {
+    headers.set("Content-Type", "application/json");
+  }
+
   const response = await fetch(`${apiBaseUrl}${path}`, {
-    headers: {
-      Accept: "application/json",
-    },
-    next: {
-      revalidate: 30,
-    },
+    ...init,
+    headers,
   });
 
   if (!response.ok) {
-    throw new Error(`API request failed: ${response.status} ${response.statusText}`);
+    const detail = await response.text();
+    const suffix = detail ? `: ${detail}` : "";
+    throw new Error(`API request failed: ${response.status} ${response.statusText}${suffix}`);
   }
 
   return response.json() as Promise<T>;
 }
 
+async function getJson<T>(path: string): Promise<T> {
+  return requestJson<T>(path, {
+    next: {
+      revalidate: 30,
+    },
+  });
+}
+
+async function postJson<T>(path: string, body: JsonObject): Promise<T> {
+  return requestJson<T>(path, {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
 export function listRecipes(): Promise<RecipeListResponse> {
-  return requestJson<RecipeListResponse>("/api/recipes");
+  return getJson<RecipeListResponse>("/api/recipes");
 }
 
 export function listTools(): Promise<ToolListResponse> {
-  return requestJson<ToolListResponse>("/api/tools");
+  return getJson<ToolListResponse>("/api/tools");
+}
+
+export function createNaturalLanguageRun(
+  request: string,
+  check = true,
+  plannerModel?: string | null,
+): Promise<RunAcceptedResponse> {
+  const body: NaturalLanguageRunRequest = {
+    request,
+    check,
+  };
+
+  if (plannerModel) {
+    body.planner_model = plannerModel;
+  }
+
+  return postJson<RunAcceptedResponse>("/api/runs", body);
+}
+
+export function createStructuredCompileRun(
+  payload: JsonObject,
+  check = true,
+): Promise<RunAcceptedResponse> {
+  const body: CompileWorkflowRequest = {
+    payload,
+    check,
+  };
+
+  return postJson<RunAcceptedResponse>("/api/compile", body);
+}
+
+export function getRunSnapshot(runId: string): Promise<WorkflowRunSnapshotResponse> {
+  return getJson<WorkflowRunSnapshotResponse>(`/api/runs/${encodeURIComponent(runId)}`);
+}
+
+export function buildRunEventsUrl(eventsUrl: string, afterSequence?: number): string {
+  const url = new URL(eventsUrl, apiBaseUrl);
+
+  if (afterSequence !== undefined && afterSequence > 0) {
+    url.searchParams.set("after", String(afterSequence));
+  }
+
+  return url.toString();
 }

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -95,7 +95,9 @@ export function createStructuredCompileRun(
 }
 
 export function getRunSnapshot(runId: string): Promise<WorkflowRunSnapshotResponse> {
-  return getJson<WorkflowRunSnapshotResponse>(`/api/runs/${encodeURIComponent(runId)}`);
+  return requestJson<WorkflowRunSnapshotResponse>(`/api/runs/${encodeURIComponent(runId)}`, {
+    cache: "no-store",
+  });
 }
 
 export function buildRunEventsUrl(eventsUrl: string, afterSequence?: number): string {

--- a/web/lib/examples.ts
+++ b/web/lib/examples.ts
@@ -1,3 +1,5 @@
+import type { JsonObject } from "@/lib/types";
+
 export const rnaseqExamplePrompt =
   "构建一个 bulk RNA-seq 差异表达分析工作流，输入多个样本的 paired-end FASTQ 文件。每个样本先运行 fastp 做读段质控，再用 Salmon 做转录本定量，随后通过 tximport 汇总到基因层面，用 DESeq2 完成差异表达分析，并返回 MultiQC 质控报告。";
 
@@ -8,3 +10,86 @@ export const rnaseqRecipeSteps = [
   "DESeq2 差异分析",
   "MultiQC 报告",
 ];
+
+export const rnaseqRecipePlan: JsonObject = {
+  workflow: {
+    name: "RNASeqDEG",
+    recipe: "rnaseq_differential_expression",
+    inputs: {
+      sample_ids: "Array[String]",
+      raw_r1s: "Array[File]",
+      raw_r2s: "Array[File]",
+      transcriptome_index: "File",
+      tx2gene: "File",
+      sample_groups: "File",
+    },
+    tool_calls: [
+      {
+        id: "qc",
+        step: "qc",
+        tool: "fastp",
+        version: "1.3.3",
+        inputs: {
+          r1: "raw_r1s",
+          r2: "raw_r2s",
+        },
+        params: {
+          thread: 4,
+        },
+      },
+      {
+        id: "quantify",
+        step: "quantify",
+        tool: "salmon",
+        version: "1.9.0",
+        inputs: {
+          r1: "qc.clean_r1",
+          r2: "qc.clean_r2",
+          index: "transcriptome_index",
+        },
+        params: {
+          thread: 8,
+        },
+      },
+      {
+        id: "summarize",
+        step: "summarize_transcripts",
+        tool: "tximport",
+        version: "1.30.0",
+        inputs: {
+          quant_files: "quantify.quant_file",
+          sample_ids: "sample_ids",
+          tx2gene: "tx2gene",
+        },
+        params: {},
+      },
+      {
+        id: "deg",
+        step: "differential_expression",
+        tool: "deseq2",
+        version: "1.42.1",
+        inputs: {
+          counts: "summarize.gene_counts",
+          sample_groups: "sample_groups",
+        },
+        params: {
+          contrast: "condition",
+        },
+      },
+      {
+        id: "report",
+        step: "qc_report",
+        tool: "multiqc",
+        version: "1.21",
+        inputs: {
+          report_files: ["qc.html_report", "qc.json_report", "quantify.log_file"],
+        },
+        params: {},
+      },
+    ],
+    outputs: {
+      deg_table: "deg.deg_table",
+      multiqc_report: "report.multiqc_report",
+    },
+  },
+};

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -57,10 +57,75 @@ export type ToolListResponse = {
   tools: Tool[];
 };
 
+export type JsonPrimitive = string | number | boolean | null;
+
+export type JsonValue = JsonPrimitive | JsonObject | JsonValue[];
+
+export type JsonObject = {
+  [key: string]: JsonValue;
+};
+
 export type RunStatus = "created" | "running" | "succeeded" | "failed";
+
+export type CompileWorkflowRequest = {
+  payload: JsonObject;
+  check?: boolean;
+};
+
+export type NaturalLanguageRunRequest = {
+  request: string;
+  planner_model?: string | null;
+  check?: boolean;
+};
 
 export type RunAcceptedResponse = {
   run_id: string;
   status: RunStatus;
   events_url: string;
+};
+
+export type WorkflowArtifacts = {
+  plan: JsonObject | null;
+  workflow_ir: JsonObject;
+  wdl: string;
+};
+
+export type DiagnosticReport = {
+  analysis_errors: string[];
+  analysis_warnings: string[];
+  repair_actions: string[];
+  validation_message: string;
+  is_valid: boolean;
+  succeeded: boolean;
+  check_performed: boolean;
+};
+
+export type WorkflowRunSnapshotResponse = {
+  run_id: string;
+  status: RunStatus;
+  request: string | JsonObject | null;
+  events_url: string | null;
+  artifacts: WorkflowArtifacts;
+  diagnostics: DiagnosticReport;
+};
+
+export type RunEventType =
+  | "run.created"
+  | "node.started"
+  | "node.completed"
+  | "node.failed"
+  | "artifact.updated"
+  | "repair.applied"
+  | "validation.completed"
+  | "run.completed";
+
+export type RunEvent = {
+  event_id: string;
+  run_id: string;
+  sequence: number;
+  type: RunEventType;
+  timestamp: string;
+  summary: string;
+  node: string | null;
+  payload: JsonObject;
 };


### PR DESCRIPTION
## Summary

- Document the W4 workflow workbench implementation scope and acceptance criteria.
- Add typed frontend clients for run creation, run snapshots, and run event URLs.
- Connect the workspace page to create a structured RNA-seq compile run from the example Recipe Tool Plan.
- Add local FastAPI CORS support for the Next.js development origin.
- Poll run snapshots after creation and show the current status, WDL summary, validation message, and diagnostic counts.

## Impact

This establishes the first usable W4 workbench path: a visitor can submit the RNA-seq structured example and see the run progress to a terminal compiler result without requiring natural-language planner credentials. Full SSE timeline rendering and complete Plan / IR / WDL tabs remain follow-up W4 slices.

## Validation

- `.\.venv\Scripts\python.exe -m unittest tests.api.test_server -v`
- `npm.cmd run lint`
- `npm.cmd run build`
- Temporary API smoke: `POST /api/compile` followed by polling `GET /api/runs/{run_id}` reached `succeeded` and returned generated WDL.