### PR TITLE
Polish W4 workbench docs and copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ uv run main.py \
   --output outputs/rnaseq_deg.wdl
 ```
 
-### 6. 启动 W1 FastAPI 开发服务
+### 6. 启动 FastAPI 开发服务
 
 如果本地同时运行 Cromwell server，建议保留 Cromwell 使用 `8000` 端口，本项目 FastAPI 开发服务使用 `8010` 端口，避免两个服务的 `/api/...` 路径互相混淆。
 
@@ -168,9 +168,11 @@ $env:AI_BIOWORKFLOW_API_PORT = "8020"
 .\.venv\Scripts\python.exe -m src.api.server
 ```
 
-### 6. 启动 W3 前端展示页
+### 7. 启动 Web 工作台
 
-前端位于 `web/`，作为独立的 Next.js 应用运行。默认读取本地 FastAPI：
+前端位于 `web/`，作为独立的 Next.js 应用运行。`/workspace?example=rnaseq-deg`
+的“运行示例”会调用 FastAPI `POST /api/compile`，并轮询 run snapshot 显示状态摘要。
+本地演示时需要分别启动 FastAPI 和 Next.js。前端默认读取本地 FastAPI：
 
 ```text
 http://127.0.0.1:8010
@@ -193,6 +195,13 @@ npm run dev
 
 ```env
 NEXT_PUBLIC_API_BASE_URL=http://127.0.0.1:8010
+```
+
+如果 Next.js 开发服务不在默认 `3000` 端口运行，也需要让 FastAPI 允许对应来源：
+
+```powershell
+$env:AI_BIOWORKFLOW_CORS_ORIGINS = "http://127.0.0.1:3001,http://localhost:3001"
+.\.venv\Scripts\python.exe -m src.api.server
 ```
 
 ## 📥 支持的输入格式
@@ -268,7 +277,9 @@ Workflow IR 的结构、表达式规则、scatter 语义和 WDL 后端映射详�
 - [x] 增加 P0 快速检查脚本，默认覆盖单测和代表性 WDL 编译/校验。
 - [x] 记录一份可复现的 [Cromwell e2e 验证摘要](./docs/p0-e2e-verification.md)，包括 workflow id、最终状态和 output keys。
 - [x] 实现 W2 run 事件、SQLite 展示级持久化和 SSE 事件流。
-- [ ] 建设 Next.js 工作台、DAG 可视化和历史详情页。
+- [x] 接入 W4 工作台初版：RNA-seq 结构化示例 run 创建、snapshot 轮询和状态摘要。
+- [ ] 完成 W4 SSE 时间线、Plan / IR / WDL / Diagnostics tabs 和失败态打磨。
+- [ ] 建设 W5 DAG 可视化和历史详情页。
 - [ ] 扩展更多常用生信 recipe 与 tool catalog。
 
 ## 📄 许可证

--- a/docs/w4-workbench-plan.md
+++ b/docs/w4-workbench-plan.md
@@ -27,7 +27,11 @@
   - `repair.applied`
   - `validation.completed`
   - `run.completed`
-- 前端已有 `/workspace` 页面，但当前仍是静态预览：运行按钮禁用，timeline、artifact tabs 和 diagnostics 文案均为占位内容。
+- 前端已有 `/workspace` 页面和初版 run launcher：
+  - “运行示例”会使用内置 RNA-seq Recipe Tool Plan 调用 `POST /api/compile`。
+  - 前端会轮询 `GET /api/runs/{run_id}`，展示 run 状态、WDL 摘要、校验信息和诊断计数。
+  - 默认本地 API base URL 为 `http://127.0.0.1:8010`，可通过 `NEXT_PUBLIC_API_BASE_URL` 覆盖。
+- Timeline、完整 artifact tabs、SSE 连接状态和自然语言输入仍是后续 W4 切片。
 
 ## 产品行为
 
@@ -133,7 +137,7 @@ SSE 断开但 run 未终态时，页面应显示连接状态，并允许自动�
 
 ### 7. 文案与导航更新
 
-W4 完成后，需要把 Web 页面中 “W3 静态预览”、“运行待接入”、“W4 接入真实 run 数据” 等占位文案更新为真实工作台表述。
+W4 初版已把工作台顶部、运行按钮和产物区说明更新为真实 run 接入表述。后续切片继续替换时间线、artifact tabs 和失败态中的静态占位文案。
 
 项目介绍页可以继续强调：
 
@@ -142,7 +146,7 @@ W4 完成后，需要把 Web 页面中 “W3 静态预览”、“运行待接�
 - WDL 由确定性 renderer 生成。
 - Analyzer / Repairer / Checker 过程可追踪。
 
-公共文案保持项目维护者视角，不加入工具签名、自动生成说明或 AI-assistant 品牌化措辞。
+公共文案保持项目维护者视角，不加入工具签名、自动生成说明或外部助手品牌化措辞。
 
 ## W4 不做
 
@@ -155,22 +159,26 @@ W4 完成后，需要把 Web 页面中 “W3 静态预览”、“运行待接�
 
 ## 建议 PR 顺序
 
