### PR TITLE
Add workflow graph model

### DIFF
--- a/docs/test-cases.md
+++ b/docs/test-cases.md
@@ -2728,8 +2728,8 @@ miniwdl run <tmp>/rnaseq_deg.wdl -i examples/tiny/rnaseq_deg.inputs.json --dir <
 ## `web/tests/workflow-graph.test.mjs`
 
 该文件验证 W5 DAG 可视化前置的数据模型转换层。测试通过 Node 内置
-test runner 直接调用 `web/lib/workflow-graph.ts`，不启动 Next.js，也不引入额外
-前端测试依赖。
+test runner 配合 `tsx` loader 直接调用 `web/lib/workflow-graph.ts`，不启动
+Next.js。
 
 运行方式：
 

--- a/docs/test-cases.md
+++ b/docs/test-cases.md
@@ -2809,6 +2809,24 @@ npm run test:graph
 - 前端图模型只做可解释的引用提取。
 - 无法解析或无法确认的表达式保留在节点详情中，供后续 UI 展示和审计。
 
+### `normalizes object expression fallbacks with stable key order`
+
+输入：
+
+- 两份语义相同但 object key 插入顺序不同的 call input：
+  - `{b: 2, a: 1, nested: {z: true, y: false}}`
+  - `{nested: {y: false, z: true}, a: 1, b: 2}`
+
+期望输出：
+
+- 两份 graph 中 `metadata.call.inputs.config` 的 fallback JSON 字符串完全一致。
+- 嵌套 object key 也按稳定顺序输出。
+
+覆盖点：
+
+- graph metadata 中无法直接转成表达式文本的 object fallback 保持 deterministic。
+- 该行为只影响节点详情/审计字符串，不改变 Workflow IR，也不参与 Analyzer 或 Renderer。
+
 ## 当前测试覆盖边界
 
 已有测试重点覆盖：

--- a/docs/test-cases.md
+++ b/docs/test-cases.md
@@ -2727,8 +2727,8 @@ miniwdl run <tmp>/rnaseq_deg.wdl -i examples/tiny/rnaseq_deg.inputs.json --dir <
 
 ## `web/tests/workflow-graph.test.mjs`
 
-该文件验证 W5 DAG 可视化前置的数据模型转换层。测试通过 Node 内置
-test runner 配合 `tsx` loader 直接调用 `web/lib/workflow-graph.ts`，不启动
+该文件验证 W5 DAG 可视化前置的数据模型转换层。测试通过 `tsx --test`
+调用 Node 内置 test runner，并直接加载 `web/lib/workflow-graph.ts`，不启动
 Next.js。
 
 运行方式：
@@ -2793,6 +2793,7 @@ npm run test:graph
   - `missing.result`：未知 call。
   - `qc.missing_report`：已知 call 上未知 output。
   - `qc.html_report + qc.json_report`：不支持的字符串拼接表达式。
+  - `qc.html_report-qc.json_report` 和 `qc.html_report*qc.json_report`：不支持的无空格运算表达式。
 
 期望输出：
 

--- a/docs/test-cases.md
+++ b/docs/test-cases.md
@@ -2725,6 +2725,89 @@ miniwdl run <tmp>/rnaseq_deg.wdl -i examples/tiny/rnaseq_deg.inputs.json --dir <
 
 - `--all` 只发现实际容器目录，非容器草稿目录不会被强制要求声明镜像修订号。
 
+## `web/tests/workflow-graph.test.mjs`
+
+该文件验证 W5 DAG 可视化前置的数据模型转换层。测试通过 Node 内置
+test runner 直接调用 `web/lib/workflow-graph.ts`，不启动 Next.js，也不引入额外
+前端测试依赖。
+
+运行方式：
+
+```powershell
+cd web
+npm run test:graph
+```
+
+### `builds call dependency and workflow output graph from legacy calls`
+
+输入：
+
+- legacy Workflow IR，使用 `workflow.calls`：
+  - workflow inputs：`raw_r1`、`raw_r2`、`reference`
+  - calls：`qc` 调用 `fastp`，`align` 调用 `bwa_mem`
+  - `align` 的输入引用 `qc.clean_r1/qc.clean_r2`
+  - workflow output：`bam = align.bam`
+- task metadata 包含 outputs 和 runtime docker。
+
+期望输出：
+
+- 生成 workflow input、call 和 workflow output 节点。
+- 生成 `qc -> align` 的 dependency edges。
+- 生成 `align -> bam output` 的 output edge。
+- call node metadata 保留 task、outputs 和 runtime。
+
+覆盖点：
+
+- 图模型兼容旧 `workflow.calls` 输入，但不修改 IR。
+- W5 DAG 模型能从 task metadata 暴露节点详情需要的核心字段。
+
+### `builds scatter group and nested call dependencies from workflow steps`
+
+输入：
+
+- canonical Workflow IR，使用 `workflow.steps`：
+  - workflow inputs：`sample_ids`、`raw_r1s`、`raw_r2s`、`transcriptome_index`
+  - scatter step：`per_sample`，`over = range(length(sample_ids))`
+  - scatter body 内含 `qc` 和 `quantify`
+  - scatter 后有 `summarize`，输入引用 `quantify.quant_file`
+  - workflow output：`counts = summarize.gene_counts`
+
+期望输出：
+
+- 生成 scatter group node。
+- scatter body 内的 call nodes 记录 `parentId = scatter:per_sample`。
+- 生成 `sample_ids -> scatter` 的 input edge。
+- 生成 `qc -> quantify`、`quantify -> summarize` 的 dependency edges。
+- 生成 `summarize -> counts output` 的 output edge。
+
+覆盖点：
+
+- 图模型优先读取 `workflow.steps`。
+- scatter body 会递归转成节点和边，但不做 Analyzer 的类型提升或修复工作。
+
+### `records unresolved references without guessing unsupported expressions`
+
+输入：
+
+- Workflow IR 中 `report` call 的输入包含：
+  - `missing.result`：未知 call。
+  - `qc.missing_report`：已知 call 上未知 output。
+  - `qc.html_report + qc.json_report`：不支持的字符串拼接表达式。
+
+期望输出：
+
+- `graph.unresolvedReferences` 按原因记录：
+  - `unknown-call`
+  - `unknown-output`
+  - `unsupported-expression`
+- 对不支持表达式不生成猜测性的 dependency edge。
+- 对已解析的 `report.multiqc_report` workflow output 仍生成 output edge。
+
+覆盖点：
+
+- 前端图模型只做可解释的引用提取。
+- 无法解析或无法确认的表达式保留在节点详情中，供后续 UI 展示和审计。
+
 ## 当前测试覆盖边界
 
 已有测试重点覆盖：
