### PR TITLE
Add orchestration planner node

### DIFF
--- a/docs/p1-orchestration-graph-plan.md
+++ b/docs/p1-orchestration-graph-plan.md
@@ -153,7 +153,7 @@ CLI --input / API POST /api/compile / tests
 
 目标：把现有 `create_natural_language_plan` 包装为上层图节点。
 
-建议行为：
+已落地行为（`src/orchestration/nodes/planner.py`）：
 
 - 输入 `request`、`planner_model`、可选测试注入的 `llm` / catalog 对象。
 - 输出 `plan`、`planner_prompt`、`planner_raw_response`。
@@ -391,7 +391,7 @@ run.completed
 - [x] `compiler_graph` 成为结构化编译图的明确导出名。
 - [x] `agent` 兼容别名仍可用于旧调用，或有明确迁移说明。
 - [x] Orchestration State 不污染 `WorkflowState`。
-- [ ] Planner node 只产出 Recipe Tool Plan 和 trace，不产出最终 WDL。
+- [x] Planner node 只产出 Recipe Tool Plan 和 trace，不产出最终 WDL。
 - [ ] Orchestration Graph 实现 `natural_language_planner -> compiler_graph`。
 - [ ] 自然语言入口调用 Orchestration Graph。
 - [ ] `--input`、测试入口和 `/api/compile` 直接调用 Compiler Graph。

--- a/docs/test-cases.md
+++ b/docs/test-cases.md
@@ -52,7 +52,7 @@ powershell -ExecutionPolicy Bypass -File scripts\check_p0.ps1 `
 
 ```text
 .venv\Scripts\python.exe -m unittest discover -v
-Ran 152 tests
+Ran 153 tests
 OK (skipped=2)
 ```
 
@@ -1529,7 +1529,7 @@ Compiler Graph，也不产出 Workflow IR 或 WDL。
 期望输出：
 
 - `errors` 包含 JSON 解析失败信息。
-- update 不包含 `plan`。
+- `plan`、`planner_prompt`、`planner_raw_response` 均为 `None`。
 - events 顺序为 `node.started`、`node.failed`。
 - failure payload 的 `error_type == "PlannerJsonError"`。
 - failure payload 不包含 `api_key` 或 `authorization`。
@@ -1538,6 +1538,28 @@ Compiler Graph，也不产出 Workflow IR 或 WDL。
 
 - Planner JSON 失败保留结构化错误分类。
 - 失败事件不记录鉴权敏感信息。
+
+### `test_planner_node_records_unexpected_failure`
+
+输入：
+
+- 注入的 Planner LLM 抛出 `RuntimeError("planner transport unavailable")`。
+
+执行：
+
+- 调用 Planner Node。
+
+期望输出：
+
+- `errors` 包含原始异常消息。
+- `plan`、`planner_prompt`、`planner_raw_response` 均为 `None`。
+- events 顺序为 `node.started`、`node.failed`。
+- failure payload 的 `error_type == "RuntimeError"`。
+
+覆盖点：
+
+- 非 `NaturalLanguagePlanningError` 的意外异常也会被 Planner Node 转换为结构化失败。
+- 上层 Orchestration Graph 可以继续聚合 `errors` / `events`，不会被异常直接打断。
 
 ### `test_planner_node_preserves_schema_error_classification`
 

--- a/docs/test-cases.md
+++ b/docs/test-cases.md
@@ -52,7 +52,7 @@ powershell -ExecutionPolicy Bypass -File scripts\check_p0.ps1 `
 
 ```text
 .venv\Scripts\python.exe -m unittest discover -v
-Ran 147 tests
+Ran 152 tests
 OK (skipped=2)
 ```
 
@@ -1465,6 +1465,117 @@ files = flatten([qc.html_report, qc.json_report, [extra_report]])
 覆盖点：
 
 - P1 上层 run 的成功语义要求 orchestration 和 delegated compiler 都成功。
