### PR TITLE
Add local development startup script

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -162,6 +162,7 @@ P0 后续工作重点不再是证明 runner 能否运行，而是把已验证流
 | P0 本地快速检查 | `powershell -ExecutionPolicy Bypass -File scripts\check_p0.ps1` | 运行单测、代表性 RNA-seq WDL 编译和语法校验；不触发真实 e2e。 |
 | 结构化编译 | `uv run main.py --input examples/rnaseq_deg_recipe_plan.json --output outputs/rnaseq_deg.wdl` | 直接走确定性 Recipe Tool Plan / IR 编译路径，不需要 API key。 |
 | 自然语言规划编译 | `uv run main.py --prompt-file examples/rnaseq_deg_request.txt --output outputs/rnaseq_deg.wdl` | 先生成 Recipe Tool Plan，再进入确定性编译链路；需要 `DEEPSEEK_API_KEY`。 |
+| 本地 API + Web 开发服务 | `powershell -ExecutionPolicy Bypass -File scripts\dev_local.ps1` | 同时启动 FastAPI `127.0.0.1:8010` 与 Next.js `127.0.0.1:3000`，用于本地观察工作台修改结果。 |
 | FastAPI 开发服务 | `.\.venv\Scripts\python.exe -m src.api.server` | 默认监听 `127.0.0.1:8010`，避开 Cromwell 的 `8000`。 |
 | 真实 Cromwell tiny e2e | `powershell -ExecutionPolicy Bypass -File scripts\check_p0.ps1 -RunE2E -CromwellUrl http://localhost:8000 -WindowsFixtureRoot C:\data\ai-bioworkflow-tiny -CromwellFixtureRoot /data/ai-bioworkflow-runner/tiny` | 显式 opt-in；`check_p0.ps1` 委托 `run_cromwell_tiny_e2e.ps1` 准备 fixture、同步 runner 并运行真实 e2e。 |
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ JAVA_HOME="D:/path/to/jdk-17"
 # 本地 P0 快速检查：单测 + 代表性 WDL 编译/语法校验
 powershell -ExecutionPolicy Bypass -File scripts\check_p0.ps1
 
+# 启动本地 API + Web 开发服务
+powershell -ExecutionPolicy Bypass -File scripts\dev_local.ps1
+
 # 结构化 Recipe Tool Plan 编译
 uv run main.py --input examples/rnaseq_deg_recipe_plan.json --output outputs/rnaseq_deg.wdl
 
@@ -150,6 +153,14 @@ uv run main.py \
 ### 6. 启动 FastAPI 开发服务
 
 如果本地同时运行 Cromwell server，建议保留 Cromwell 使用 `8000` 端口，本项目 FastAPI 开发服务使用 `8010` 端口，避免两个服务的 `/api/...` 路径互相混淆。
+
+本地同时观察 API 与 Web 工作台时，可以使用联合开发脚本：
+
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts\dev_local.ps1
+```
+
+该脚本默认启动 FastAPI `127.0.0.1:8010` 与 Next.js `127.0.0.1:3000`，并支持 `-ApiOnly`、`-WebOnly`、`-ApiPort` 和 `-WebPort`。
 
 ```powershell
 .\.venv\Scripts\python.exe -m src.api.server