@@ -2744,6 +2827,7 @@ miniwdl run <tmp>/rnaseq_deg.wdl -i examples/tiny/rnaseq_deg.inputs.json --dir <
 - Planner 的 JSON 解析、prompt 构建、schema 错误和 catalog 错误归类。
 - Cromwell execution backend 的可用性检查、提交、轮询、结果收集错误语义和 factory 路由。
 - WDL validator wrapper 和可选 miniwdl tiny run。
+- W5 前端 workflow graph 数据模型对 call、scatter、workflow output 和 unresolved reference 的覆盖。
 
 目前相对少覆盖或未覆盖的方向：
 

--- a/web/lib/workflow-graph.ts
+++ b/web/lib/workflow-graph.ts
@@ -546,7 +546,7 @@ function findInputReferences(
 
 function isUnsupportedExpression(expression: string): boolean {
   const maskedExpression = maskQuotedText(expression);
-  return /(?:\+|&&|\|\|)/.test(maskedExpression) || /\s(?:-|\*|\/)\s/.test(maskedExpression);
+  return /(?:\+|-|\*|\/|&&|\|\|)/.test(maskedExpression);
 }
 
 function workflowInputNodeId(name: string): string {

--- a/web/lib/workflow-graph.ts
+++ b/web/lib/workflow-graph.ts
@@ -1,0 +1,612 @@
+type JsonPrimitive = string | number | boolean | null;
+type JsonValue = JsonPrimitive | JsonObject | JsonValue[];
+type JsonObject = {
+  [key: string]: JsonValue;
+};
+
+export type WorkflowGraphNodeKind =
+  | "workflow-input"
+  | "call"
+  | "scatter"
+  | "workflow-output";
+
+export type WorkflowGraphEdgeKind = "input" | "dependency" | "output";
+
+export type WorkflowGraphExpression = string | string[];
+
+export type WorkflowGraphUnresolvedReason =
+  | "unknown-call"
+  | "unknown-output"
+  | "unsupported-expression";
+
+export type WorkflowGraphUnresolvedReference = {
+  expression: string;
+  ownerId: string;
+  ownerKind: WorkflowGraphNodeKind;
+  reason: WorkflowGraphUnresolvedReason;
+  reference: string | null;
+};
+
+export type WorkflowGraphTaskOutput = {
+  type: string | null;
+  value: string | null;
+};
+
+export type WorkflowGraphNodeMetadata = {
+  workflowInput?: {
+    name: string;
+    type: string;
+  };
+  call?: {
+    id: string;
+    task: string | null;
+    inputs: Record<string, WorkflowGraphExpression>;
+    outputs: Record<string, WorkflowGraphTaskOutput>;
+    runtime: Record<string, JsonValue>;
+    unresolvedReferences: WorkflowGraphUnresolvedReference[];
+  };
+  scatter?: {
+    id: string;
+    item: string | null;
+    over: string | null;
+    unresolvedReferences: WorkflowGraphUnresolvedReference[];
+  };
+  workflowOutput?: {
+    name: string;
+    expression: WorkflowGraphExpression;
+    unresolvedReferences: WorkflowGraphUnresolvedReference[];
+  };
+};
+
+export type WorkflowGraphNode = {
+  id: string;
+  kind: WorkflowGraphNodeKind;
+  label: string;
+  parentId: string | null;
+  sourceStepId: string;
+  metadata: WorkflowGraphNodeMetadata;
+};
+
+export type WorkflowGraphEdge = {
+  id: string;
+  source: string;
+  target: string;
+  kind: WorkflowGraphEdgeKind;
+  label: string;
+  expression: string;
+  unresolved: false;
+};
+
+export type WorkflowGraph = {
+  nodes: WorkflowGraphNode[];
+  edges: WorkflowGraphEdge[];
+  unresolvedReferences: WorkflowGraphUnresolvedReference[];
+};
+
+type WorkflowGraphCallInfo = {
+  callId: string;
+  nodeId: string;
+  outputNames: Set<string> | null;
+};
+
+type PendingExpression = {
+  ownerId: string;
+  ownerKind: WorkflowGraphNodeKind;
+  targetNodeId: string;
+  label: string;
+  value: unknown;
+  callEdgeKind: WorkflowGraphEdgeKind;
+  inputEdgeKind: WorkflowGraphEdgeKind;
+};
+
+type CallReference = {
+  callId: string;
+  outputName: string;
+  text: string;
+};
+
+type InputReference = {
+  inputName: string;
+  text: string;
+};
+
+const CALL_REFERENCE_PATTERN =
+  /\b([A-Za-z_][A-Za-z0-9_]*)\.([A-Za-z_][A-Za-z0-9_]*)\b/g;
+const IDENTIFIER_PATTERN = /\b[A-Za-z_][A-Za-z0-9_]*\b/g;
+const RESERVED_IDENTIFIERS = new Set([
+  "false",
+  "flatten",
+  "length",
+  "null",
+  "range",
+  "read_json",
+  "read_lines",
+  "read_map",
+  "read_string",
+  "read_tsv",
+  "select_all",
+  "select_first",
+  "true",
+]);
+
+export function buildWorkflowGraph(workflowIr: JsonObject): WorkflowGraph {
+  const workflow = getRecord(workflowIr, "workflow");
+  const tasks = getRecord(workflowIr, "tasks");
+
+  const nodes: WorkflowGraphNode[] = [];
+  const edges: WorkflowGraphEdge[] = [];
+  const edgeKeys = new Set<string>();
+  const unresolvedReferences: WorkflowGraphUnresolvedReference[] = [];
+  const nodeById = new Map<string, WorkflowGraphNode>();
+  const callInfoById = new Map<string, WorkflowGraphCallInfo>();
+  const inputNames = new Set<string>();
+  const pendingExpressions: PendingExpression[] = [];
+
+  function addNode(node: WorkflowGraphNode): void {
+    if (nodeById.has(node.id)) {
+      return;
+    }
+    nodeById.set(node.id, node);
+    nodes.push(node);
+  }
+
+  function addEdge(
+    source: string,
+    target: string,
+    kind: WorkflowGraphEdgeKind,
+    label: string,
+    expression: string,
+  ): void {
+    const key = `${source}|${target}|${kind}|${label}|${expression}`;
+    if (edgeKeys.has(key)) {
+      return;
+    }
+    edgeKeys.add(key);
+    edges.push({
+      id: `edge:${edges.length + 1}`,
+      source,
+      target,
+      kind,
+      label,
+      expression,
+      unresolved: false,
+    });
+  }
+
+  function addUnresolved(reference: WorkflowGraphUnresolvedReference): void {
+    unresolvedReferences.push(reference);
+    const node = nodeById.get(reference.ownerId);
+    if (!node) {
+      return;
+    }
+
+    const metadata = node.metadata;
+    if (node.kind === "call" && metadata.call) {
+      metadata.call.unresolvedReferences.push(reference);
+    } else if (node.kind === "scatter" && metadata.scatter) {
+      metadata.scatter.unresolvedReferences.push(reference);
+    } else if (node.kind === "workflow-output" && metadata.workflowOutput) {
+      metadata.workflowOutput.unresolvedReferences.push(reference);
+    }
+  }
+
+  for (const [name, inputDefinition] of Object.entries(getRecord(workflow, "inputs"))) {
+    inputNames.add(name);
+    addNode({
+      id: workflowInputNodeId(name),
+      kind: "workflow-input",
+      label: name,
+      parentId: null,
+      sourceStepId: name,
+      metadata: {
+        workflowInput: {
+          name,
+          type: normalizeInputType(inputDefinition),
+        },
+      },
+    });
+  }
+
+  processSteps(normalizeWorkflowSteps(workflow), null);
+
+  for (const [name, outputExpression] of Object.entries(getRecord(workflow, "outputs"))) {
+    const nodeId = workflowOutputNodeId(name);
+    addNode({
+      id: nodeId,
+      kind: "workflow-output",
+      label: name,
+      parentId: null,
+      sourceStepId: name,
+      metadata: {
+        workflowOutput: {
+          name,
+          expression: normalizeExpression(outputExpression),
+          unresolvedReferences: [],
+        },
+      },
+    });
+    pendingExpressions.push({
+      ownerId: nodeId,
+      ownerKind: "workflow-output",
+      targetNodeId: nodeId,
+      label: name,
+      value: outputExpression,
+      callEdgeKind: "output",
+      inputEdgeKind: "output",
+    });
+  }
+
+  for (const pendingExpression of pendingExpressions) {
+    for (const expression of expressionTexts(pendingExpression.value)) {
+      if (isUnsupportedExpression(expression)) {
+        addUnresolved({
+          expression,
+          ownerId: pendingExpression.ownerId,
+          ownerKind: pendingExpression.ownerKind,
+          reason: "unsupported-expression",
+          reference: null,
+        });
+        continue;
+      }
+
+      for (const callReference of findCallReferences(expression)) {
+        const sourceCall = callInfoById.get(callReference.callId);
+        if (!sourceCall) {
+          addUnresolved({
+            expression,
+            ownerId: pendingExpression.ownerId,
+            ownerKind: pendingExpression.ownerKind,
+            reason: "unknown-call",
+            reference: callReference.text,
+          });
+          continue;
+        }
+
+        if (
+          sourceCall.outputNames !== null &&
+          !sourceCall.outputNames.has(callReference.outputName)
+        ) {
+          addUnresolved({
+            expression,
+            ownerId: pendingExpression.ownerId,
+            ownerKind: pendingExpression.ownerKind,
+            reason: "unknown-output",
+            reference: callReference.text,
+          });
+          continue;
+        }
+
+        addEdge(
+          sourceCall.nodeId,
+          pendingExpression.targetNodeId,
+          pendingExpression.callEdgeKind,
+          pendingExpression.label,
+          expression,
+        );
+      }
+
+      for (const inputReference of findInputReferences(expression, inputNames)) {
+        addEdge(
+          workflowInputNodeId(inputReference.inputName),
+          pendingExpression.targetNodeId,
+          pendingExpression.inputEdgeKind,
+          pendingExpression.label,
+          expression,
+        );
+      }
+    }
+  }
+
+  return {
+    nodes,
+    edges,
+    unresolvedReferences,
+  };
+
+  function processSteps(steps: Record<string, unknown>[], parentId: string | null): void {
+    for (const step of steps) {
+      const kind = typeof step.kind === "string" ? step.kind : step.task ? "call" : null;
+      if (kind === "call") {
+        processCallStep(step, parentId);
+      } else if (kind === "scatter") {
+        processScatterStep(step, parentId);
+      }
+    }
+  }
+
+  function processCallStep(step: Record<string, unknown>, parentId: string | null): void {
+    const callId = getString(step.id);
+    if (!callId) {
+      return;
+    }
+
+    const nodeId = callNodeId(callId);
+    const taskName = getString(step.task);
+    const taskDefinition = taskName ? getRecord(tasks, taskName) : {};
+    const outputs = normalizeTaskOutputs(getRecord(taskDefinition, "outputs"));
+    const runtime = normalizeRuntime(getRecord(taskDefinition, "runtime"));
+    const inputs = normalizeInputs(getRecord(step, "inputs"));
+
+    addNode({
+      id: nodeId,
+      kind: "call",
+      label: callId,
+      parentId,
+      sourceStepId: callId,
+      metadata: {
+        call: {
+          id: callId,
+          task: taskName,
+          inputs,
+          outputs,
+          runtime,
+          unresolvedReferences: [],
+        },
+      },
+    });
+
+    callInfoById.set(callId, {
+      callId,
+      nodeId,
+      outputNames: Object.keys(outputs).length > 0 ? new Set(Object.keys(outputs)) : null,
+    });
+
+    for (const [inputName, inputExpression] of Object.entries(getRecord(step, "inputs"))) {
+      pendingExpressions.push({
+        ownerId: nodeId,
+        ownerKind: "call",
+        targetNodeId: nodeId,
+        label: inputName,
+        value: inputExpression,
+        callEdgeKind: "dependency",
+        inputEdgeKind: "input",
+      });
+    }
+  }
+
+  function processScatterStep(step: Record<string, unknown>, parentId: string | null): void {
+    const scatterId = getString(step.id);
+    if (!scatterId) {
+      return;
+    }
+
+    const nodeId = scatterNodeId(scatterId);
+    const overExpression = getString(step.over);
+    addNode({
+      id: nodeId,
+      kind: "scatter",
+      label: scatterId,
+      parentId,
+      sourceStepId: scatterId,
+      metadata: {
+        scatter: {
+          id: scatterId,
+          item: getString(step.item),
+          over: overExpression,
+          unresolvedReferences: [],
+        },
+      },
+    });
+
+    if (overExpression) {
+      pendingExpressions.push({
+        ownerId: nodeId,
+        ownerKind: "scatter",
+        targetNodeId: nodeId,
+        label: "over",
+        value: overExpression,
+        callEdgeKind: "dependency",
+        inputEdgeKind: "input",
+      });
+    }
+
+    processSteps(normalizeStepArray(step.body), nodeId);
+  }
+}
+
+function normalizeWorkflowSteps(workflow: Record<string, unknown>): Record<string, unknown>[] {
+  const steps = normalizeStepArray(workflow.steps);
+  if (steps.length > 0) {
+    return steps;
+  }
+
+  return normalizeStepArray(workflow.calls).map((call) => ({
+    ...call,
+    kind: "call",
+  }));
+}
+
+function normalizeStepArray(value: unknown): Record<string, unknown>[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.filter(isRecord);
+}
+
+function normalizeInputType(value: unknown): string {
+  if (typeof value === "string") {
+    return value;
+  }
+  if (isRecord(value) && typeof value.type === "string") {
+    return value.type;
+  }
+  return "unknown";
+}
+
+function normalizeInputs(value: Record<string, unknown>): Record<string, WorkflowGraphExpression> {
+  return Object.fromEntries(
+    Object.entries(value).map(([name, inputValue]) => [name, normalizeExpression(inputValue)]),
+  );
+}
+
+function normalizeTaskOutputs(
+  value: Record<string, unknown>,
+): Record<string, WorkflowGraphTaskOutput> {
+  return Object.fromEntries(
+    Object.entries(value).map(([name, outputValue]) => {
+      if (isRecord(outputValue)) {
+        return [
+          name,
+          {
+            type: getString(outputValue.type),
+            value: expressionText(outputValue.value),
+          },
+        ];
+      }
+
+      return [
+        name,
+        {
+          type: typeof outputValue === "string" ? outputValue : null,
+          value: null,
+        },
+      ];
+    }),
+  );
+}
+
+function normalizeRuntime(value: Record<string, unknown>): Record<string, JsonValue> {
+  return Object.fromEntries(
+    Object.entries(value).filter((entry): entry is [string, JsonValue] => isJsonValue(entry[1])),
+  );
+}
+
+function normalizeExpression(value: unknown): WorkflowGraphExpression {
+  if (Array.isArray(value)) {
+    return value.map((item) => expressionText(item) ?? stableJson(item));
+  }
+
+  return expressionText(value) ?? stableJson(value);
+}
+
+function expressionTexts(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return value.flatMap(expressionTexts);
+  }
+
+  const text = expressionText(value);
+  return text ? [text] : [];
+}
+
+function expressionText(value: unknown): string | null {
+  if (typeof value === "string") {
+    return value;
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  if (value === null || value === undefined) {
+    return null;
+  }
+  if (isRecord(value) && "value" in value) {
+    return expressionText(value.value);
+  }
+  return null;
+}
+
+function findCallReferences(expression: string): CallReference[] {
+  return [...maskQuotedText(expression).matchAll(CALL_REFERENCE_PATTERN)].map((match) => ({
+    callId: match[1],
+    outputName: match[2],
+    text: `${match[1]}.${match[2]}`,
+  }));
+}
+
+function findInputReferences(
+  expression: string,
+  inputNames: Set<string>,
+): InputReference[] {
+  const maskedExpression = maskQuotedText(expression);
+  const callReferenceSpans = [...maskedExpression.matchAll(CALL_REFERENCE_PATTERN)].map(
+    (match) => ({
+      start: match.index ?? 0,
+      end: (match.index ?? 0) + match[0].length,
+    }),
+  );
+  const references = new Map<string, InputReference>();
+
+  for (const match of maskedExpression.matchAll(IDENTIFIER_PATTERN)) {
+    const token = match[0];
+    const start = match.index ?? 0;
+    const end = start + token.length;
+
+    if (
+      RESERVED_IDENTIFIERS.has(token) ||
+      !inputNames.has(token) ||
+      callReferenceSpans.some((span) => start >= span.start && end <= span.end)
+    ) {
+      continue;
+    }
+
+    references.set(token, {
+      inputName: token,
+      text: token,
+    });
+  }
+
+  return [...references.values()];
+}
+
+function isUnsupportedExpression(expression: string): boolean {
+  const maskedExpression = maskQuotedText(expression);
+  return /(?:\+|&&|\|\|)/.test(maskedExpression) || /\s(?:-|\*|\/)\s/.test(maskedExpression);
+}
+
+function workflowInputNodeId(name: string): string {
+  return `input:${name}`;
+}
+
+function callNodeId(id: string): string {
+  return `call:${id}`;
+}
+
+function scatterNodeId(id: string): string {
+  return `scatter:${id}`;
+}
+
+function workflowOutputNodeId(name: string): string {
+  return `output:${name}`;
+}
+
+function getRecord(source: Record<string, unknown>, key: string): Record<string, unknown> {
+  const value = source[key];
+  return isRecord(value) ? value : {};
+}
+
+function getString(value: unknown): string | null {
+  return typeof value === "string" ? value : null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isJsonValue(value: unknown): value is JsonValue {
+  if (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  ) {
+    return true;
+  }
+  if (Array.isArray(value)) {
+    return value.every(isJsonValue);
+  }
+  if (isRecord(value)) {
+    return Object.values(value).every(isJsonValue);
+  }
+  return false;
+}
+
+function stableJson(value: unknown): string {
+  if (value === undefined) {
+    return "";
+  }
+  return JSON.stringify(value);
+}
+
+function maskQuotedText(value: string): string {
+  return value.replace(/"([^"\\]|\\.)*"|'([^'\\]|\\.)*'/g, (match) => " ".repeat(match.length));
+}

--- a/web/lib/workflow-graph.ts
+++ b/web/lib/workflow-graph.ts
@@ -600,7 +600,21 @@ function stableJson(value: unknown): string {
   if (value === undefined) {
     return "";
   }
-  return JSON.stringify(value);
+  return JSON.stringify(canonicalJsonValue(value)) ?? "";
+}
+
+function canonicalJsonValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(canonicalJsonValue);
+  }
+  if (isRecord(value)) {
+    return Object.fromEntries(
+      Object.keys(value)
+        .sort()
+        .map((key) => [key, canonicalJsonValue(value[key])]),
+    );
+  }
+  return value;
 }
 
 function maskQuotedText(value: string): string {

--- a/web/lib/workflow-graph.ts
+++ b/web/lib/workflow-graph.ts
@@ -1,8 +1,4 @@
-type JsonPrimitive = string | number | boolean | null;
-type JsonValue = JsonPrimitive | JsonObject | JsonValue[];
-type JsonObject = {
-  [key: string]: JsonValue;
-};
+import type { JsonObject, JsonValue } from "./types";
 
 export type WorkflowGraphNodeKind =
   | "workflow-input"

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -28,6 +28,7 @@
         "eslint-config-next": "^15.1.0",
         "postcss": "^8.5.10",
         "tailwindcss": "^3.4.17",
+        "tsx": "^4.22.4",
         "typescript": "^5.7.2"
       }
     },