+
+## `tests/test_orchestration_planner_node.py`
+
+该文件验证 P1 Planner Node 初版。Planner Node 负责把自然语言请求转换为
+Recipe Tool Plan，并记录 planner prompt / raw response 等 trace；它不运行
+Compiler Graph，也不产出 Workflow IR 或 WDL。
+
+### `test_planner_node_returns_plan_trace_and_events`
+
+输入：
+
+- 自然语言请求：`Run RNA-seq differential expression.`
+- `FakePlannerLlm` 返回有效 RNA-seq Recipe Tool Plan JSON。
+
+执行：
+
+- 调用 `make_natural_language_planner_node(llm=fake_llm)(state)`。
+
+期望输出：
+
+- update 中包含 Recipe Tool Plan。
+- `planner_prompt` 包含 `Catalog:`。
+- `planner_raw_response` 包含 `RNASeqDEG`。
+- `errors == []`。
+- update 不包含 `compiler_result`、`workflow_ir` 或 `wdl`。
+- events 顺序为 `node.started`、`node.completed`、`artifact.updated`。
+- artifact event payload 为 `{"artifact": "plan"}`。
+
+覆盖点：
+
+- Planner Node 只产出 Recipe Tool Plan 和 planner trace。
+- Planner Node 成功事件可被后续 run history 或 SSE 层复用。
+
+### `test_default_planner_node_uses_same_node_contract`
+
+输入：
+
+- 默认 `natural_language_planner_node`。
+
+执行：
+
+- 检查该对象是否可调用。
+
+期望输出：
+
+- 默认 Planner Node 是可注册到 LangGraph 的 callable。
+
+覆盖点：
+
+- 后续 Orchestration Graph 可以直接注册默认 planner node。
+
+### `test_planner_node_records_json_failure_without_secret_payloads`
+
+输入：
+
+- `FakePlannerLlm` 返回非 JSON 文本。
+
+执行：
+
+- 调用 Planner Node。
+
+期望输出：
+
+- `errors` 包含 JSON 解析失败信息。
+- update 不包含 `plan`。
+- events 顺序为 `node.started`、`node.failed`。
+- failure payload 的 `error_type == "PlannerJsonError"`。
+- failure payload 不包含 `api_key` 或 `authorization`。
+
+覆盖点：
+
+- Planner JSON 失败保留结构化错误分类。
+- 失败事件不记录鉴权敏感信息。
+
+### `test_planner_node_preserves_schema_error_classification`
+
+输入：
+
+- `FakePlannerLlm` 返回缺少 `tool_calls` 的 plan JSON。
+
+执行：
+
+- 调用 Planner Node。
+
+期望输出：
+
+- `errors` 包含 `plan schema validation failed`。
+- failure event payload 的 `error_type == "PlannerSchemaError"`。
+
+覆盖点：
+
+- Planner schema 错误不会被吞成泛化错误。
+
+### `test_planner_node_preserves_catalog_error_classification`
+
+输入：
+
+- `FakePlannerLlm` 返回缺少 differential expression step 的 RNA-seq plan。
+
+执行：
+
+- 调用 Planner Node。
+
+期望输出：
+
+- `errors` 包含 `recipe/catalog validation failed`。
+- failure event payload 的 `error_type == "PlannerCatalogError"`。
+
+覆盖点：
+
+- Planner catalog/resolver 错误可被上层 graph 识别为 planner-stage 失败。
 
 ## `tests/test_workflow_service.py`
 

--- a/src/orchestration/nodes/__init__.py
+++ b/src/orchestration/nodes/__init__.py
@@ -1,0 +1,9 @@
+"""Node implementations for the orchestration graph."""
+
+from src.orchestration.nodes.planner import make_natural_language_planner_node, natural_language_planner_node
+
+__all__ = [
+    "make_natural_language_planner_node",
+    "natural_language_planner_node",
+]
+

