### PR TITLE
Document W4 server config coverage

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -368,6 +368,13 @@ FastAPI 开发服务通过以下命令启动：
 
 `src.api.server` 默认使用 `127.0.0.1:8010`，避免与 Cromwell 的 `8000` 端口冲突。需要临时覆盖时可设置 `AI_BIOWORKFLOW_API_HOST` 或 `AI_BIOWORKFLOW_API_PORT`。
 
+FastAPI 默认允许本地 Next.js 开发来源 `http://127.0.0.1:3000` 和
+`http://localhost:3000` 访问 API。当前端开发服务改用其他端口时，可通过
+`AI_BIOWORKFLOW_CORS_ORIGINS` 配置逗号分隔的 allowed origins；配置值会去除首尾空白和末尾 `/`，避免常见本地 URL 写法导致 CORS 不匹配。
+
+W4 初版工作台已接入结构化 RNA-seq 示例 run：`/workspace?example=rnaseq-deg`
+会调用 `POST /api/compile` 并轮询 `GET /api/runs/{run_id}` 展示状态、WDL 摘要和诊断摘要。SSE 时间线、完整 Plan / IR / WDL / Diagnostics tabs，以及自然语言输入交互仍按 W4 后续切片推进。
+
 W2 当前接口：
 
 | Endpoint | 用途 | 主要返回 |
@@ -483,7 +490,7 @@ Web 展示轨道与后续 Multi-Agent 能力路线并行推进，优先让已经
 | W1 | FastAPI API 基础 | `POST /api/runs`、`POST /api/compile`、catalog 查询与 API 测试 | W0 |
 | W2 | Run 事件与展示级持久化 | SQLite 数据模型、SSE 事件流、成功/失败历史快照 | W1 |
 | W3 | Next.js 产品外壳与项目介绍页 | TypeScript/Tailwind/shadcn UI 基础、介绍页、案例入口 | W1 |
-| W4 | Workflow 生成工作台 | 输入面板、执行时间线、Plan/IR/WDL/诊断查看与 SSE 接入 | W2, W3 |
+| W4 | Workflow 生成工作台 | 已落地结构化示例 run launcher 与 snapshot 摘要；继续推进 SSE 时间线、Plan/IR/WDL/诊断 tabs | W2, W3 |
 | W5 | DAG 与历史详情 | React Flow 工作流图、run 历史详情和失败/修复回放 | W4 |
 | W6 | 部署与作品集打磨 | 在线 demo、示例数据、架构图、截图/录屏、API 文档与 README 导航 | W5 |
 

--- a/docs/test-cases.md
+++ b/docs/test-cases.md
@@ -660,6 +660,109 @@ OK (skipped=2)
 
 - 本地或容器开发场景可以临时覆盖 API host。
 
+### `test_default_cors_origins_cover_next_development_server`
+
+输入：
+
+- `DEFAULT_CORS_ORIGINS`
+
+执行：
+
+- 读取 `src.api.app` 中的默认 CORS origins。
+
+期望输出：
+
+- 默认允许 `http://127.0.0.1:3000`。
+- 默认允许 `http://localhost:3000`。
+
+覆盖点：
+
+- 本地 Next.js 默认开发服务可以直接访问 FastAPI。
+
+### `test_cors_origins_can_be_overridden_by_environment`
+
+输入：
+
+- 环境变量 `AI_BIOWORKFLOW_CORS_ORIGINS=http://127.0.0.1:3001/, http://localhost:3001`。
+
+执行：
+
+- 调用 `get_cors_origins()`。
+
+期望输出：
+
+- 返回 `["http://127.0.0.1:3001", "http://localhost:3001"]`。
+- 末尾 `/` 会被规范化移除。
+
+覆盖点：
+
+- 前端开发服务使用非默认端口时，可以显式配置 allowed origins。
+- 常见的 trailing slash 写法不会导致 CORS origin 匹配失败。
+
+### `test_next_development_origin_can_preflight_api_requests`
+
+输入：
+
+- `TestClient(create_app())`
+- `OPTIONS /api/compile`
+- 请求头：
+  - `Origin: http://127.0.0.1:3000`
+  - `Access-Control-Request-Method: POST`
+  - `Access-Control-Request-Headers: content-type`
+
+执行：
+
+- 调用 FastAPI TestClient 发起浏览器预检请求。
+
+期望输出：
+
+- HTTP 状态码为 `200`。
+- `access-control-allow-origin` 响应头为 `http://127.0.0.1:3000`。
+
+覆盖点：
+
+- W4 工作台从 Next.js 开发服务点击“运行示例”时，浏览器可以通过 CORS preflight 调用 `POST /api/compile`。
+
+### `test_root_and_health_endpoints_are_available`
+
+输入：
+
+- `TestClient(create_app())`
+- `GET /`
+- `GET /health`
+
+执行：
+
+- 调用 FastAPI TestClient 请求根路径和健康检查路径。
+
+期望输出：
+
+- 根路径 HTTP 状态码为 `200`，响应 JSON 中 `status == "ok"`。
+- `/health` HTTP 状态码为 `200`，响应 JSON 为 `{"status": "ok"}`。
+
+覆盖点：
+
+- 本地开发服务和部署探针都有轻量健康检查入口。
+
+### `test_favicon_request_does_not_log_404`
+
+输入：
+
+- `TestClient(create_app())`
+- `GET /favicon.ico`
+
+执行：
+
+- 调用 FastAPI TestClient 请求浏览器常见 favicon 路径。
+
+期望输出：
+
+- HTTP 状态码为 `204`。
+
+覆盖点：
+
+- 浏览器访问 API docs 或 health 页面时不会因为 favicon 请求产生无意义的 404 噪声。
+
 ## `tests/test_catalog.py`
 
 该文件验证 Recipe / Tool Catalog resolver 的结构化校验、IR 生成和 WDL 渲染。


### PR DESCRIPTION
## Summary

- Document the current W4 structured run launcher state and local CORS configuration in `DEVELOPMENT.md`.
- Record the API server config, CORS, preflight, health, and favicon test coverage in `docs/test-cases.md`.
- Keep the W4 roadmap language aligned with the implemented snapshot summary flow and remaining SSE/tabs work.

## Validation

- `./.venv/Scripts/python.exe -m unittest tests.api.test_server -v`

WDL generation paths were not changed.