@@ -74,6 +75,422 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -2845,6 +3262,48 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "devOptional": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/escalade": {
@@ -6042,6 +6501,25 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/web/package.json
+++ b/web/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint app components lib --max-warnings=0"
+    "lint": "eslint app components lib --max-warnings=0",
+    "test:graph": "node --no-warnings --test tests/workflow-graph.test.mjs"
   },
   "dependencies": {
     "@radix-ui/react-slot": "^1.1.0",

--- a/web/package.json
+++ b/web/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint app components lib --max-warnings=0",
-    "test:graph": "node --import tsx --test tests/workflow-graph.test.mjs"
+    "test:graph": "tsx --test tests/workflow-graph.test.mjs"
   },
   "dependencies": {
     "@radix-ui/react-slot": "^1.1.0",

--- a/web/package.json
+++ b/web/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint app components lib --max-warnings=0",
-    "test:graph": "node --no-warnings --test tests/workflow-graph.test.mjs"
+    "test:graph": "node --import tsx --test tests/workflow-graph.test.mjs"
   },
   "dependencies": {
     "@radix-ui/react-slot": "^1.1.0",
@@ -33,6 +33,7 @@
     "eslint-config-next": "^15.1.0",
     "postcss": "^8.5.10",
     "tailwindcss": "^3.4.17",
+    "tsx": "^4.22.4",
     "typescript": "^5.7.2"
   }
 }