--- a/scripts/dev_local.ps1
+++ b/scripts/dev_local.ps1
@@ -46,7 +46,13 @@ function Resolve-ApiBaseUrl {
     if ($ApiBaseUrl) {
         return $ApiBaseUrl.TrimEnd("/")
     }
-    return "http://${ApiHost}:${ApiPort}"
+
+    $apiBaseHost = $ApiHost
+    if ($apiBaseHost -eq "0.0.0.0") {
+        $apiBaseHost = "127.0.0.1"
+    }
+
+    return "http://${apiBaseHost}:${ApiPort}"
 }
 
 function Get-WebCorsOrigins {
@@ -298,9 +304,13 @@ if ($ApiOnly -and $WebOnly) {
     throw "Choose at most one of -ApiOnly or -WebOnly."
 }
 
-Set-PythonCommand
 $resolvedApiBaseUrl = Resolve-ApiBaseUrl
-$corsOrigins = Get-WebCorsOrigins
+$corsOrigins = ""
+
+if (-not $WebOnly) {
+    Set-PythonCommand
+    $corsOrigins = Get-WebCorsOrigins
+}
 
 if (-not $WebOnly) {
     Assert-PortAvailable -Name "API" -HostName $ApiHost -Port $ApiPort

--- a/scripts/dev_local.ps1
+++ b/scripts/dev_local.ps1
@@ -1,0 +1,292 @@
+param(
+    [string]$PythonExe = "",
+    [string]$ApiHost = "127.0.0.1",
+    [ValidateRange(1, 65535)]
+    [int]$ApiPort = 8010,
+    [string]$WebHost = "127.0.0.1",
+    [ValidateRange(1, 65535)]
+    [int]$WebPort = 3000,
+    [string]$ApiBaseUrl = "",
+    [switch]$ApiOnly,
+    [switch]$WebOnly,
+    [switch]$DryRun,
+    [switch]$SkipPortCheck
+)
+
+$ErrorActionPreference = "Stop"
+
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot "..")
+$webRoot = Join-Path $repoRoot "web"
+$script:pythonCommand = @()
+
+function Set-PythonCommand {
+    if ($PythonExe) {
+        if (-not (Test-Path -LiteralPath $PythonExe)) {
+            throw "Python executable not found: $PythonExe"
+        }
+        $script:pythonCommand = @($PythonExe)
+        return
+    }
+
+    $venvPython = Join-Path $repoRoot ".venv\Scripts\python.exe"
+    if (Test-Path -LiteralPath $venvPython) {
+        $script:pythonCommand = @($venvPython)
+        return
+    }
+
+    if (Get-Command uv -ErrorAction SilentlyContinue) {
+        $script:pythonCommand = @("uv", "run", "python")
+        return
+    }
+
+    throw "No Python runtime found. Expected .venv\Scripts\python.exe or uv on PATH."
+}
+
+function Resolve-ApiBaseUrl {
+    if ($ApiBaseUrl) {
+        return $ApiBaseUrl.TrimEnd("/")
+    }
+    return "http://${ApiHost}:${ApiPort}"
+}
+
+function Get-WebCorsOrigins {
+    $origins = @("http://${WebHost}:${WebPort}")
+    if ($WebHost -eq "127.0.0.1") {
+        $origins += "http://localhost:${WebPort}"
+    }
+    elseif ($WebHost -eq "localhost") {
+        $origins += "http://127.0.0.1:${WebPort}"
+    }
+
+    return (($origins | Select-Object -Unique) -join ",")
+}
+
+function Test-TcpPortAvailable {
+    param(
+        [Parameter(Mandatory = $true)][string]$HostName,
+        [Parameter(Mandatory = $true)][int]$Port
+    )
+
+    $listener = $null
+    try {
+        $address = [System.Net.IPAddress]::Any
+        if (-not [System.Net.IPAddress]::TryParse($HostName, [ref]$address)) {
+            $address = [System.Net.Dns]::GetHostAddresses($HostName) |
+                Where-Object { $_.AddressFamily -eq [System.Net.Sockets.AddressFamily]::InterNetwork } |
+                Select-Object -First 1
+        }
+
+        if ($null -eq $address) {
+            return $false
+        }
+
+        $listener = [System.Net.Sockets.TcpListener]::new($address, $Port)
+        $listener.Start()
+        return $true
+    }
+    catch {
+        return $false
+    }
+    finally {
+        if ($null -ne $listener) {
+            $listener.Stop()
+        }
+    }
+}
+
+function Assert-PortAvailable {
+    param(
+        [Parameter(Mandatory = $true)][string]$Name,
+        [Parameter(Mandatory = $true)][string]$HostName,
+        [Parameter(Mandatory = $true)][int]$Port
+    )
+
+    if ($SkipPortCheck) {
+        return
+    }
+
+    if (-not (Test-TcpPortAvailable -HostName $HostName -Port $Port)) {
+        throw "$Name port is already in use: ${HostName}:${Port}. Pass a different port or use -SkipPortCheck if this is expected."
+    }
+}
+
+function Assert-WebReady {
+    if (-not (Test-Path -LiteralPath (Join-Path $webRoot "package.json"))) {
+        throw "Web package.json not found: $webRoot"
+    }
+    if (-not (Get-Command npm -ErrorAction SilentlyContinue)) {
+        throw "npm was not found on PATH. Install Node.js/npm before starting the web app."
+    }
+    if (-not (Test-Path -LiteralPath (Join-Path $webRoot "node_modules"))) {
+        throw "Web dependencies are not installed. Run 'npm install' from the web directory first."
+    }
+}
+
+function Invoke-ApiServer {
+    param(
+        [Parameter(Mandatory = $true)][string[]]$PythonCommand,
+        [Parameter(Mandatory = $true)][string]$CorsOrigins
+    )
+
+    $env:AI_BIOWORKFLOW_API_HOST = $ApiHost
+    $env:AI_BIOWORKFLOW_API_PORT = [string]$ApiPort
+    $env:AI_BIOWORKFLOW_CORS_ORIGINS = $CorsOrigins
+
+    Push-Location $repoRoot
+    try {
+        $command = $PythonCommand[0]
+        $commandArgs = @()
+        if ($PythonCommand.Count -gt 1) {
+            $commandArgs += $PythonCommand[1..($PythonCommand.Count - 1)]
+        }
+        $commandArgs += @("-m", "src.api.server")
+
+        & $command @commandArgs
+        if ($LASTEXITCODE -ne 0) {
+            throw "API server exited with code $LASTEXITCODE"
+        }
+    }
+    finally {
+        Pop-Location
+    }
+}
+
+function Invoke-WebServer {
+    param([Parameter(Mandatory = $true)][string]$ResolvedApiBaseUrl)
+
+    $env:NEXT_PUBLIC_API_BASE_URL = $ResolvedApiBaseUrl
+
+    Push-Location $webRoot
+    try {
+        & npm run dev -- -H $WebHost -p $WebPort
+        if ($LASTEXITCODE -ne 0) {
+            throw "Next.js dev server exited with code $LASTEXITCODE"
+        }
+    }
+    finally {
+        Pop-Location
+    }
+}
+
+function Start-ApiJob {
+    param(
+        [Parameter(Mandatory = $true)][string[]]$PythonCommand,
+        [Parameter(Mandatory = $true)][string]$CorsOrigins
+    )
+
+    Start-Job -Name "api" -ScriptBlock {
+        param($RepoRoot, $PythonCommand, $ApiHost, $ApiPort, $CorsOrigins)
+
+        $ErrorActionPreference = "Stop"
+        Set-Location $RepoRoot
+        $env:AI_BIOWORKFLOW_API_HOST = $ApiHost
+        $env:AI_BIOWORKFLOW_API_PORT = [string]$ApiPort
+        $env:AI_BIOWORKFLOW_CORS_ORIGINS = $CorsOrigins
+
+        $command = $PythonCommand[0]
+        $commandArgs = @()
+        if ($PythonCommand.Count -gt 1) {
+            $commandArgs += $PythonCommand[1..($PythonCommand.Count - 1)]
+        }
+        $commandArgs += @("-m", "src.api.server")
+
+        & $command @commandArgs 2>&1 | ForEach-Object { "[api] $_" }
+        if ($LASTEXITCODE -ne 0) {
+            throw "API server exited with code $LASTEXITCODE"
+        }
+    } -ArgumentList $repoRoot, $PythonCommand, $ApiHost, $ApiPort, $CorsOrigins
+}
+
+function Start-WebJob {
+    param([Parameter(Mandatory = $true)][string]$ResolvedApiBaseUrl)
+
+    Start-Job -Name "web" -ScriptBlock {
+        param($WebRoot, $WebHost, $WebPort, $ResolvedApiBaseUrl)
+
+        $ErrorActionPreference = "Stop"
+        Set-Location $WebRoot
+        $env:NEXT_PUBLIC_API_BASE_URL = $ResolvedApiBaseUrl
+
+        & npm run dev -- -H $WebHost -p $WebPort 2>&1 | ForEach-Object { "[web] $_" }
+        if ($LASTEXITCODE -ne 0) {
+            throw "Next.js dev server exited with code $LASTEXITCODE"
+        }
+    } -ArgumentList $webRoot, $WebHost, $WebPort, $ResolvedApiBaseUrl
+}
+
+function Receive-DevJobs {
+    param([Parameter(Mandatory = $true)][object[]]$Jobs)
+
+    while ($true) {
+        foreach ($job in $Jobs) {
+            Receive-Job -Job $job
+        }
+
+        $stoppedJobs = @($Jobs | Where-Object { $_.State -ne "Running" })
+        if ($stoppedJobs.Count -gt 0) {
+            foreach ($job in $stoppedJobs) {
+                Receive-Job -Job $job
+            }
+            $names = ($stoppedJobs | ForEach-Object { "$($_.Name):$($_.State)" }) -join ", "
+            throw "One or more dev services stopped: $names"
+        }
+
+        Start-Sleep -Seconds 1
+    }
+}
+
+if ($ApiOnly -and $WebOnly) {
+    throw "Choose at most one of -ApiOnly or -WebOnly."
+}
+
+Set-PythonCommand
+$resolvedApiBaseUrl = Resolve-ApiBaseUrl
+$corsOrigins = Get-WebCorsOrigins
+
+if (-not $WebOnly) {
+    Assert-PortAvailable -Name "API" -HostName $ApiHost -Port $ApiPort
+}
+if (-not $ApiOnly) {
+    Assert-WebReady
+    Assert-PortAvailable -Name "Web" -HostName $WebHost -Port $WebPort
+}
+
+Write-Host "AI-bioworkflow local dev"
+Write-Host "Repo: $repoRoot"
+if (-not $WebOnly) {
+    Write-Host "API:  http://${ApiHost}:${ApiPort}"
+    Write-Host "Docs: http://${ApiHost}:${ApiPort}/docs"
+}
+if (-not $ApiOnly) {
+    Write-Host "Web:  http://${WebHost}:${WebPort}"
+    Write-Host "NEXT_PUBLIC_API_BASE_URL=$resolvedApiBaseUrl"
+}
+Write-Host "Press Ctrl+C to stop."
+
+if ($DryRun) {
+    Write-Host "Dry run complete. No dev services were started."
+    exit 0
+}
+
+if ($ApiOnly) {
+    Invoke-ApiServer -PythonCommand $script:pythonCommand -CorsOrigins $corsOrigins
+    exit 0
+}
+
+if ($WebOnly) {
+    Invoke-WebServer -ResolvedApiBaseUrl $resolvedApiBaseUrl
+    exit 0
+}
+
+$jobs = @()
+try {
+    $jobs += Start-ApiJob -PythonCommand $script:pythonCommand -CorsOrigins $corsOrigins
+    $jobs += Start-WebJob -ResolvedApiBaseUrl $resolvedApiBaseUrl
+    Receive-DevJobs -Jobs $jobs
+}
+finally {
+    foreach ($job in $jobs) {
+        Stop-Job -Job $job -ErrorAction SilentlyContinue
+        Remove-Job -Job $job -Force -ErrorAction SilentlyContinue
+    }
+}

--- a/scripts/dev_local.ps1
+++ b/scripts/dev_local.ps1
@@ -50,7 +50,16 @@ function Resolve-ApiBaseUrl {
 }
 
 function Get-WebCorsOrigins {
-    $origins = @("http://${WebHost}:${WebPort}")
+    if ($WebHost -eq "0.0.0.0") {
+        $origins = @(
+            "http://127.0.0.1:${WebPort}",
+            "http://localhost:${WebPort}"
+        )
+    }
+    else {
+        $origins = @("http://${WebHost}:${WebPort}")
+    }
+
     if ($WebHost -eq "127.0.0.1") {
         $origins += "http://localhost:${WebPort}"
     }
@@ -61,6 +70,30 @@ function Get-WebCorsOrigins {
     return (($origins | Select-Object -Unique) -join ",")
 }
 
+function Resolve-BindAddress {
+    param([Parameter(Mandatory = $true)][string]$HostName)
+
+    $address = [System.Net.IPAddress]::Any
+    if ([System.Net.IPAddress]::TryParse($HostName, [ref]$address)) {
+        return $address
+    }
+
+    try {
+        $address = [System.Net.Dns]::GetHostAddresses($HostName) |
+            Where-Object { $_.AddressFamily -eq [System.Net.Sockets.AddressFamily]::InterNetwork } |
+            Select-Object -First 1
+    }
+    catch {
+        throw "Host could not be resolved: $HostName"
+    }
+
+    if ($null -eq $address) {
+        throw "Host did not resolve to an IPv4 address: $HostName"
+    }
+
+    return $address
+}
+
 function Test-TcpPortAvailable {
     param(
         [Parameter(Mandatory = $true)][string]$HostName,
@@ -69,23 +102,36 @@ function Test-TcpPortAvailable {
 
     $listener = $null
     try {
-        $address = [System.Net.IPAddress]::Any
-        if (-not [System.Net.IPAddress]::TryParse($HostName, [ref]$address)) {
-            $address = [System.Net.Dns]::GetHostAddresses($HostName) |
-                Where-Object { $_.AddressFamily -eq [System.Net.Sockets.AddressFamily]::InterNetwork } |
-                Select-Object -First 1
-        }
-
-        if ($null -eq $address) {
-            return $false
-        }
-
+        $address = Resolve-BindAddress -HostName $HostName
         $listener = [System.Net.Sockets.TcpListener]::new($address, $Port)
         $listener.Start()
-        return $true
+        return [pscustomobject]@{
+            Available = $true
+            Reason = ""
+            Message = ""
+        }
+    }
+    catch [System.Net.Sockets.SocketException] {
+        $reason = "BindFailed"
+        if ($_.Exception.SocketErrorCode -eq [System.Net.Sockets.SocketError]::AddressAlreadyInUse) {
+            $reason = "PortInUse"
+        }
+        elseif ($_.Exception.SocketErrorCode -eq [System.Net.Sockets.SocketError]::AddressNotAvailable) {
+            $reason = "AddressNotAvailable"
+        }
+
+        return [pscustomobject]@{
+            Available = $false
+            Reason = $reason
+            Message = $_.Exception.Message
+        }
     }
     catch {
-        return $false
+        return [pscustomobject]@{
+            Available = $false
+            Reason = "HostResolutionFailed"
+            Message = $_.Exception.Message
+        }
     }
     finally {
         if ($null -ne $listener) {
@@ -105,9 +151,22 @@ function Assert-PortAvailable {
         return
     }
 
-    if (-not (Test-TcpPortAvailable -HostName $HostName -Port $Port)) {
+    $result = Test-TcpPortAvailable -HostName $HostName -Port $Port
+    if ($result.Available) {
+        return
+    }
+
+    if ($result.Reason -eq "HostResolutionFailed") {
+        throw "$Name host could not be resolved for port check: $HostName. $($result.Message)"
+    }
+    elseif ($result.Reason -eq "AddressNotAvailable") {
+        throw "$Name host is not available for binding: ${HostName}:${Port}. $($result.Message)"
+    }
+    elseif ($result.Reason -eq "PortInUse") {
         throw "$Name port is already in use: ${HostName}:${Port}. Pass a different port or use -SkipPortCheck if this is expected."
     }
+
+    throw "$Name port check failed for ${HostName}:${Port}. $($result.Message)"
 }
 
 function Assert-WebReady {


### PR DESCRIPTION
## Summary

- Add `scripts/dev_local.ps1` to start the FastAPI API and Next.js workbench together for local development.
- Support API-only, web-only, dry-run, custom port, and port-check workflows.
- Document the combined local development entry in `README.md` and `DEVELOPMENT.md`.

## Validation

- `powershell -NoProfile -ExecutionPolicy Bypass -Command '$tokens = $null; $errors = $null; [System.Management.Automation.Language.Parser]::ParseFile(''scripts\dev_local.ps1'', [ref]$tokens, [ref]$errors) | Out-Null; if ($errors.Count -gt 0) { $errors | ForEach-Object { Write-Error $_ }; exit 1 }; Write-Host ''PowerShell parser OK'''`
- `powershell -NoProfile -ExecutionPolicy Bypass -File scripts\dev_local.ps1 -DryRun -ApiPort 18010 -WebPort 13000`

Note: the default API port `8010` was already in use locally during validation, so the dry-run used temporary ports.