--- a/src/orchestration/nodes/planner.py
+++ b/src/orchestration/nodes/planner.py
@@ -1,0 +1,98 @@
+"""Natural-language planner node for the orchestration graph."""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from src.catalog.loader import ToolCatalog
+from src.nl_planner import (
+    NaturalLanguagePlanningError,
+    PlannerLlm,
+    create_natural_language_plan,
+)
+from src.orchestration.state import OrchestrationState
+from src.recipes.loader import RecipeCatalog
+
+
+PlannerNode = Callable[[OrchestrationState], dict[str, Any]]
+
+
+def natural_language_planner_node(state: OrchestrationState) -> dict[str, Any]:
+    """Plan from natural language using the default planner dependencies."""
+    return make_natural_language_planner_node()(state)
+
+
+def make_natural_language_planner_node(
+    *,
+    llm: PlannerLlm | None = None,
+    tool_catalog: ToolCatalog | None = None,
+    recipe_catalog: RecipeCatalog | None = None,
+) -> PlannerNode:
+    """Create a planner node, optionally injecting dependencies for tests."""
+
+    def node(state: OrchestrationState) -> dict[str, Any]:
+        started_event = _planner_event(
+            "node.started",
+            "Natural-language planner started.",
+            {"planner_model": state["planner_model"]},
+        )
+
+        try:
+            plan_result = create_natural_language_plan(
+                state["request"],
+                model=state["planner_model"],
+                llm=llm,
+                tool_catalog=tool_catalog,
+                recipe_catalog=recipe_catalog,
+            )
+        except NaturalLanguagePlanningError as exc:
+            return {
+                "plan": None,
+                "planner_prompt": None,
+                "planner_raw_response": None,
+                "errors": [str(exc)],
+                "events": [
+                    started_event,
+                    _planner_event(
+                        "node.failed",
+                        "Natural-language planner failed.",
+                        {
+                            "error_type": exc.__class__.__name__,
+                            "error": str(exc),
+                        },
+                    ),
+                ],
+            }
+
+        return {
+            "plan": plan_result.plan,
+            "planner_prompt": plan_result.planner_prompt,
+            "planner_raw_response": plan_result.raw_response,
+            "errors": [],
+            "events": [
+                started_event,
+                _planner_event("node.completed", "Natural-language planner completed."),
+                _planner_event(
+                    "artifact.updated",
+                    "Recipe Tool Plan artifact updated.",
+                    {"artifact": "plan"},
+                ),
+            ],
+        }
+
+    return node
+
+
+def _planner_event(
+    event_type: str,
+    summary: str,
+    payload: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    event: dict[str, Any] = {
+        "type": event_type,
+        "node": "planner",
+        "summary": summary,
+    }
+    if payload is not None:
+        event["payload"] = payload
+    return event

--- a/src/orchestration/nodes/planner.py
+++ b/src/orchestration/nodes/planner.py
@@ -34,7 +34,7 @@ def make_natural_language_planner_node(
         started_event = _planner_event(
             "node.started",
             "Natural-language planner started.",
-            {"planner_model": state["planner_model"]},
+            {"model": state["planner_model"]},
         )
 
         try:
@@ -56,6 +56,24 @@ def make_natural_language_planner_node(
                     _planner_event(
                         "node.failed",
                         "Natural-language planner failed.",
+                        {
+                            "error_type": exc.__class__.__name__,
+                            "error": str(exc),
+                        },
+                    ),
+                ],
+            }
+        except Exception as exc:
+            return {
+                "plan": None,
+                "planner_prompt": None,
+                "planner_raw_response": None,
+                "errors": [str(exc)],
+                "events": [
+                    started_event,
+                    _planner_event(
+                        "node.failed",
+                        "Natural-language planner failed unexpectedly.",
                         {
                             "error_type": exc.__class__.__name__,
                             "error": str(exc),

--- a/tests/test_orchestration_planner_node.py
+++ b/tests/test_orchestration_planner_node.py
@@ -106,6 +106,11 @@ class FakePlannerLlm:
         return SimpleNamespace(content=self.response)
 
 
+class RaisingPlannerLlm:
+    def invoke(self, prompt: str):
+        raise RuntimeError("planner transport unavailable")
+
+
 class OrchestrationPlannerNodeTests(unittest.TestCase):
     def test_planner_node_returns_plan_trace_and_events(self):
         fake_llm = FakePlannerLlm(json.dumps(sample_rnaseq_tool_plan()))
@@ -127,7 +132,7 @@ class OrchestrationPlannerNodeTests(unittest.TestCase):
             [event["type"] for event in update["events"]],
             ["node.started", "node.completed", "artifact.updated"],
         )
-        self.assertEqual(update["events"][0]["payload"], {"planner_model": DEFAULT_PLANNER_MODEL})
+        self.assertEqual(update["events"][0]["payload"], {"model": DEFAULT_PLANNER_MODEL})
         self.assertEqual(update["events"][-1]["payload"], {"artifact": "plan"})
         self.assertEqual(len(fake_llm.prompts), 1)
 
@@ -155,6 +160,26 @@ class OrchestrationPlannerNodeTests(unittest.TestCase):
         self.assertEqual(failure_payload["error_type"], "PlannerJsonError")
         self.assertNotIn("api_key", json.dumps(failure_payload).lower())
         self.assertNotIn("authorization", json.dumps(failure_payload).lower())
+
+    def test_planner_node_records_unexpected_failure(self):
+        state = build_initial_orchestration_state(
+            "Run RNA-seq differential expression.",
+            planner_model=DEFAULT_PLANNER_MODEL,
+        )
+
+        update = make_natural_language_planner_node(llm=RaisingPlannerLlm())(state)
+
+        self.assertIn("planner transport unavailable", update["errors"][0])
+        self.assertIsNone(update["plan"])
+        self.assertIsNone(update["planner_prompt"])
+        self.assertIsNone(update["planner_raw_response"])
+        self.assertEqual(
+            [event["type"] for event in update["events"]],
+            ["node.started", "node.failed"],
+        )
+        failure_payload = update["events"][-1]["payload"]
+        self.assertEqual(failure_payload["error_type"], "RuntimeError")
+        self.assertEqual(failure_payload["error"], "planner transport unavailable")
 
     def test_planner_node_preserves_schema_error_classification(self):
         fake_llm = FakePlannerLlm(json.dumps({"workflow": {"name": "RNASeqDEG"}}))

--- a/tests/test_orchestration_planner_node.py
+++ b/tests/test_orchestration_planner_node.py
@@ -1,0 +1,191 @@
+import json
+import unittest
+from types import SimpleNamespace
+
+from src.nl_planner import DEFAULT_PLANNER_MODEL
+from src.orchestration.nodes import make_natural_language_planner_node, natural_language_planner_node
+from src.orchestration.state import build_initial_orchestration_state
+
+
+def sample_rnaseq_tool_plan() -> dict:
+    return {
+        "workflow": {
+            "name": "RNASeqDEG",
+            "recipe": "rnaseq_differential_expression",
+            "inputs": {
+                "sample_ids": "Array[String]",
+                "raw_r1s": "Array[File]",
+                "raw_r2s": "Array[File]",
+                "transcriptome_index": "File",
+                "tx2gene": "File",
+                "sample_groups": "File",
+            },
+            "tool_calls": [
+                {
+                    "id": "qc",
+                    "step": "qc",
+                    "tool": "fastp",
+                    "version": "1.3.3",
+                    "inputs": {
+                        "r1": "raw_r1s",
+                        "r2": "raw_r2s",
+                    },
+                    "params": {
+                        "thread": 4,
+                    },
+                },
+                {
+                    "id": "quantify",
+                    "step": "quantify",
+                    "tool": "salmon",
+                    "version": "1.9.0",
+                    "inputs": {
+                        "r1": "qc.clean_r1",
+                        "r2": "qc.clean_r2",
+                        "index": "transcriptome_index",
+                    },
+                    "params": {
+                        "thread": 8,
+                    },
+                },
+                {
+                    "id": "summarize",
+                    "step": "summarize_transcripts",
+                    "tool": "tximport",
+                    "version": "1.30.0",
+                    "inputs": {
+                        "quant_files": "quantify.quant_file",
+                        "sample_ids": "sample_ids",
+                        "tx2gene": "tx2gene",
+                    },
+                    "params": {},
+                },
+                {
+                    "id": "deg",
+                    "step": "differential_expression",
+                    "tool": "deseq2",
+                    "version": "1.42.1",
+                    "inputs": {
+                        "counts": "summarize.gene_counts",
+                        "sample_groups": "sample_groups",
+                    },
+                    "params": {
+                        "contrast": "condition",
+                    },
+                },
+                {
+                    "id": "report",
+                    "step": "qc_report",
+                    "tool": "multiqc",
+                    "version": "1.21",
+                    "inputs": {
+                        "report_files": [
+                            "qc.html_report",
+                            "qc.json_report",
+                            "quantify.log_file",
+                        ],
+                    },
+                    "params": {},
+                },
+            ],
+            "outputs": {
+                "deg_table": "deg.deg_table",
+                "multiqc_report": "report.multiqc_report",
+            },
+        }
+    }
+
+
+class FakePlannerLlm:
+    def __init__(self, response: str):
+        self.response = response
+        self.prompts = []
+
+    def invoke(self, prompt: str):
+        self.prompts.append(prompt)
+        return SimpleNamespace(content=self.response)
+
+
+class OrchestrationPlannerNodeTests(unittest.TestCase):
+    def test_planner_node_returns_plan_trace_and_events(self):
+        fake_llm = FakePlannerLlm(json.dumps(sample_rnaseq_tool_plan()))
+        state = build_initial_orchestration_state(
+            "Run RNA-seq differential expression.",
+            planner_model=DEFAULT_PLANNER_MODEL,
+        )
+
+        update = make_natural_language_planner_node(llm=fake_llm)(state)
+
+        self.assertEqual(update["plan"]["workflow"]["recipe"], "rnaseq_differential_expression")
+        self.assertIn("Catalog:", update["planner_prompt"])
+        self.assertIn("RNASeqDEG", update["planner_raw_response"])
+        self.assertEqual(update["errors"], [])
+        self.assertNotIn("compiler_result", update)
+        self.assertNotIn("workflow_ir", update)
+        self.assertNotIn("wdl", update)
+        self.assertEqual(
+            [event["type"] for event in update["events"]],
+            ["node.started", "node.completed", "artifact.updated"],
+        )
+        self.assertEqual(update["events"][0]["payload"], {"planner_model": DEFAULT_PLANNER_MODEL})
+        self.assertEqual(update["events"][-1]["payload"], {"artifact": "plan"})
+        self.assertEqual(len(fake_llm.prompts), 1)
+
+    def test_default_planner_node_uses_same_node_contract(self):
+        self.assertTrue(callable(natural_language_planner_node))
+
+    def test_planner_node_records_json_failure_without_secret_payloads(self):
+        fake_llm = FakePlannerLlm("I would run fastp first.")
+        state = build_initial_orchestration_state(
+            "Run RNA-seq differential expression.",
+            planner_model=DEFAULT_PLANNER_MODEL,
+        )
+
+        update = make_natural_language_planner_node(llm=fake_llm)(state)
+
+        self.assertIn("LLM planner response does not contain a JSON object", update["errors"][0])
+        self.assertIsNone(update["plan"])
+        self.assertIsNone(update["planner_prompt"])
+        self.assertIsNone(update["planner_raw_response"])
+        self.assertEqual(
+            [event["type"] for event in update["events"]],
+            ["node.started", "node.failed"],
+        )
+        failure_payload = update["events"][-1]["payload"]
+        self.assertEqual(failure_payload["error_type"], "PlannerJsonError")
+        self.assertNotIn("api_key", json.dumps(failure_payload).lower())
+        self.assertNotIn("authorization", json.dumps(failure_payload).lower())
+
+    def test_planner_node_preserves_schema_error_classification(self):
+        fake_llm = FakePlannerLlm(json.dumps({"workflow": {"name": "RNASeqDEG"}}))
+        state = build_initial_orchestration_state(
+            "Run RNA-seq differential expression.",
+            planner_model=DEFAULT_PLANNER_MODEL,
+        )
+
+        update = make_natural_language_planner_node(llm=fake_llm)(state)
+
+        self.assertIn("plan schema validation failed", update["errors"][0])
+        self.assertEqual(update["events"][-1]["payload"]["error_type"], "PlannerSchemaError")
+
+    def test_planner_node_preserves_catalog_error_classification(self):
+        plan = sample_rnaseq_tool_plan()
+        plan["workflow"]["tool_calls"] = [
+            tool_call
+            for tool_call in plan["workflow"]["tool_calls"]
+            if tool_call["step"] != "differential_expression"
+        ]
+        fake_llm = FakePlannerLlm(json.dumps(plan))
+        state = build_initial_orchestration_state(
+            "Run RNA-seq differential expression.",
+            planner_model=DEFAULT_PLANNER_MODEL,
+        )
+
+        update = make_natural_language_planner_node(llm=fake_llm)(state)
+
+        self.assertIn("recipe/catalog validation failed", update["errors"][0])
+        self.assertEqual(update["events"][-1]["payload"]["error_type"], "PlannerCatalogError")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add a natural-language planner node for the P1 orchestration graph boundary.
- Expose a factory for dependency injection so planner behavior can be tested without external LLM calls.
- Document the P1.3 implementation status and planner-node test coverage.

## Validation

- `.\.venv\Scripts\python.exe -m unittest tests.test_orchestration_planner_node -v`
- `.\.venv\Scripts\python.exe -m unittest discover -v`