--- a/web/tests/workflow-graph.test.mjs
+++ b/web/tests/workflow-graph.test.mjs
@@ -274,6 +274,8 @@ test("records unresolved references without guessing unsupported expressions", (
             missing_call: "missing.result",
             missing_output: "qc.missing_report",
             unsupported: "qc.html_report + qc.json_report",
+            unsupported_minus: "qc.html_report-qc.json_report",
+            unsupported_multiply: "qc.html_report*qc.json_report",
           },
         },
       ],
@@ -327,16 +329,42 @@ test("records unresolved references without guessing unsupported expressions", (
         reference: null,
         expression: "qc.html_report + qc.json_report",
       },
+      {
+        reason: "unsupported-expression",
+        reference: null,
+        expression: "qc.html_report-qc.json_report",
+      },
+      {
+        reason: "unsupported-expression",
+        reference: null,
+        expression: "qc.html_report*qc.json_report",
+      },
     ],
   );
 
   const reportNode = nodeById(graph, "call:report");
-  assert.equal(reportNode.metadata.call.unresolvedReferences.length, 3);
+  assert.equal(reportNode.metadata.call.unresolvedReferences.length, 5);
   assert.equal(
     findEdge(graph, {
       source: "call:qc",
       target: "call:report",
       expression: "qc.html_report + qc.json_report",
+    }),
+    undefined,
+  );
+  assert.equal(
+    findEdge(graph, {
+      source: "call:qc",
+      target: "call:report",
+      expression: "qc.html_report-qc.json_report",
+    }),
+    undefined,
+  );
+  assert.equal(
+    findEdge(graph, {
+      source: "call:qc",
+      target: "call:report",
+      expression: "qc.html_report*qc.json_report",
     }),
     undefined,
   );

