### PR TITLE
Add run detail replay page

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -438,8 +438,12 @@ W2 当前接口：
 {
   "run_id": "run_001",
   "status": "succeeded",
+  "kind": "structured_compile",
   "request": "Run bulk RNA-seq differential expression.",
   "events_url": "/api/runs/run_001/events",
+  "created_at": "2026-06-16T00:00:00Z",
+  "updated_at": "2026-06-16T00:00:02Z",
+  "completed_at": "2026-06-16T00:00:02Z",
   "artifacts": {
     "plan": {},
     "workflow_ir": {},

--- a/docs/test-cases.md
+++ b/docs/test-cases.md
@@ -665,6 +665,32 @@ OK (skipped=2)
 
 该文件验证 persistent run lifecycle service。Service 层连接 API DTO、RunRepository、自然语言 planner 和 deterministic compiler graph，FastAPI routes 只调用 service 方法。
 
+### `test_structured_compile_run_succeeds_and_records_events`
+
+输入：
+
+- `examples/rnaseq_deg_recipe_plan.json`
+- `check=False`
+
+执行：
+
+- 通过 `RunService.create_structured_compile_run(...)` 创建 run。
+- 调用 `RunService.execute_structured_compile_run(...)`。
+- 读取 snapshot 与 events。
+
+期望输出：
+
+- snapshot `status == "succeeded"`。
+- snapshot `kind == "structured_compile"`。
+- snapshot 包含 `created_at`、`updated_at` 和 `completed_at`。
+- Workflow IR 名称为 `RNASeqDEG`。
+- WDL 包含 `workflow RNASeqDEG`。
+- events 包含 `run.created`、`artifact.updated`，最后一条为 `run.completed`。
+
+覆盖点：
+
+- 结构化编译 run 会持久化详情页所需元数据、产物、诊断和事件回放记录。
+
 ### `test_list_runs_returns_api_summaries`
 
 输入：

--- a/docs/test-cases.md
+++ b/docs/test-cases.md
@@ -227,6 +227,26 @@ OK (skipped=2)
 
 - API response DTO 能保留 service 诊断，不把无效 plan 包装成成功响应。
 
+### `test_run_snapshot_response_defaults_to_empty_artifacts_and_diagnostics`
+
+输入：
+
+- 只包含 run id、运行状态、请求内容和事件 URL 的 `WorkflowRunSnapshotResponse`。
+
+执行：
+
+- 直接构造 `WorkflowRunSnapshotResponse(...)`。
+
+期望输出：
+
+- artifacts 默认为空 Workflow IR 与空 WDL。
+- diagnostics 默认不是 succeeded。
+- `kind`、`created_at`、`updated_at` 和 `completed_at` 默认为 `None`。
+
+覆盖点：
+
+- run 详情页依赖的 snapshot metadata 默认契约保持显式、稳定。
+
 ### `test_run_list_response_accepts_history_summaries`
 
 输入：

--- a/src/api/models/workflows.py
+++ b/src/api/models/workflows.py
@@ -172,7 +172,11 @@ class WorkflowRunSnapshotResponse(BaseModel):
 
     run_id: str
     status: RunStatus
+    kind: str | None = None
     request: str | JsonObject | None = None
     events_url: str | None = None
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+    completed_at: datetime | None = None
     artifacts: WorkflowArtifacts = Field(default_factory=WorkflowArtifacts)
     diagnostics: DiagnosticReport = Field(default_factory=DiagnosticReport)

--- a/src/services/run_service.py
+++ b/src/services/run_service.py
@@ -171,8 +171,12 @@ class RunService:
         return WorkflowRunSnapshotResponse(
             run_id=snapshot.run.run_id,
             status=snapshot.run.status,
+            kind=snapshot.run.kind,
             request=snapshot.run.request,
             events_url=snapshot.run.events_url,
+            created_at=snapshot.run.created_at,
+            updated_at=snapshot.run.updated_at,
+            completed_at=snapshot.run.completed_at,
             artifacts=snapshot.artifacts,
             diagnostics=snapshot.diagnostics,
         )

--- a/tests/api/test_models.py
+++ b/tests/api/test_models.py
@@ -101,6 +101,8 @@ class WorkflowDtoTests(unittest.TestCase):
         self.assertEqual(response.artifacts.workflow_ir, {})
         self.assertEqual(response.artifacts.wdl, "")
         self.assertFalse(response.diagnostics.succeeded)
+        self.assertIsNone(response.kind)
+        self.assertIsNone(response.created_at)
 
     def test_run_list_response_accepts_history_summaries(self):
         created_at = datetime(2026, 6, 16, tzinfo=UTC)

--- a/tests/api/test_models.py
+++ b/tests/api/test_models.py
@@ -103,6 +103,8 @@ class WorkflowDtoTests(unittest.TestCase):
         self.assertFalse(response.diagnostics.succeeded)
         self.assertIsNone(response.kind)
         self.assertIsNone(response.created_at)
+        self.assertIsNone(response.updated_at)
+        self.assertIsNone(response.completed_at)
 
     def test_run_list_response_accepts_history_summaries(self):
         created_at = datetime(2026, 6, 16, tzinfo=UTC)

--- a/tests/test_run_service.py
+++ b/tests/test_run_service.py
@@ -42,6 +42,10 @@ class RunServiceTests(unittest.TestCase):
             self.assertIsNotNone(snapshot)
             assert snapshot is not None
             self.assertEqual(snapshot.status, RunStatus.SUCCEEDED)
+            self.assertEqual(snapshot.kind, "structured_compile")
+            self.assertIsNotNone(snapshot.created_at)
+            self.assertIsNotNone(snapshot.updated_at)
+            self.assertIsNotNone(snapshot.completed_at)
             self.assertEqual(snapshot.artifacts.workflow_ir["workflow"]["name"], "RNASeqDEG")
             self.assertIn("workflow RNASeqDEG", snapshot.artifacts.wdl)
             self.assertTrue(snapshot.diagnostics.succeeded)

--- a/web/app/runs/[runId]/page.tsx
+++ b/web/app/runs/[runId]/page.tsx
@@ -1,0 +1,246 @@
+import {
+  AlertCircle,
+  ArrowLeft,
+  CheckCircle2,
+  CircleDashed,
+  Clock3,
+  FileText,
+  Layers3,
+  RotateCcw,
+  XCircle,
+} from "lucide-react";
+import Link from "next/link";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { getRunSnapshot } from "@/lib/api";
+import type { JsonObject, RunStatus, WorkflowRunSnapshotResponse } from "@/lib/types";
+import { RunArtifactsPanel } from "./run-artifacts-panel";
+import { RunEventsTimeline } from "./run-events-timeline";
+
+export const dynamic = "force-dynamic";
+
+const statusLabels: Record<RunStatus, string> = {
+  created: "已创建",
+  running: "运行中",
+  succeeded: "成功",
+  failed: "失败",
+};
+
+const kindLabels: Record<string, string> = {
+  natural_language: "自然语言",
+  structured_compile: "结构化编译",
+};
+
+const detailDateTimeFormat = new Intl.DateTimeFormat("zh-CN", {
+  year: "numeric",
+  month: "2-digit",
+  day: "2-digit",
+  hour: "2-digit",
+  minute: "2-digit",
+  second: "2-digit",
+});
+
+function getStatusBadgeVariant(status: RunStatus): "secondary" | "destructive" | "outline" {
+  if (status === "failed") {
+    return "destructive";
+  }
+  if (status === "succeeded") {
+    return "secondary";
+  }
+  return "outline";
+}
+
+function getStatusIcon(status: RunStatus) {
+  if (status === "succeeded") {
+    return <CheckCircle2 className="h-4 w-4" />;
+  }
+  if (status === "failed") {
+    return <XCircle className="h-4 w-4" />;
+  }
+  if (status === "running") {
+    return <Clock3 className="h-4 w-4" />;
+  }
+  return <CircleDashed className="h-4 w-4" />;
+}
+
+function formatDateTime(value: string | null): string {
+  if (!value) {
+    return "未记录";
+  }
+  return detailDateTimeFormat.format(new Date(value));
+}
+
+function formatRequest(request: string | JsonObject | null): string {
+  if (request === null) {
+    return "暂无请求内容。";
+  }
+  if (typeof request === "string") {
+    return request;
+  }
+  return JSON.stringify(request, null, 2);
+}
+
+function getRequestLabel(request: string | JsonObject | null): string {
+  if (request === null) {
+    return "未记录";
+  }
+  return typeof request === "string" ? "Natural-language request" : "Structured payload";
+}
+
+function formatError(error: unknown): string {
+  console.error("Failed to load run detail.", error);
+  return "Run 详情暂时无法读取，请确认 FastAPI 服务正在运行，或从历史列表重新进入。";
+}
+
+function StatItem({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-md border bg-background p-4">
+      <div className="text-xs text-muted-foreground">{label}</div>
+      <div className="mt-2 break-words text-sm font-semibold">{value}</div>
+    </div>
+  );
+}
+
+function DiagnosticsSummary({ snapshot }: { snapshot: WorkflowRunSnapshotResponse }) {
+  const diagnostics = snapshot.diagnostics;
+  const validationLabel = !diagnostics.check_performed
+    ? "未校验"
+    : diagnostics.is_valid
+      ? "WDL valid"
+      : "校验未通过";
+
+  return (
+    <div className="grid gap-3 md:grid-cols-4">
+      <StatItem label="分析错误" value={String(diagnostics.analysis_errors.length)} />
+      <StatItem label="分析警告" value={String(diagnostics.analysis_warnings.length)} />
+      <StatItem label="修复记录" value={String(diagnostics.repair_actions.length)} />
+      <StatItem label="校验状态" value={validationLabel} />
+    </div>
+  );
+}
+
+function RunDetail({ snapshot }: { snapshot: WorkflowRunSnapshotResponse }) {
+  const kindLabel = snapshot.kind ? kindLabels[snapshot.kind] ?? snapshot.kind : "未记录";
+  const requestText = formatRequest(snapshot.request);
+
+  return (
+    <>
+      <div className="mb-8 flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+        <div className="max-w-3xl">
+          <div className="flex flex-wrap gap-3">
+            <Badge variant={getStatusBadgeVariant(snapshot.status)} className="gap-1.5">
+              {getStatusIcon(snapshot.status)}
+              {statusLabels[snapshot.status]}
+            </Badge>
+            <Badge variant="outline">{kindLabel}</Badge>
+            <Badge variant="secondary">W5 详情回放</Badge>
+          </div>
+          <h1 className="mt-4 break-words text-3xl font-semibold tracking-normal">
+            Run 详情回放
+          </h1>
+          <p className="mt-3 break-all font-mono text-sm leading-6 text-muted-foreground">
+            {snapshot.run_id}
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-3">
+          <Button asChild variant="outline">
+            <Link href="/runs">
+              <ArrowLeft className="h-4 w-4" />
+              返回历史
+            </Link>
+          </Button>
+          <Button asChild>
+            <Link href="/workspace?example=rnaseq-deg">
+              <RotateCcw className="h-4 w-4" />
+              运行示例
+            </Link>
+          </Button>
+        </div>
+      </div>
+
+      <section className="grid gap-3 md:grid-cols-4">
+        <StatItem label="创建时间" value={formatDateTime(snapshot.created_at)} />
+        <StatItem label="更新时间" value={formatDateTime(snapshot.updated_at)} />
+        <StatItem label="完成时间" value={formatDateTime(snapshot.completed_at)} />
+        <StatItem label="运行类型" value={kindLabel} />
+      </section>
+
+      <section className="mt-6 rounded-md border bg-white p-5">
+        <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+          <div>
+            <div className="flex items-center gap-2">
+              <FileText className="h-5 w-5 text-primary" />
+              <h2 className="font-semibold">请求内容</h2>
+            </div>
+            <p className="mt-2 text-sm leading-6 text-muted-foreground">
+              {getRequestLabel(snapshot.request)}
+            </p>
+          </div>
+          {snapshot.artifacts.workflow_ir && Object.keys(snapshot.artifacts.workflow_ir).length ? (
+            <Badge variant="outline" className="gap-1.5">
+              <Layers3 className="h-3.5 w-3.5" />
+              Workflow IR 已保存
+            </Badge>
+          ) : null}
+        </div>
+        <pre className="mt-5 max-h-80 overflow-auto whitespace-pre-wrap break-words rounded-md border bg-background p-4 font-mono text-xs leading-6">
+          {requestText}
+        </pre>
+      </section>
+
+      <section className="mt-6 rounded-md border bg-white p-5">
+        <div className="mb-5 flex items-center gap-2">
+          <AlertCircle className="h-5 w-5 text-primary" />
+          <h2 className="font-semibold">诊断摘要</h2>
+        </div>
+        <DiagnosticsSummary snapshot={snapshot} />
+      </section>
+
+      <RunEventsTimeline eventsUrl={snapshot.events_url} status={snapshot.status} />
+      <RunArtifactsPanel artifacts={snapshot.artifacts} diagnostics={snapshot.diagnostics} />
+    </>
+  );
+}
+
+export default async function RunDetailPage({
+  params,
+}: {
+  params: Promise<{ runId: string }>;
+}) {
+  const { runId } = await params;
+  let snapshot: WorkflowRunSnapshotResponse | null = null;
+  let errorMessage: string | null = null;
+
+  try {
+    snapshot = await getRunSnapshot(runId);
+  } catch (error) {
+    errorMessage = formatError(error);
+  }
+
+  return (
+    <div className="mx-auto max-w-7xl px-6 py-8 sm:px-8 lg:px-10">
+      {snapshot ? (
+        <RunDetail snapshot={snapshot} />
+      ) : (
+        <div>
+          <Button asChild variant="ghost" className="mb-8 px-0">
+            <Link href="/runs">
+              <ArrowLeft className="h-4 w-4" />
+              返回历史
+            </Link>
+          </Button>
+          <div className="rounded-md border border-destructive/40 bg-white p-6">
+            <div className="flex items-center gap-2 font-semibold text-destructive">
+              <AlertCircle className="h-5 w-5" />
+              Run 详情读取失败
+            </div>
+            <p className="mt-3 break-words text-sm leading-6 text-muted-foreground">
+              {errorMessage}
+            </p>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/app/runs/[runId]/run-artifacts-panel.tsx
+++ b/web/app/runs/[runId]/run-artifacts-panel.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+import { Activity, FileJson, Layers3, SquareTerminal } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import { useMemo, useState } from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import type { DiagnosticReport, JsonObject, WorkflowArtifacts } from "@/lib/types";
+
+type ArtifactTabId = "plan" | "ir" | "wdl" | "diagnostics";
+
+type ArtifactTab = {
+  id: ArtifactTabId;
+  label: string;
+  description: string;
+  icon: LucideIcon;
+};
+
+const artifactTabs: ArtifactTab[] = [
+  { id: "plan", label: "Plan", description: "Recipe Tool Plan", icon: FileJson },
+  { id: "ir", label: "IR", description: "Workflow DAG 契约", icon: Layers3 },
+  { id: "wdl", label: "WDL", description: "生成的 WDL 1.0", icon: SquareTerminal },
+  { id: "diagnostics", label: "Diagnostics", description: "Analyzer 与 checker 输出", icon: Activity },
+];
+
+function hasJsonContent(value: JsonObject | null): boolean {
+  return value !== null && Object.keys(value).length > 0;
+}
+
+function formatJson(value: JsonObject | null): string {
+  if (!hasJsonContent(value)) {
+    return "";
+  }
+  return JSON.stringify(value, null, 2);
+}
+
+function DiagnosticsView({ diagnostics }: { diagnostics: DiagnosticReport }) {
+  return (
+    <div className="grid gap-4">
+      <div className="grid gap-3 sm:grid-cols-4">
+        <div className="rounded-md border bg-white p-3">
+          <div className="text-xs text-muted-foreground">分析错误</div>
+          <div className="mt-1 text-lg font-semibold">{diagnostics.analysis_errors.length}</div>
+        </div>
+        <div className="rounded-md border bg-white p-3">
+          <div className="text-xs text-muted-foreground">分析警告</div>
+          <div className="mt-1 text-lg font-semibold">{diagnostics.analysis_warnings.length}</div>
+        </div>
+        <div className="rounded-md border bg-white p-3">
+          <div className="text-xs text-muted-foreground">修复记录</div>
+          <div className="mt-1 text-lg font-semibold">{diagnostics.repair_actions.length}</div>
+        </div>
+        <div className="rounded-md border bg-white p-3">
+          <div className="text-xs text-muted-foreground">WDL 校验</div>
+          <div className="mt-1 text-sm font-semibold">
+            {!diagnostics.check_performed
+              ? "未校验"
+              : diagnostics.is_valid
+                ? "通过"
+                : "未通过"}
+          </div>
+        </div>
+      </div>
+
+      <div className="rounded-md border bg-white p-4">
+        <div className="text-sm font-semibold">校验信息</div>
+        <p className="mt-2 break-words text-sm leading-6 text-muted-foreground">
+          {diagnostics.validation_message || "暂无校验信息。"}
+        </p>
+      </div>
+
+      {diagnostics.analysis_errors.length ? (
+        <div className="rounded-md border border-destructive/40 bg-white p-4">
+          <div className="text-sm font-semibold text-destructive">分析错误</div>
+          <ul className="mt-3 grid gap-2 text-sm leading-6 text-muted-foreground">
+            {diagnostics.analysis_errors.map((error) => (
+              <li key={error} className="break-words">
+                {error}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+
+      {diagnostics.analysis_warnings.length ? (
+        <div className="rounded-md border bg-white p-4">
+          <div className="text-sm font-semibold">分析警告</div>
+          <ul className="mt-3 grid gap-2 text-sm leading-6 text-muted-foreground">
+            {diagnostics.analysis_warnings.map((warning) => (
+              <li key={warning} className="break-words">
+                {warning}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+
+      {diagnostics.repair_actions.length ? (
+        <div className="rounded-md border bg-white p-4">
+          <div className="text-sm font-semibold">修复记录</div>
+          <ul className="mt-3 grid gap-2 text-sm leading-6 text-muted-foreground">
+            {diagnostics.repair_actions.map((action) => (
+              <li key={action} className="break-words">
+                {action}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export function RunArtifactsPanel({
+  artifacts,
+  diagnostics,
+}: {
+  artifacts: WorkflowArtifacts;
+  diagnostics: DiagnosticReport;
+}) {
+  const [activeTab, setActiveTab] = useState<ArtifactTabId>("plan");
+  const content = useMemo(
+    () => ({
+      plan: formatJson(artifacts.plan),
+      ir: formatJson(artifacts.workflow_ir),
+      wdl: artifacts.wdl,
+    }),
+    [artifacts.plan, artifacts.workflow_ir, artifacts.wdl],
+  );
+
+  const active = artifactTabs.find((tab) => tab.id === activeTab) ?? artifactTabs[0];
+
+  return (
+    <section className="mt-6 rounded-md border bg-white p-5">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+        <div>
+          <div className="flex flex-wrap items-center gap-2">
+            <h2 className="font-semibold">结构化产物</h2>
+            <Badge variant="outline">{active.description}</Badge>
+          </div>
+          <p className="mt-2 text-sm leading-6 text-muted-foreground">
+            Plan、Workflow IR、WDL 与诊断来自持久化 run snapshot。
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2" role="tablist" aria-label="Run artifacts">
+          {artifactTabs.map((tab) => (
+            <Button
+              key={tab.id}
+              type="button"
+              variant={activeTab === tab.id ? "secondary" : "outline"}
+              size="sm"
+              role="tab"
+              aria-selected={activeTab === tab.id}
+              onClick={() => setActiveTab(tab.id)}
+            >
+              <tab.icon className="h-4 w-4" />
+              {tab.label}
+            </Button>
+          ))}
+        </div>
+      </div>
+
+      <div className="mt-5 rounded-md border bg-background p-4" role="tabpanel">
+        {activeTab === "diagnostics" ? (
+          <DiagnosticsView diagnostics={diagnostics} />
+        ) : content[activeTab] ? (
+          <pre className="max-h-[42rem] overflow-auto whitespace-pre-wrap break-words font-mono text-xs leading-6 text-foreground">
+            {content[activeTab]}
+          </pre>
+        ) : (
+          <div className="text-sm leading-6 text-muted-foreground">当前 run 尚未产生该产物。</div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/web/app/runs/[runId]/run-artifacts-panel.tsx
+++ b/web/app/runs/[runId]/run-artifacts-panel.tsx
@@ -143,15 +143,14 @@ export function RunArtifactsPanel({
             Plan、Workflow IR、WDL 与诊断来自持久化 run snapshot。
           </p>
         </div>
-        <div className="flex flex-wrap gap-2" role="tablist" aria-label="Run artifacts">
+        <div className="flex flex-wrap gap-2" aria-label="Run artifacts">
           {artifactTabs.map((tab) => (
             <Button
               key={tab.id}
               type="button"
               variant={activeTab === tab.id ? "secondary" : "outline"}
               size="sm"
-              role="tab"
-              aria-selected={activeTab === tab.id}
+              aria-pressed={activeTab === tab.id}
               onClick={() => setActiveTab(tab.id)}
             >
               <tab.icon className="h-4 w-4" />
@@ -161,7 +160,7 @@ export function RunArtifactsPanel({
         </div>
       </div>
 
-      <div className="mt-5 rounded-md border bg-background p-4" role="tabpanel">
+      <div className="mt-5 rounded-md border bg-background p-4">
         {activeTab === "diagnostics" ? (
           <DiagnosticsView diagnostics={diagnostics} />
         ) : content[activeTab] ? (

--- a/web/app/runs/[runId]/run-events-timeline.tsx
+++ b/web/app/runs/[runId]/run-events-timeline.tsx
@@ -12,7 +12,7 @@ import { useEffect, useState } from "react";
 
 import { Badge } from "@/components/ui/badge";
 import { buildRunEventsUrl } from "@/lib/api";
-import type { RunEvent, RunEventType, RunStatus } from "@/lib/types";
+import type { JsonObject, RunEvent, RunEventType, RunStatus } from "@/lib/types";
 
 const eventTypes: RunEventType[] = [
   "run.created",
@@ -75,13 +75,48 @@ function mergeEvent(events: RunEvent[], nextEvent: RunEvent): RunEvent[] {
   return Array.from(bySequence.values()).sort((left, right) => left.sequence - right.sequence);
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isRunEventType(value: unknown): value is RunEventType {
+  return typeof value === "string" && eventTypes.includes(value as RunEventType);
+}
+
 function parseRunEvent(message: MessageEvent<string>): RunEvent | null {
   try {
-    const parsed = JSON.parse(message.data) as RunEvent;
-    if (typeof parsed.sequence !== "number" || typeof parsed.type !== "string") {
+    const parsed: unknown = JSON.parse(message.data);
+    if (!isRecord(parsed)) {
       return null;
     }
-    return parsed;
+
+    const { event_id, node, payload, run_id, sequence, summary, timestamp, type } = parsed;
+    if (
+      typeof event_id !== "string" ||
+      typeof run_id !== "string" ||
+      typeof sequence !== "number" ||
+      !Number.isInteger(sequence) ||
+      sequence < 1 ||
+      !isRunEventType(type) ||
+      typeof timestamp !== "string" ||
+      Number.isNaN(Date.parse(timestamp)) ||
+      typeof summary !== "string" ||
+      !(node === null || typeof node === "string") ||
+      !isRecord(payload)
+    ) {
+      return null;
+    }
+
+    return {
+      event_id,
+      run_id,
+      sequence,
+      type,
+      timestamp,
+      summary,
+      node,
+      payload: payload as JsonObject,
+    };
   } catch (error) {
     console.error("Failed to parse run event.", error);
     return null;

--- a/web/app/runs/[runId]/run-events-timeline.tsx
+++ b/web/app/runs/[runId]/run-events-timeline.tsx
@@ -1,0 +1,199 @@
+"use client";
+
+import {
+  AlertCircle,
+  CheckCircle2,
+  CircleDashed,
+  Clock3,
+  Loader2,
+  XCircle,
+} from "lucide-react";
+import { useEffect, useState } from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { buildRunEventsUrl } from "@/lib/api";
+import type { RunEvent, RunEventType, RunStatus } from "@/lib/types";
+
+const eventTypes: RunEventType[] = [
+  "run.created",
+  "node.started",
+  "node.completed",
+  "node.failed",
+  "artifact.updated",
+  "repair.applied",
+  "validation.completed",
+  "run.completed",
+];
+
+const eventLabels: Record<RunEventType, string> = {
+  "run.created": "Run 创建",
+  "node.started": "节点开始",
+  "node.completed": "节点完成",
+  "node.failed": "节点失败",
+  "artifact.updated": "产物更新",
+  "repair.applied": "修复应用",
+  "validation.completed": "校验完成",
+  "run.completed": "Run 完成",
+};
+
+const eventDateTimeFormat = new Intl.DateTimeFormat("zh-CN", {
+  month: "2-digit",
+  day: "2-digit",
+  hour: "2-digit",
+  minute: "2-digit",
+  second: "2-digit",
+});
+
+function isTerminalRunStatus(status: RunStatus): boolean {
+  return status === "succeeded" || status === "failed";
+}
+
+function getEventIcon(event: RunEvent) {
+  if (event.type === "node.failed" || event.payload.status === "failed") {
+    return <XCircle className="h-4 w-4 text-destructive" />;
+  }
+  if (
+    event.type === "node.completed" ||
+    event.type === "validation.completed" ||
+    event.type === "run.completed"
+  ) {
+    return <CheckCircle2 className="h-4 w-4 text-primary" />;
+  }
+  if (event.type === "node.started") {
+    return <Loader2 className="h-4 w-4 animate-spin text-primary" />;
+  }
+  return <CircleDashed className="h-4 w-4 text-muted-foreground" />;
+}
+
+function formatDateTime(value: string): string {
+  return eventDateTimeFormat.format(new Date(value));
+}
+
+function mergeEvent(events: RunEvent[], nextEvent: RunEvent): RunEvent[] {
+  const bySequence = new Map(events.map((event) => [event.sequence, event]));
+  bySequence.set(nextEvent.sequence, nextEvent);
+  return Array.from(bySequence.values()).sort((left, right) => left.sequence - right.sequence);
+}
+
+function parseRunEvent(message: MessageEvent<string>): RunEvent | null {
+  try {
+    const parsed = JSON.parse(message.data) as RunEvent;
+    if (typeof parsed.sequence !== "number" || typeof parsed.type !== "string") {
+      return null;
+    }
+    return parsed;
+  } catch (error) {
+    console.error("Failed to parse run event.", error);
+    return null;
+  }
+}
+
+export function RunEventsTimeline({
+  eventsUrl,
+  status,
+}: {
+  eventsUrl: string | null;
+  status: RunStatus;
+}) {
+  const [events, setEvents] = useState<RunEvent[]>([]);
+  const [streamError, setStreamError] = useState<string | null>(null);
+  const [isConnected, setIsConnected] = useState(false);
+
+  useEffect(() => {
+    if (!eventsUrl) {
+      return undefined;
+    }
+
+    const eventSource = new EventSource(buildRunEventsUrl(eventsUrl));
+
+    eventSource.onopen = () => {
+      setIsConnected(true);
+      setStreamError(null);
+    };
+
+    eventSource.onerror = () => {
+      setIsConnected(false);
+      setStreamError("事件流暂时不可用，请稍后刷新。");
+      if (isTerminalRunStatus(status)) {
+        eventSource.close();
+      }
+    };
+
+    const handlers = eventTypes.map((eventType) => {
+      const handler = (message: MessageEvent<string>) => {
+        const parsed = parseRunEvent(message);
+        if (!parsed) {
+          return;
+        }
+        setEvents((currentEvents) => mergeEvent(currentEvents, parsed));
+        if (parsed.type === "run.completed") {
+          setIsConnected(false);
+          eventSource.close();
+        }
+      };
+      eventSource.addEventListener(eventType, handler);
+      return { eventType, handler };
+    });
+
+    return () => {
+      handlers.forEach(({ eventType, handler }) => {
+        eventSource.removeEventListener(eventType, handler);
+      });
+      eventSource.close();
+    };
+  }, [eventsUrl, status]);
+
+  return (
+    <section className="mt-6 rounded-md border bg-white p-5">
+      <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+        <div>
+          <div className="flex items-center gap-2">
+            <h2 className="font-semibold">事件时间线</h2>
+            <Badge variant="outline">{events.length} 条事件</Badge>
+          </div>
+          <p className="mt-2 text-sm leading-6 text-muted-foreground">
+            事件来自持久化 SSE envelope，可用于回放 run 的关键阶段。
+          </p>
+        </div>
+        <Badge variant={isConnected ? "secondary" : "outline"} className="gap-1.5">
+          {isConnected ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Clock3 className="h-3.5 w-3.5" />}
+          {isConnected ? "读取事件" : isTerminalRunStatus(status) ? "已完成" : "等待连接"}
+        </Badge>
+      </div>
+
+      {streamError ? (
+        <div className="mt-4 flex items-start gap-2 rounded-md border border-destructive/40 bg-background p-4 text-sm text-destructive">
+          <AlertCircle className="mt-0.5 h-4 w-4 flex-none" />
+          <span>{streamError}</span>
+        </div>
+      ) : null}
+
+      {events.length ? (
+        <div className="mt-5 grid gap-3">
+          {events.map((event) => (
+            <div key={event.event_id} className="grid gap-3 rounded-md border bg-background p-4 md:grid-cols-[auto_minmax(0,1fr)_auto] md:items-start">
+              <div className="mt-0.5">{getEventIcon(event)}</div>
+              <div className="min-w-0">
+                <div className="flex flex-wrap items-center gap-2">
+                  <Badge variant="outline">#{event.sequence}</Badge>
+                  <span className="font-medium">{eventLabels[event.type]}</span>
+                  {event.node ? <Badge variant="secondary">{event.node}</Badge> : null}
+                </div>
+                <p className="mt-2 break-words text-sm leading-6 text-muted-foreground">
+                  {event.summary}
+                </p>
+              </div>
+              <div className="text-xs text-muted-foreground md:text-right">
+                {formatDateTime(event.timestamp)}
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div className="mt-5 rounded-md border bg-background p-5 text-sm leading-6 text-muted-foreground">
+          暂无事件回放。
+        </div>
+      )}
+    </section>
+  );
+}

--- a/web/app/runs/page.tsx
+++ b/web/app/runs/page.tsx
@@ -4,6 +4,7 @@ import {
   CheckCircle2,
   CircleDashed,
   Clock3,
+  Eye,
   History,
   Loader2,
   RotateCcw,
@@ -116,7 +117,7 @@ function RunRow({ run }: { run: RunSummary }) {
   const diagnostic = run.diagnostic_summary;
 
   return (
-    <div className="grid gap-4 rounded-md border bg-background p-4 lg:grid-cols-[minmax(0,1.2fr)_auto_auto] lg:items-center">
+    <div className="grid gap-4 rounded-md border bg-background p-4 lg:grid-cols-[minmax(0,1.2fr)_auto_auto_auto] lg:items-center">
       <div className="min-w-0">
         <div className="flex flex-wrap items-center gap-2">
           <Badge variant={getStatusBadgeVariant(run.status)} className="gap-1.5">
@@ -160,6 +161,13 @@ function RunRow({ run }: { run: RunSummary }) {
         <div className="mt-2 text-xs">创建 {formatDateTime(run.created_at)}</div>
         <div className="mt-1 text-xs">完成 {formatDateTime(run.completed_at)}</div>
       </div>
+
+      <Button asChild variant="outline" size="sm">
+        <Link href={`/runs/${encodeURIComponent(run.run_id)}`}>
+          <Eye className="h-4 w-4" />
+          查看详情
+        </Link>
+      </Button>
     </div>
   );
 }

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -130,8 +130,12 @@ export type DiagnosticReport = {
 export type WorkflowRunSnapshotResponse = {
   run_id: string;
   status: RunStatus;
+  kind: string | null;
   request: string | JsonObject | null;
   events_url: string | null;
+  created_at: string | null;
+  updated_at: string | null;
+  completed_at: string | null;
   artifacts: WorkflowArtifacts;
   diagnostics: DiagnosticReport;
 };


### PR DESCRIPTION
## Summary
- Add `/runs/[runId]` detail replay page with run metadata, request content, diagnostic summary, and artifact tabs.
- Replay persisted run events from the SSE endpoint in the detail view.
- Expose snapshot metadata (`kind`, `created_at`, `updated_at`, `completed_at`) for history detail rendering and document the contract.

## Validation
- `npm.cmd run lint`
- `npm.cmd run build`
- `.\.venv\Scripts\python.exe -m unittest discover -v` (`160 tests`, `2 skipped`)
- HTTP smoke check for a real structured compile run detail page and SSE replay endpoint