### PR TITLE
Add real run history list page

### DIFF
--- a/web/app/runs/page.tsx
+++ b/web/app/runs/page.tsx
@@ -39,6 +39,13 @@ const kindLabels: Record<string, string> = {
   structured_compile: "结构化编译",
 };
 
+const runListDateTimeFormat = new Intl.DateTimeFormat("zh-CN", {
+  month: "2-digit",
+  day: "2-digit",
+  hour: "2-digit",
+  minute: "2-digit",
+});
+
 function isRunStatus(value: string | undefined): value is RunStatus {
   return value === "created" || value === "running" || value === "succeeded" || value === "failed";
 }
@@ -80,19 +87,12 @@ function formatDateTime(value: string | null): string {
   if (!value) {
     return "未完成";
   }
-  return new Intl.DateTimeFormat("zh-CN", {
-    month: "2-digit",
-    day: "2-digit",
-    hour: "2-digit",
-    minute: "2-digit",
-  }).format(new Date(value));
+  return runListDateTimeFormat.format(new Date(value));
 }
 
 function formatError(error: unknown): string {
-  if (error instanceof Error) {
-    return error.message;
-  }
-  return "Run 历史记录读取失败。";
+  console.error("Failed to load run history.", error);
+  return "Run 历史记录暂时无法读取，请确认 FastAPI 服务正在运行后重试。";
 }
 
 function buildRunsHref(status: RunStatus | "all", page = 1): string {

--- a/web/app/runs/page.tsx
+++ b/web/app/runs/page.tsx
@@ -164,8 +164,31 @@ function RunRow({ run }: { run: RunSummary }) {
   );
 }
 