--- a/web/tests/workflow-graph.test.mjs
+++ b/web/tests/workflow-graph.test.mjs
@@ -1,0 +1,352 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { buildWorkflowGraph } from "../lib/workflow-graph.ts";
+
+function nodeById(graph, id) {
+  const node = graph.nodes.find((candidate) => candidate.id === id);
+  assert.ok(node, `missing node ${id}`);
+  return node;
+}
+
+function findEdge(graph, expected) {
+  return graph.edges.find((edge) =>
+    Object.entries(expected).every(([key, value]) => edge[key] === value),
+  );
+}
+
+test("builds call dependency and workflow output graph from legacy calls", () => {
+  const graph = buildWorkflowGraph({
+    workflow: {
+      name: "RNASeqPipeline",
+      inputs: {
+        raw_r1: "File",
+        raw_r2: "File",
+        reference: "File",
+      },
+      calls: [
+        {
+          id: "qc",
+          task: "fastp",
+          inputs: {
+            r1: "raw_r1",
+            r2: "raw_r2",
+          },
+        },
+        {
+          id: "align",
+          task: "bwa_mem",
+          inputs: {
+            r1: "qc.clean_r1",
+            r2: "qc.clean_r2",
+            ref: "reference",
+          },
+        },
+      ],
+      outputs: {
+        bam: "align.bam",
+      },
+    },
+    tasks: {
+      fastp: {
+        outputs: {
+          clean_r1: {
+            type: "File",
+            value: '"clean_R1.fq.gz"',
+          },
+          clean_r2: {
+            type: "File",
+            value: '"clean_R2.fq.gz"',
+          },
+        },
+        runtime: {
+          docker: "quay.io/biocontainers/fastp:1.3.3--h43da1c4_0",
+        },
+      },
+      bwa_mem: {
+        outputs: {
+          bam: {
+            type: "File",
+            value: '"aligned.sam"',
+          },
+        },
+        runtime: {
+          docker: "quay.io/biocontainers/bwa:0.7.17--hed695b0_7",
+          cpu: 8,
+        },
+      },
+    },
+  });
+
+  assert.equal(nodeById(graph, "input:raw_r1").metadata.workflowInput.type, "File");
+  assert.equal(nodeById(graph, "call:qc").metadata.call.task, "fastp");
+
+  const alignNode = nodeById(graph, "call:align");
+  assert.equal(alignNode.metadata.call.task, "bwa_mem");
+  assert.equal(alignNode.metadata.call.outputs.bam.type, "File");
+  assert.equal(
+    alignNode.metadata.call.runtime.docker,
+    "quay.io/biocontainers/bwa:0.7.17--hed695b0_7",
+  );
+
+  assert.ok(
+    findEdge(graph, {
+      source: "call:qc",
+      target: "call:align",
+      kind: "dependency",
+      label: "r1",
+      expression: "qc.clean_r1",
+    }),
+  );
+  assert.ok(
+    findEdge(graph, {
+      source: "call:qc",
+      target: "call:align",
+      kind: "dependency",
+      label: "r2",
+      expression: "qc.clean_r2",
+    }),
+  );
+  assert.ok(
+    findEdge(graph, {
+      source: "call:align",
+      target: "output:bam",
+      kind: "output",
+      label: "bam",
+      expression: "align.bam",
+    }),
+  );
+  assert.deepEqual(graph.unresolvedReferences, []);
+});
+
+test("builds scatter group and nested call dependencies from workflow steps", () => {
+  const graph = buildWorkflowGraph({
+    workflow: {
+      name: "RNASeqDEG",
+      inputs: {
+        sample_ids: "Array[String]",
+        raw_r1s: "Array[File]",
+        raw_r2s: "Array[File]",
+        transcriptome_index: "File",
+      },
+      steps: [
+        {
+          id: "per_sample",
+          kind: "scatter",
+          item: "i",
+          over: "range(length(sample_ids))",
+          body: [
+            {
+              id: "qc",
+              kind: "call",
+              task: "fastp",
+              inputs: {
+                r1: "raw_r1s[i]",
+                r2: "raw_r2s[i]",
+              },
+            },
+            {
+              id: "quantify",
+              kind: "call",
+              task: "salmon",
+              inputs: {
+                r1: "qc.clean_r1",
+                r2: "qc.clean_r2",
+                index: "transcriptome_index",
+              },
+            },
+          ],
+        },
+        {
+          id: "summarize",
+          kind: "call",
+          task: "tximport",
+          inputs: {
+            quant_files: "quantify.quant_file",
+          },
+        },
+      ],
+      outputs: {
+        counts: "summarize.gene_counts",
+      },
+    },
+    tasks: {
+      fastp: {
+        outputs: {
+          clean_r1: {
+            type: "File",
+            value: '"clean_R1.fq.gz"',
+          },
+          clean_r2: {
+            type: "File",
+            value: '"clean_R2.fq.gz"',
+          },
+        },
+      },
+      salmon: {
+        outputs: {
+          quant_file: {
+            type: "File",
+            value: '"quant.sf"',
+          },
+        },
+        runtime: {
+          docker: "quay.io/biocontainers/salmon:1.9.0--h7e5ed60_0",
+        },
+      },
+      tximport: {
+        outputs: {
+          gene_counts: {
+            type: "File",
+            value: '"gene_counts.tsv"',
+          },
+        },
+      },
+    },
+  });
+
+  const scatterNode = nodeById(graph, "scatter:per_sample");
+  assert.equal(scatterNode.metadata.scatter.item, "i");
+  assert.equal(scatterNode.metadata.scatter.over, "range(length(sample_ids))");
+  assert.equal(nodeById(graph, "call:qc").parentId, "scatter:per_sample");
+  assert.equal(nodeById(graph, "call:quantify").parentId, "scatter:per_sample");
+
+  assert.ok(
+    findEdge(graph, {
+      source: "input:sample_ids",
+      target: "scatter:per_sample",
+      kind: "input",
+      label: "over",
+      expression: "range(length(sample_ids))",
+    }),
+  );
+  assert.ok(
+    findEdge(graph, {
+      source: "call:qc",
+      target: "call:quantify",
+      kind: "dependency",
+      label: "r1",
+      expression: "qc.clean_r1",
+    }),
+  );
+  assert.ok(
+    findEdge(graph, {
+      source: "call:quantify",
+      target: "call:summarize",
+      kind: "dependency",
+      label: "quant_files",
+      expression: "quantify.quant_file",
+    }),
+  );
+  assert.ok(
+    findEdge(graph, {
+      source: "call:summarize",
+      target: "output:counts",
+      kind: "output",
+      label: "counts",
+      expression: "summarize.gene_counts",
+    }),
+  );
+  assert.deepEqual(graph.unresolvedReferences, []);
+});
+
+test("records unresolved references without guessing unsupported expressions", () => {
+  const graph = buildWorkflowGraph({
+    workflow: {
+      name: "UnresolvedDemo",
+      inputs: {
+        raw_r1: "File",
+      },
+      steps: [
+        {
+          id: "qc",
+          kind: "call",
+          task: "fastp",
+          inputs: {
+            r1: "raw_r1",
+          },
+        },
+        {
+          id: "report",
+          kind: "call",
+          task: "multiqc",
+          inputs: {
+            missing_call: "missing.result",
+            missing_output: "qc.missing_report",
+            unsupported: "qc.html_report + qc.json_report",
+          },
+        },
+      ],
+      outputs: {
+        report: "report.multiqc_report",
+      },
+    },
+    tasks: {
+      fastp: {
+        outputs: {
+          html_report: {
+            type: "File",
+            value: '"fastp.html"',
+          },
+          json_report: {
+            type: "File",
+            value: '"fastp.json"',
+          },
+        },
+      },
+      multiqc: {
+        outputs: {
+          multiqc_report: {
+            type: "File",
+            value: '"multiqc.html"',
+          },
+        },
+      },
+    },
+  });
+
+  assert.deepEqual(
+    graph.unresolvedReferences.map((reference) => ({
+      reason: reference.reason,
+      reference: reference.reference,
+      expression: reference.expression,
+    })),
+    [
+      {
+        reason: "unknown-call",
+        reference: "missing.result",
+        expression: "missing.result",
+      },
+      {
+        reason: "unknown-output",
+        reference: "qc.missing_report",
+        expression: "qc.missing_report",
+      },
+      {
+        reason: "unsupported-expression",
+        reference: null,
+        expression: "qc.html_report + qc.json_report",
+      },
+    ],
+  );
+
+  const reportNode = nodeById(graph, "call:report");
+  assert.equal(reportNode.metadata.call.unresolvedReferences.length, 3);
+  assert.equal(
+    findEdge(graph, {
+      source: "call:qc",
+      target: "call:report",
+      expression: "qc.html_report + qc.json_report",
+    }),
+    undefined,
+  );
+  assert.ok(
+    findEdge(graph, {
+      source: "call:report",
+      target: "output:report",
+      kind: "output",
+      label: "report",
+      expression: "report.multiqc_report",
+    }),
+  );
+});