-1. **W4 API client and types**：补齐前端 run DTO、API client、SSE URL helper。
-2. **W4 workbench run lifecycle**：实现提交、run 状态、EventSource 订阅和 snapshot 拉取。
-3. **W4 timeline and artifacts**：实现时间线状态映射、Plan / IR / WDL / Diagnostics tabs。
-4. **W4 failure states and polish**：补齐错误状态、空状态、占位文案替换和响应式细节。
-5. **W4 docs and verification**：更新 README / DEVELOPMENT 中的阶段状态说明，并记录验证结果。
+1. **W4 API client and types**：补齐前端 run DTO、API client、SSE URL helper。已完成。
+2. **W4 workbench structured run launcher**：实现结构化示例提交、run 状态和 snapshot 轮询。已完成。
+3. **W4 SSE timeline**：实现 EventSource 订阅、断线恢复和时间线状态映射。
+4. **W4 artifacts tabs**：实现 Plan / IR / WDL / Diagnostics tabs 和空状态。
+5. **W4 failure states and polish**：补齐错误状态、占位文案替换、响应式细节和自然语言运行入口。
+6. **W4 docs and verification**：持续更新 README / DEVELOPMENT 中的阶段状态说明，并记录验证结果。
 
 ## 验收标准
 
 功能验收：
 
-- 启动 FastAPI 与 Next.js 后，访问 `/workspace?example=rnaseq-deg` 可以提交一次结构化 RNA-seq 示例 run。
-- 页面能从 `created` / `running` 推进到 `succeeded` 或 `failed`。
-- Timeline 能实时显示 Compiler Graph 节点进度。
-- Plan、Workflow IR、WDL 和 Diagnostics 来自真实 run snapshot。
-- 自然语言模式在 planner 环境可用时能走 `POST /api/runs`；环境不可用时显示明确失败诊断。
-- 失败 run 仍保留已产生事件、artifact 和 diagnostics。
+- 已落地初版：
+  - 启动 FastAPI 与 Next.js 后，访问 `/workspace?example=rnaseq-deg` 可以提交一次结构化 RNA-seq 示例 run。
+  - 页面能从 accepted run 轮询到 `created` / `running` / `succeeded` / `failed` snapshot。
+  - 运行卡片展示 run id、状态、WDL 摘要、校验信息、analysis error 计数和 repair action 计数。
+- 后续完整 W4：
+  - Timeline 能实时显示 Compiler Graph 节点进度。
+  - Plan、Workflow IR、WDL 和 Diagnostics 来自真实 run snapshot tabs。
+  - 自然语言模式在 planner 环境可用时能走 `POST /api/runs`；环境不可用时显示明确失败诊断。
+  - 失败 run 仍保留已产生事件、artifact 和 diagnostics。
 
 验证建议：
 

--- a/web/app/workspace/page.tsx
+++ b/web/app/workspace/page.tsx
@@ -58,12 +58,11 @@ export default async function WorkspacePage({
           </Button>
           <div className="flex flex-wrap items-center gap-3">
             <h1 className="text-3xl font-semibold tracking-normal">Workflow 工作台</h1>
-            <Badge variant="secondary">W4 接入中</Badge>
+            <Badge variant="secondary">W4 初版</Badge>
           </div>
           <p className="mt-3 max-w-2xl text-muted-foreground">
-            这个页面正在从静态 review surface 演进为真实生成工作台。当前已接入
-            RNA-seq 结构化示例 run 创建；SSE 时间线、snapshot 产物刷新和 diagnostics
-            展示会在后续 W4 切片继续接入。
+            当前已可提交 RNA-seq 结构化示例 run，轮询 snapshot，并显示 run 状态、WDL
+            摘要和校验结果。SSE 时间线与完整 Plan / IR / WDL / Diagnostics tabs 会在后续切片接入。
           </p>
         </div>
         <div className="flex flex-wrap gap-3">
@@ -107,12 +106,12 @@ export default async function WorkspacePage({
             <div>
               <h2 className="font-semibold">Run 时间线</h2>
               <p className="mt-1 text-sm text-muted-foreground">
-                当前保留事件结构预览；下一切片会从持久化 SSE event envelope 实时更新。
+                当前展示目标事件结构；下一切片会从持久化 SSE event envelope 实时更新。
               </p>
             </div>
             <Badge variant="outline">
               <Clock3 className="mr-1 h-3.5 w-3.5" />
-              等待 SSE 接入
+              SSE 待接入
             </Badge>
           </div>
           <div className="mt-5 grid gap-3 md:grid-cols-2">
@@ -139,7 +138,8 @@ export default async function WorkspacePage({
           <div>
             <h2 className="font-semibold">结构化产物</h2>
             <p className="mt-1 text-sm text-muted-foreground">
-              当前先固定产物区的信息架构；W4 接入后会展示同一次 run 产生的 Plan、IR、WDL 和 diagnostics。
+              当前先固定产物区的信息架构，并在运行卡片中读取同一次 run 的 WDL 与 diagnostics 摘要。
+              完整 Plan、IR、WDL 和 Diagnostics tabs 会在后续切片接入。
             </p>
           </div>
           <div className="flex flex-wrap gap-2">
@@ -175,7 +175,7 @@ export default async function WorkspacePage({
               ].map((item) => (
                 <div key={item} className="rounded-md border bg-white p-3 text-sm">
                   <div className="font-medium">{item}</div>
-                  <div className="mt-2 text-muted-foreground">W4 接入真实 run 数据</div>
+                  <div className="mt-2 text-muted-foreground">等待完整 tabs 接入</div>
                 </div>
               ))}
             </div>


### PR DESCRIPTION
## Summary

- Update README local Web workbench instructions with the FastAPI/Next.js split and CORS override guidance.
- Record the W4 initial workbench state in the phase plan, including the structured run launcher and remaining slices.
- Refresh workspace page copy so it reflects the current snapshot polling flow instead of older static-preview wording.

## Validation

- `npm.cmd run lint`
- `npm.cmd run build`

WDL generation paths were not changed.