-function RunsList({ response }: { response: RunListResponse }) {
+function RunsList({
+  firstPageHref,
+  response,
+}: {
+  firstPageHref: string;
+  response: RunListResponse;
+}) {
   if (response.runs.length === 0) {
+    if (response.total > 0) {
+      return (
+        <div className="rounded-md border bg-background p-6">
+          <div className="flex items-center gap-2 font-semibold">
+            <History className="h-5 w-5 text-primary" />
+            当前页没有记录
+          </div>
+          <p className="mt-2 max-w-2xl text-sm leading-6 text-muted-foreground">
+            该筛选条件下共有 {response.total} 条 run，但当前分页已超出结果范围。
+          </p>
+          <Button asChild className="mt-5" variant="outline">
+            <Link href={firstPageHref}>返回第一页</Link>
+          </Button>
+        </div>
+      );
+    }
+
     return (
       <div className="rounded-md border bg-background p-6">
         <div className="flex items-center gap-2 font-semibold">
@@ -218,7 +241,6 @@ export default async function RunsPage({
     errorMessage = formatError(error);
   }
 
-  const total = runList?.total ?? 0;
   const hasPreviousPage = page > 1;
   const hasNextPage = runList ? runList.offset + runList.runs.length < runList.total : false;
 
@@ -271,7 +293,7 @@ export default async function RunsPage({
         </div>
 
         <div className="mt-5 flex flex-wrap items-center gap-3 text-sm text-muted-foreground">
-          <Badge variant="outline">{total} 条记录</Badge>
+          {runList ? <Badge variant="outline">{runList.total} 条记录</Badge> : null}
           {status ? <span>当前筛选：{statusLabels[status]}</span> : <span>当前筛选：全部</span>}
         </div>
 
@@ -285,7 +307,7 @@ export default async function RunsPage({
               <p className="mt-2 break-words text-sm leading-6 text-muted-foreground">{errorMessage}</p>
             </div>
           ) : runList ? (
-            <RunsList response={runList} />
+            <RunsList firstPageHref={buildRunsHref(selectedFilter)} response={runList} />
           ) : null}
         </div>
 

--- a/web/app/runs/page.tsx
+++ b/web/app/runs/page.tsx
@@ -1,22 +1,227 @@
-import { ArrowLeft, CheckCircle2, Clock3, History, RotateCcw, XCircle } from "lucide-react";
+import {
+  AlertCircle,
+  ArrowLeft,
+  CheckCircle2,
+  CircleDashed,
+  Clock3,
+  History,
+  Loader2,
+  RotateCcw,
+  XCircle,
+} from "lucide-react";
 import Link from "next/link";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { listRuns } from "@/lib/api";
+import type { RunListResponse, RunStatus, RunSummary } from "@/lib/types";
 
-const runStates = [
-  ["succeeded", "成功样例", "RNA-seq DEG 示例", "Plan、IR、WDL、diagnostics 已归档"],
-  ["running", "流式样例", "自然语言 workflow 请求", "Timeline 事件正在追加"],
-  ["failed", "失败样例", "无效 recipe 输入", "诊断报告与错误阶段已保留"],
+export const dynamic = "force-dynamic";
+
+const PAGE_SIZE = 20;
+const statusFilters: Array<{ label: string; value: RunStatus | "all" }> = [
+  { label: "全部", value: "all" },
+  { label: "运行中", value: "running" },
+  { label: "成功", value: "succeeded" },
+  { label: "失败", value: "failed" },
+  { label: "已创建", value: "created" },
 ];
 
-const stateIcon = {
-  succeeded: CheckCircle2,
-  running: Clock3,
-  failed: XCircle,
+const statusLabels: Record<RunStatus, string> = {
+  created: "已创建",
+  running: "运行中",
+  succeeded: "成功",
+  failed: "失败",
 };
 
-export default function RunsPage() {
+const kindLabels: Record<string, string> = {
+  natural_language: "自然语言",
+  structured_compile: "结构化编译",
+};
+
+function isRunStatus(value: string | undefined): value is RunStatus {
+  return value === "created" || value === "running" || value === "succeeded" || value === "failed";
+}
+
+function getStatusBadgeVariant(status: RunStatus): "secondary" | "destructive" | "outline" {
+  if (status === "failed") {
+    return "destructive";
+  }
+  if (status === "succeeded") {
+    return "secondary";
+  }
+  return "outline";
+}
+
+function getStatusIcon(status: RunStatus) {
+  if (status === "succeeded") {
+    return <CheckCircle2 className="h-4 w-4" />;
+  }
+  if (status === "failed") {
+    return <XCircle className="h-4 w-4" />;
+  }
+  if (status === "running") {
+    return <Loader2 className="h-4 w-4 animate-spin" />;
+  }
+  return <CircleDashed className="h-4 w-4" />;
+}
+
+function getValidationLabel(run: RunSummary): string {
+  if (!run.diagnostic_summary.check_performed) {
+    return "未校验";
+  }
+  if (run.status === "created" || run.status === "running") {
+    return "等待校验";
+  }
+  return run.diagnostic_summary.is_valid ? "WDL valid" : "校验未通过";
+}
+
+function formatDateTime(value: string | null): string {
+  if (!value) {
+    return "未完成";
+  }
+  return new Intl.DateTimeFormat("zh-CN", {
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(new Date(value));
+}
+
+function formatError(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return "Run 历史记录读取失败。";
+}
+
+function buildRunsHref(status: RunStatus | "all", page = 1): string {
+  const params = new URLSearchParams();
+  if (status !== "all") {
+    params.set("status", status);
+  }
+  if (page > 1) {
+    params.set("page", String(page));
+  }
+  const query = params.toString();
+  return query ? `/runs?${query}` : "/runs";
+}
+
+function parsePage(value: string | undefined): number {
+  const parsed = Number.parseInt(value ?? "1", 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 1;
+}
+
+function RunRow({ run }: { run: RunSummary }) {
+  const diagnostic = run.diagnostic_summary;
+
+  return (
+    <div className="grid gap-4 rounded-md border bg-background p-4 lg:grid-cols-[minmax(0,1.2fr)_auto_auto] lg:items-center">
+      <div className="min-w-0">
+        <div className="flex flex-wrap items-center gap-2">
+          <Badge variant={getStatusBadgeVariant(run.status)} className="gap-1.5">
+            {getStatusIcon(run.status)}
+            {statusLabels[run.status]}
+          </Badge>
+          <Badge variant="outline">{kindLabels[run.kind] ?? run.kind}</Badge>
+        </div>
+        <div className="mt-3 break-words font-medium">
+          {run.request_summary ?? "无请求摘要"}
+        </div>
+        <div className="mt-2 break-all font-mono text-xs text-muted-foreground">
+          {run.run_id}
+        </div>
+      </div>
+
+      <div className="grid gap-2 text-sm text-muted-foreground sm:grid-cols-4 lg:min-w-[28rem]">
+        <div>
+          <div className="text-xs">错误</div>
+          <div className="mt-1 font-medium text-foreground">{diagnostic.analysis_error_count}</div>
+        </div>
+        <div>
+          <div className="text-xs">警告</div>
+          <div className="mt-1 font-medium text-foreground">{diagnostic.analysis_warning_count}</div>
+        </div>
+        <div>
+          <div className="text-xs">修复</div>
+          <div className="mt-1 font-medium text-foreground">{diagnostic.repair_action_count}</div>
+        </div>
+        <div>
+          <div className="text-xs">校验</div>
+          <div className="mt-1 font-medium text-foreground">{getValidationLabel(run)}</div>
+        </div>
+      </div>
+
+      <div className="text-sm text-muted-foreground lg:text-right">
+        <div className="flex items-center gap-2 lg:justify-end">
+          <Clock3 className="h-4 w-4 text-primary" />
+          {formatDateTime(run.updated_at)}
+        </div>
+        <div className="mt-2 text-xs">创建 {formatDateTime(run.created_at)}</div>
+        <div className="mt-1 text-xs">完成 {formatDateTime(run.completed_at)}</div>
+      </div>
+    </div>
+  );
+}
+
+function RunsList({ response }: { response: RunListResponse }) {
+  if (response.runs.length === 0) {
+    return (
+      <div className="rounded-md border bg-background p-6">
+        <div className="flex items-center gap-2 font-semibold">
+          <History className="h-5 w-5 text-primary" />
+          暂无历史记录
+        </div>
+        <p className="mt-2 max-w-2xl text-sm leading-6 text-muted-foreground">
+          运行一次 RNA-seq 示例后，这里会显示持久化 run 摘要。
+        </p>
+        <Button asChild className="mt-5">
+          <Link href="/workspace?example=rnaseq-deg">
+            <RotateCcw className="h-4 w-4" />
+            打开工作台
+          </Link>
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid gap-3">
+      {response.runs.map((run) => (
+        <RunRow key={run.run_id} run={run} />
+      ))}
+    </div>
+  );
+}
+
+export default async function RunsPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ status?: string; page?: string }>;
+}) {
+  const params = await searchParams;
+  const status = isRunStatus(params.status) ? params.status : undefined;
+  const selectedFilter = status ?? "all";
+  const page = parsePage(params.page);
+  const offset = (page - 1) * PAGE_SIZE;
+
+  let runList: RunListResponse | null = null;
+  let errorMessage: string | null = null;
+
+  try {
+    runList = await listRuns({
+      limit: PAGE_SIZE,
+      offset,
+      status,
+    });
+  } catch (error) {
+    errorMessage = formatError(error);
+  }
+
+  const total = runList?.total ?? 0;
+  const hasPreviousPage = page > 1;
+  const hasNextPage = runList ? runList.offset + runList.runs.length < runList.total : false;
+
   return (
     <div className="mx-auto max-w-7xl px-6 py-8 sm:px-8 lg:px-10">
       <Button asChild variant="ghost" className="mb-8 px-0">
@@ -29,63 +234,86 @@ export default function RunsPage() {
       <div className="mb-8 flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
         <div className="max-w-3xl">
           <div className="flex flex-wrap gap-3">
-            <Badge variant="secondary">W3 静态预览</Badge>
-            <Badge variant="outline">状态样例</Badge>
+            <Badge variant="secondary">W5 历史列表</Badge>
+            <Badge variant="outline">真实 run 数据</Badge>
           </div>
-          <h1 className="mt-4 text-3xl font-semibold tracking-normal">Run 回放与审计预览</h1>
+          <h1 className="mt-4 text-3xl font-semibold tracking-normal">Run 回放与审计</h1>
           <p className="mt-3 leading-7 text-muted-foreground">
-            这个页面预览历史回放的列表结构：每条 run 会汇总状态、请求摘要、
-            关键产物和诊断入口。当前展示静态样例，真实 run 列表与事件回放将在 W5 接入。
+            历史列表读取持久化 run 摘要，保留状态、请求摘要、诊断计数和时间戳。
           </p>
         </div>
         <Button asChild variant="outline">
           <Link href="/workspace?example=rnaseq-deg">
             <RotateCcw className="h-4 w-4" />
-            查看工作台预览
+            运行 RNA-seq 示例
           </Link>
         </Button>
       </div>
 
-      <section className="rounded-md border bg-white p-5">
-        <div className="flex flex-wrap items-center justify-between gap-3">
+      <section>
+        <div className="flex flex-col gap-4 border-b pb-5 md:flex-row md:items-center md:justify-between">
           <div className="flex items-center gap-2 font-semibold">
             <History className="h-5 w-5 text-primary" />
-            Run 状态样例
+            Run 历史
           </div>
-          <Badge variant="outline">非真实运行记录</Badge>
+          <div className="flex flex-wrap gap-2">
+            {statusFilters.map((filter) => (
+              <Button
+                key={filter.value}
+                asChild
+                variant={selectedFilter === filter.value ? "secondary" : "outline"}
+                size="sm"
+              >
+                <Link href={buildRunsHref(filter.value)}>{filter.label}</Link>
+              </Button>
+            ))}
+          </div>
         </div>
-        <div className="mt-5 grid gap-3">
-          {runStates.map(([state, stateLabel, title, detail]) => {
-            const Icon = stateIcon[state as keyof typeof stateIcon];
-            return (
-              <div key={title} className="grid gap-4 rounded-md border bg-background p-4 md:grid-cols-[auto_1fr_auto] md:items-center">
-                <Icon className="h-5 w-5 text-primary" />
-                <div>
-                  <div className="font-semibold">{title}</div>
-                  <div className="mt-1 text-sm text-muted-foreground">{detail}</div>
-                </div>
-                <Badge variant={state === "failed" ? "destructive" : state === "running" ? "outline" : "secondary"}>
-                  {stateLabel}
-                </Badge>
-              </div>
-            );
-          })}
-        </div>
-      </section>
 
-      <section className="mt-6 grid gap-3 md:grid-cols-2">
-        <div className="rounded-md border bg-white p-5">
-          <div className="font-semibold text-primary">当前已实现</div>
-          <p className="mt-2 text-sm leading-6 text-muted-foreground">
-            展示历史页应该如何组织成功、流式更新和失败三类 run 的摘要状态。
-          </p>
+        <div className="mt-5 flex flex-wrap items-center gap-3 text-sm text-muted-foreground">
+          <Badge variant="outline">{total} 条记录</Badge>
+          {status ? <span>当前筛选：{statusLabels[status]}</span> : <span>当前筛选：全部</span>}
         </div>
-        <div className="rounded-md border bg-white p-5">
-          <div className="font-semibold text-primary">后续接入</div>
-          <p className="mt-2 text-sm leading-6 text-muted-foreground">
-            从持久化 run repository 读取真实记录，并进入详情页回放 events、artifacts 和 diagnostics。
-          </p>
+
+        <div className="mt-5">
+          {errorMessage ? (
+            <div className="rounded-md border border-destructive/40 bg-background p-5">
+              <div className="flex items-center gap-2 font-semibold text-destructive">
+                <AlertCircle className="h-5 w-5" />
+                历史记录读取失败
+              </div>
+              <p className="mt-2 break-words text-sm leading-6 text-muted-foreground">{errorMessage}</p>
+            </div>
+          ) : runList ? (
+            <RunsList response={runList} />
+          ) : null}
         </div>
+
+        {runList && (hasPreviousPage || hasNextPage) ? (
+          <div className="mt-5 flex flex-wrap items-center justify-between gap-3 border-t pt-5">
+            <div className="text-sm text-muted-foreground">第 {page} 页</div>
+            <div className="flex gap-2">
+              {hasPreviousPage ? (
+                <Button asChild variant="outline" size="sm">
+                  <Link href={buildRunsHref(selectedFilter, Math.max(1, page - 1))}>上一页</Link>
+                </Button>
+              ) : (
+                <Button variant="outline" size="sm" disabled>
+                  上一页
+                </Button>
+              )}
+              {hasNextPage ? (
+                <Button asChild variant="outline" size="sm">
+                  <Link href={buildRunsHref(selectedFilter, page + 1)}>下一页</Link>
+                </Button>
+              ) : (
+                <Button variant="outline" size="sm" disabled>
+                  下一页
+                </Button>
+              )}
+            </div>
+          </div>
+        ) : null}
       </section>
     </div>
   );

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -4,6 +4,8 @@ import type {
   NaturalLanguageRunRequest,
   RecipeListResponse,
   RunAcceptedResponse,
+  RunListResponse,
+  RunStatus,
   ToolListResponse,
   WorkflowRunSnapshotResponse,
 } from "@/lib/types";
@@ -92,6 +94,33 @@ export function createStructuredCompileRun(
   };
 
   return postJson<RunAcceptedResponse>("/api/compile", body);
+}
+
+export type ListRunsParams = {
+  limit?: number;
+  offset?: number;
+  status?: RunStatus;
+};
+
+export function listRuns(params: ListRunsParams = {}): Promise<RunListResponse> {
+  const searchParams = new URLSearchParams();
+
+  if (params.limit !== undefined) {
+    searchParams.set("limit", String(params.limit));
+  }
+  if (params.offset !== undefined) {
+    searchParams.set("offset", String(params.offset));
+  }
+  if (params.status !== undefined) {
+    searchParams.set("status", params.status);
+  }
+
+  const query = searchParams.toString();
+  const path = query ? `/api/runs?${query}` : "/api/runs";
+
+  return requestJson<RunListResponse>(path, {
+    cache: "no-store",
+  });
 }
 
 export function getRunSnapshot(runId: string): Promise<WorkflowRunSnapshotResponse> {

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -84,6 +84,33 @@ export type RunAcceptedResponse = {
   events_url: string;
 };
 
+export type RunDiagnosticSummary = {
+  analysis_error_count: number;
+  analysis_warning_count: number;
+  repair_action_count: number;
+  check_performed: boolean;
+  is_valid: boolean;
+};
+
+export type RunSummary = {
+  run_id: string;
+  status: RunStatus;
+  kind: string;
+  request_summary: string | null;
+  events_url: string;
+  created_at: string;
+  updated_at: string;
+  completed_at: string | null;
+  diagnostic_summary: RunDiagnosticSummary;
+};
+
+export type RunListResponse = {
+  runs: RunSummary[];
+  limit: number;
+  offset: number;
+  total: number;
+};
+
 export type WorkflowArtifacts = {
   plan: JsonObject | null;
   workflow_ir: JsonObject;


### PR DESCRIPTION
## Summary

- Add frontend types and an API client helper for the run history list endpoint.
- Replace the static `/runs` preview with a server-rendered list backed by `GET /api/runs`.
- Add status filtering, pagination controls, empty state, and API error handling for the history list.

## Validation

- `npm.cmd run lint`
- `npm.cmd run build`
- Local HTTP check: `GET /runs` returned `200` against a temporary Next.js dev server

## Notes

- This PR does not add the run detail replay page, DAG view, or React Flow integration.
- Browser screenshot verification was not available in the local sandbox because the in-app browser bridge could not start a browser process, so validation used build and HTTP checks instead.