--- a/web/tests/workflow-graph.test.mjs
+++ b/web/tests/workflow-graph.test.mjs
@@ -378,3 +378,56 @@ test("records unresolved references without guessing unsupported expressions", (
     }),
   );
 });
+
+test("normalizes object expression fallbacks with stable key order", () => {
+  const firstGraph = buildWorkflowGraph({
+    workflow: {
+      name: "StableExpressionDemo",
+      steps: [
+        {
+          id: "report",
+          kind: "call",
+          task: "multiqc",
+          inputs: {
+            config: {
+              b: 2,
+              a: 1,
+              nested: {
+                z: true,
+                y: false,
+              },
+            },
+          },
+        },
+      ],
+    },
+  });
+  const secondGraph = buildWorkflowGraph({
+    workflow: {
+      name: "StableExpressionDemo",
+      steps: [
+        {
+          id: "report",
+          kind: "call",
+          task: "multiqc",
+          inputs: {
+            config: {
+              nested: {
+                y: false,
+                z: true,
+              },
+              a: 1,
+              b: 2,
+            },
+          },
+        },
+      ],
+    },
+  });
+
+  const firstConfig = nodeById(firstGraph, "call:report").metadata.call.inputs.config;
+  const secondConfig = nodeById(secondGraph, "call:report").metadata.call.inputs.config;
+
+  assert.equal(firstConfig, '{"a":1,"b":2,"nested":{"y":false,"z":true}}');
+  assert.equal(firstConfig, secondConfig);
+});


### PR DESCRIPTION
## Summary

- Add a pure frontend Workflow IR to graph model converter for W5 DAG visualization.
- Represent workflow inputs, call nodes, scatter groups, workflow outputs, dependency edges, and unresolved references.
- Add Node test coverage for legacy calls, canonical workflow steps with scatter, workflow outputs, and unresolved expressions.
- Document the new frontend graph model tests in `docs/test-cases.md`.

## Validation

- `npm.cmd run test:graph`
- `npm.cmd run lint`
- `npm.cmd run build`

WDL validation was not run because this change does not modify Analyzer, Renderer, IR schemas, recipes, or WDL output paths.