### PR TITLE
Fix ECS deploy image references

### DIFF
--- a/.github/workflows/build-app-images.yml
+++ b/.github/workflows/build-app-images.yml
@@ -237,9 +237,17 @@ jobs:
             exit 1
           fi
 
-          if ! [[ "$ACR_REGISTRY" =~ ^[A-Za-z0-9][A-Za-z0-9.-]*$ ]]; then
-            echo "::error::ACR_REGISTRY must be a registry host without a scheme or path"
+          if ! [[ "$ACR_REGISTRY" =~ ^[A-Za-z0-9][A-Za-z0-9.-]*(:[0-9]{1,5})?$ ]]; then
+            echo "::error::ACR_REGISTRY must be a registry host, optionally with a port, without a scheme or path"
             exit 1
+          fi
+
+          if [[ "$ACR_REGISTRY" == *:* ]]; then
+            acr_registry_port="${ACR_REGISTRY##*:}"
+            if ! [[ "$acr_registry_port" =~ ^[0-9]{1,5}$ ]] || (( 10#$acr_registry_port < 1 || 10#$acr_registry_port > 65535 )); then
+              echo "::error::ACR_REGISTRY port must be an integer between 1 and 65535"
+              exit 1
+            fi
           fi
 
           if ! [[ "$ACR_NAMESPACE" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]; then
@@ -255,7 +263,7 @@ jobs:
           web_image="${ACR_REGISTRY}/${ACR_NAMESPACE}/${WEB_IMAGE_NAME}:${IMAGE_TAG}"
 
           for image_ref in "$api_image" "$web_image"; do
-            if ! [[ "$image_ref" =~ ^[A-Za-z0-9][A-Za-z0-9._/-]+/[A-Za-z0-9._/-]+:[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$ ]]; then
+            if ! [[ "$image_ref" =~ ^[A-Za-z0-9][A-Za-z0-9.-]*(:[0-9]{1,5})?/[A-Za-z0-9][A-Za-z0-9._-]*/[A-Za-z0-9][A-Za-z0-9._-]*:[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$ ]]; then
               echo "::error::Invalid deploy image reference"
               exit 1
             fi

--- a/.github/workflows/build-app-images.yml
+++ b/.github/workflows/build-app-images.yml
@@ -56,10 +56,8 @@ jobs:
     name: Build app images
     runs-on: ubuntu-latest
     outputs:
-      api_image: ${{ steps.meta.outputs.api_image }}
       image_tag: ${{ steps.meta.outputs.image_tag }}
       publish: ${{ steps.meta.outputs.publish }}
-      web_image: ${{ steps.meta.outputs.web_image }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -79,6 +77,11 @@ jobs:
           short_sha="${GITHUB_SHA::12}"
           image_tag="${DISPATCH_IMAGE_TAG:-$short_sha}"
           next_public_api_base_url="${DISPATCH_NEXT_PUBLIC_API_BASE_URL:-${REPO_NEXT_PUBLIC_API_BASE_URL:-$FALLBACK_NEXT_PUBLIC_API_BASE_URL}}"
+
+          if ! [[ "$image_tag" =~ ^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$ ]]; then
+            echo "::error::image_tag must be a valid Docker tag using letters, numbers, '_', '.', and '-'"
+            exit 1
+          fi
 
           if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" && "$DISPATCH_PUBLISH" == "true" && "$GITHUB_REF" != "refs/heads/main" ]]; then
             echo "::error::publish=true is only allowed from refs/heads/main"
@@ -199,8 +202,9 @@ jobs:
       ECS_SSH_PORT: ${{ secrets.ECS_SSH_PORT }}
       ECS_SSH_PRIVATE_KEY: ${{ secrets.ECS_SSH_PRIVATE_KEY }}
       ECS_USER: ${{ secrets.ECS_USER }}
-      AI_BIOWORKFLOW_API_IMAGE: ${{ needs.build.outputs.api_image }}:${{ needs.build.outputs.image_tag }}
-      AI_BIOWORKFLOW_WEB_IMAGE: ${{ needs.build.outputs.web_image }}:${{ needs.build.outputs.image_tag }}
+      ACR_REGISTRY: ${{ secrets.ACR_REGISTRY }}
+      ACR_NAMESPACE: ${{ secrets.ACR_NAMESPACE }}
+      IMAGE_TAG: ${{ needs.build.outputs.image_tag }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -209,9 +213,9 @@ jobs:
         run: |
           set -euo pipefail
 
-          for name in ECS_HOST ECS_USER ECS_SSH_PRIVATE_KEY; do
+          for name in ECS_HOST ECS_USER ECS_SSH_PRIVATE_KEY ACR_REGISTRY ACR_NAMESPACE IMAGE_TAG; do
             if [[ -z "${!name}" ]]; then
-              echo "::error::Missing required secret: ${name}"
+              echo "::error::Missing required deployment value: ${name}"
               exit 1
             fi
           done
@@ -228,12 +232,39 @@ jobs:
             exit 1
           fi
 
-          for name in AI_BIOWORKFLOW_API_IMAGE AI_BIOWORKFLOW_WEB_IMAGE; do
-            if ! [[ "${!name}" =~ ^[A-Za-z0-9._/@:-]+$ ]]; then
-              echo "::error::${name} must be a non-empty image reference using only letters, numbers, '.', '_', '-', '/', ':', and '@'"
+          if ! [[ "$IMAGE_TAG" =~ ^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$ ]]; then
+            echo "::error::IMAGE_TAG must be a valid Docker tag using letters, numbers, '_', '.', and '-'"
+            exit 1
+          fi
+
+          if ! [[ "$ACR_REGISTRY" =~ ^[A-Za-z0-9][A-Za-z0-9.-]*$ ]]; then
+            echo "::error::ACR_REGISTRY must be a registry host without a scheme or path"
+            exit 1
+          fi
+
+          if ! [[ "$ACR_NAMESPACE" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]; then
+            echo "::error::ACR_NAMESPACE must be a single registry namespace segment"
+            exit 1
+          fi
+
+      - name: Prepare deploy image references
+        run: |
+          set -euo pipefail
+
+          api_image="${ACR_REGISTRY}/${ACR_NAMESPACE}/${API_IMAGE_NAME}:${IMAGE_TAG}"
+          web_image="${ACR_REGISTRY}/${ACR_NAMESPACE}/${WEB_IMAGE_NAME}:${IMAGE_TAG}"
+
+          for image_ref in "$api_image" "$web_image"; do
+            if ! [[ "$image_ref" =~ ^[A-Za-z0-9][A-Za-z0-9._/-]+/[A-Za-z0-9._/-]+:[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$ ]]; then
+              echo "::error::Invalid deploy image reference"
               exit 1
             fi
           done
+
+          {
+            echo "AI_BIOWORKFLOW_API_IMAGE=$api_image"
+            echo "AI_BIOWORKFLOW_WEB_IMAGE=$web_image"
+          } >> "$GITHUB_ENV"
 
       - name: Configure SSH
         run: |
@@ -318,7 +349,7 @@ jobs:
           {
             echo "## ECS app deploy"
             echo ""
-            echo "- API image: \`${AI_BIOWORKFLOW_API_IMAGE}\`"
-            echo "- Web image: \`${AI_BIOWORKFLOW_WEB_IMAGE}\`"
+            echo "- API image: \`${AI_BIOWORKFLOW_API_IMAGE:-not prepared}\`"
+            echo "- Web image: \`${AI_BIOWORKFLOW_WEB_IMAGE:-not prepared}\`"
             echo "- Deploy path: \`${ECS_DEPLOY_PATH:-/opt/ai-bioworkflow}\`"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/build-app-images.yml
+++ b/.github/workflows/build-app-images.yml
@@ -250,24 +250,42 @@ jobs:
             fi
           fi
 
-          if ! [[ "$ACR_NAMESPACE" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]; then
-            echo "::error::ACR_NAMESPACE must be a single registry namespace segment"
+          docker_name_component_re='[a-z0-9]+([._-][a-z0-9]+)*'
+          if ! [[ "$ACR_NAMESPACE" =~ ^$docker_name_component_re$ ]]; then
+            echo "::error::ACR_NAMESPACE must be a lowercase Docker repository path component"
             exit 1
           fi
+
+          for name in API_IMAGE_NAME WEB_IMAGE_NAME; do
+            if ! [[ "${!name}" =~ ^$docker_name_component_re$ ]]; then
+              echo "::error::${name} must be a lowercase Docker repository path component"
+              exit 1
+            fi
+          done
 
       - name: Prepare deploy image references
         run: |
           set -euo pipefail
 
+          registry_host_re='[A-Za-z0-9][A-Za-z0-9.-]*(:[0-9]{1,5})?'
+          docker_name_component_re='[a-z0-9]+([._-][a-z0-9]+)*'
+          image_tag_re='[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}'
+
+          validate_deploy_image_ref() {
+            local name="$1"
+            local image_ref="$2"
+
+            if ! [[ "$image_ref" =~ ^$registry_host_re/$docker_name_component_re/$docker_name_component_re:$image_tag_re$ ]]; then
+              echo "::error::${name} must be a valid Docker image reference with lowercase repository path components"
+              exit 1
+            fi
+          }
+
           api_image="${ACR_REGISTRY}/${ACR_NAMESPACE}/${API_IMAGE_NAME}:${IMAGE_TAG}"
           web_image="${ACR_REGISTRY}/${ACR_NAMESPACE}/${WEB_IMAGE_NAME}:${IMAGE_TAG}"
 
-          for image_ref in "$api_image" "$web_image"; do
-            if ! [[ "$image_ref" =~ ^[A-Za-z0-9][A-Za-z0-9.-]*(:[0-9]{1,5})?/[A-Za-z0-9][A-Za-z0-9._-]*/[A-Za-z0-9][A-Za-z0-9._-]*:[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$ ]]; then
-              echo "::error::Invalid deploy image reference"
-              exit 1
-            fi
-          done
+          validate_deploy_image_ref AI_BIOWORKFLOW_API_IMAGE "$api_image"
+          validate_deploy_image_ref AI_BIOWORKFLOW_WEB_IMAGE "$web_image"
 
           {
             echo "AI_BIOWORKFLOW_API_IMAGE=$api_image"

--- a/deploy/app/README.md
+++ b/deploy/app/README.md
@@ -260,6 +260,9 @@ API/Web 镜像到 ACR。镜像发布成功后，`Deploy app to ECS` job 会：
 - 用当前 commit SHA tag 生成 ECS 上的 `.env.images`。
 - 执行 `./scripts/deploy-ecs.sh` 完成 `pull`、`up -d` 和健康检查。
 
+部署 job 会在本 job 内使用 `ACR_REGISTRY`、`ACR_NAMESPACE` 和当前 commit SHA tag
+重新拼出完整镜像引用，避免跨 job 传递由 secret 派生出的完整镜像地址。
+
 需要配置 GitHub repository secrets：
 
 ```text


### PR DESCRIPTION
## Summary

- Stop passing full ACR image references as build job outputs.
- Rebuild ECS deploy image references inside the deploy job from ACR secrets, fixed image names, and the published image tag.
- Add stricter image tag, registry, namespace, and final deploy image reference validation.
- Document why automatic deployment derives full image references inside the deploy job.

## Root Cause

The deploy job received image references through `needs.build.outputs.*`. Those values were derived from ACR secrets, so GitHub Actions could treat them as secret-like outputs and omit them between jobs. The deploy step then only retained the tag, producing invalid image references such as `:309861eda8da`.

## Validation

- `git diff --check`
- `actionlint .github/workflows/build-app-images.yml`
- Workflow YAML parsed with Python/PyYAML.
- Local deploy image reference simulation verified complete image references and rejected bare `:tag` values.
