### PR TITLE
Add orchestration graph shell

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -95,16 +95,22 @@ Web 产品化遵循以下目标：
 
 ## 当前端到端调用链路与编译子图
 
-当前自然语言 Planner 尚未注册为 LangGraph 节点。`main.py` 在图外先调用 `src/nl_planner.py` 将自然语言需求转换为 Recipe Tool Plan，再将结构化 plan 提交给 LangGraph。`src/graph.py` 当前注册的是面向结构化输入的 **Compiler Graph**，而不是完整的自然语言编排图。
+当前自然语言服务入口已具备 P1 Orchestration Graph 外壳。`plan_and_compile_workflow` 会构造 `OrchestrationState`，运行 `src.orchestration.graph`，先通过 Planner node 生成 Recipe Tool Plan，再由上层 compiler delegate node 调用下层 **Compiler Graph**。`src/graph.py` 仍然是面向结构化输入的 Compiler Graph，结构化调试入口继续绕过自然语言编排层。
 
 ### 当前端到端调用链路
 
 ```text
 自然语言请求
   ↓
-main.py -> nl_planner          # 图外 LLM 调用，生成 Recipe Tool Plan
+main.py -> workflow_service.plan_and_compile_workflow
+  ↓
+Orchestration Graph
+  ↓
+natural_language_planner       # 生成 Recipe Tool Plan 和 planner trace
   ↓
 Recipe Tool Plan
+  ↓
+compiler_graph delegate
   ↓
 Compiler Graph
 

--- a/docs/p1-orchestration-graph-plan.md
+++ b/docs/p1-orchestration-graph-plan.md
@@ -179,7 +179,7 @@ CLI --input / API POST /api/compile / tests
 
 目标：第一版上层图只负责编排 Planner 与 Compiler Graph。
 
-建议节点：
+已落地节点（`src/orchestration/graph.py`）：
 
 ```text
 START
@@ -194,11 +194,14 @@ START
 - Compiler Graph 失败时保留下层 diagnostics，不由上层图直接修复。
 - `check=False` 时仍允许跳过 WDL syntax validation，但 Analyzer 和 Renderer 边界不变。
 
-验收：
+已落地行为：
 
-- 自然语言入口实际调用 Orchestration Graph。
-- 下层 Compiler Graph 仍可独立测试和调用。
-- 不引入 P2+ 的 Reviewer 或其他 Agent 占位逻辑。
+- `orchestration_graph` 组合 `natural_language_planner -> compiler_graph`。
+- `plan_and_compile_workflow` 已通过 Orchestration Graph 执行自然语言规划编译。
+- Planner 失败时通过条件路由停止，不进入 Compiler Graph。
+- Compiler Graph 失败时保留 `WorkflowCompilationResult` diagnostics，上层不做额外修复。
+- 下层 Compiler Graph 仍可通过 `compile_structured_workflow` 独立测试和调用。
+- 未引入 P2+ 的 Reviewer 或其他 Agent 占位逻辑。
 
 ### P1.5 Service 层入口
 
@@ -392,17 +395,17 @@ run.completed
 - [x] `agent` 兼容别名仍可用于旧调用，或有明确迁移说明。
 - [x] Orchestration State 不污染 `WorkflowState`。
 - [x] Planner node 只产出 Recipe Tool Plan 和 trace，不产出最终 WDL。
-- [ ] Orchestration Graph 实现 `natural_language_planner -> compiler_graph`。
-- [ ] 自然语言入口调用 Orchestration Graph。
-- [ ] `--input`、测试入口和 `/api/compile` 直接调用 Compiler Graph。
-- [ ] 结构化入口在没有 `DEEPSEEK_API_KEY` 时可运行。
-- [ ] Planner 失败不会进入 Compiler Graph。
-- [ ] Compiler Graph 失败保留 Analyzer/Checker diagnostics。
+- [x] Orchestration Graph 实现 `natural_language_planner -> compiler_graph`。
+- [x] 自然语言入口调用 Orchestration Graph。
+- [x] `--input`、测试入口和 `/api/compile` 直接调用 Compiler Graph。
+- [x] 结构化入口在没有 `DEEPSEEK_API_KEY` 时可运行。
+- [x] Planner 失败不会进入 Compiler Graph。
+- [x] Compiler Graph 失败保留 Analyzer/Checker diagnostics。
 - [ ] Planner 事件和 plan artifact 可被 run history 或 SSE 回放。
 - [ ] CLI stdout/stderr 契约保持不变。
 - [ ] API route tests 覆盖 `/api/runs` 和 `/api/compile` 的分层差异。
-- [ ] `docs/test-cases.md` 在测试覆盖意图变化时已同步更新。
-- [ ] 相关单元测试通过。
+- [x] `docs/test-cases.md` 在测试覆盖意图变化时已同步更新。
+- [x] 相关单元测试通过。
 
 ## 后续衔接
 

--- a/docs/test-cases.md
+++ b/docs/test-cases.md
@@ -52,7 +52,7 @@ powershell -ExecutionPolicy Bypass -File scripts\check_p0.ps1 `
 
 ```text
 .venv\Scripts\python.exe -m unittest discover -v
-Ran 153 tests
+Ran 161 tests
 OK (skipped=2)
 ```
 
@@ -1702,6 +1702,100 @@ Compiler Graph，也不产出 Workflow IR 或 WDL。
 
 - Planner catalog/resolver 错误可被上层 graph 识别为 planner-stage 失败。
 
+## `tests/test_orchestration_graph.py`
+
+该文件验证 P1 Orchestration Graph 外壳。该图只负责编排 Planner Node
+和下层 Compiler Graph delegate，不引入 Reviewer、Retriever 或其他 P2+
+Agent 占位逻辑。
+
+### `test_default_orchestration_graph_is_invokable`
+
+输入：
+
+- 默认 `orchestration_graph`。
+
+执行：
+
+- 检查默认图是否暴露 `invoke` callable。
+
+期望输出：
+
+- 默认 Orchestration Graph 可被 LangGraph 运行。
+
+覆盖点：
+
+- P1.4 默认图已完成编译，可作为自然语言入口的上层图外壳。
+
+### `test_orchestration_graph_runs_planner_then_compiler`
+
+输入：
+
+- fake planner node 返回 Recipe Tool Plan 和 planner trace。
+- 注入的 compiler delegate 返回成功 `WorkflowCompilationResult`。
+- `check=False`。
+
+执行：
+
+- 调用注入节点后的 Orchestration Graph。
+
+期望输出：
+
+- compiler delegate 只被调用一次。
+- delegate 收到 planner 产出的 plan 和 `check=False`。
+- final state 保留 `plan`、`planner_prompt` 和 `compiler_result`。
+- `orchestration_succeeded(...) == True`。
+- events 顺序为 Planner started/completed/artifact.updated，随后 Compiler Graph started/completed。
+
+覆盖点：
+
+- 上层图按 `natural_language_planner -> compiler_graph` 顺序运行。
+- `check` 开关能从 Orchestration State 传给下层 Compiler Graph。
+
+### `test_orchestration_graph_stops_after_planner_failure`
+
+输入：
+
+- fake planner node 返回 planner 错误和 `node.failed` event。
+- compiler node 若被调用会抛出断言错误。
+
+执行：
+
+- 调用注入节点后的 Orchestration Graph。
+
+期望输出：
+
+- `compiler_result is None`。
+- `errors` 保留 planner 错误。
+- `orchestration_failure_stage(...) == "orchestration"`。
+- events 中只有 planner 事件。
+
+覆盖点：
+
+- Planner 失败时条件路由直接结束，不进入 Compiler Graph。
+
+### `test_orchestration_graph_preserves_compiler_failure_diagnostics`
+
+输入：
+
+- fake planner node 返回 Recipe Tool Plan。
+- 注入的 compiler delegate 返回 `succeeded=False` 和 Analyzer 诊断。
+
+执行：
+
+- 调用注入节点后的 Orchestration Graph。
+
+期望输出：
+
+- 上层 `errors == []`。
+- `orchestration_failure_stage(...) == "compiler"`。
+- `compiler_result.analysis_errors` 保留下层诊断。
+- 最后一个 event 是 `compiler_graph` 的 `node.failed`。
+
+覆盖点：
+
+- Compiler Graph 失败不由上层图修复，也不混入 Planner/orchestration 错误。
+- 下层 Analyzer/Checker diagnostics 仍通过 `WorkflowCompilationResult` 返回。
+
 ## `tests/test_workflow_service.py`
 
 该文件验证 W0 workflow application service。服务层用于让 CLI 和未来 FastAPI 复用同一套编译入口，避免 API 层复制 `main.py` 中的业务逻辑。
@@ -1823,9 +1917,31 @@ Compiler Graph，也不产出 Workflow IR 或 WDL。
 
 覆盖点：
 
-- 自然语言入口先生成 Recipe Tool Plan，再进入确定性编译链路。
+- 自然语言入口通过 Orchestration Graph 先生成 Recipe Tool Plan，再进入确定性编译链路。
 - LLM 仍不直接生成最终 WDL。
 - planner observability 信息被 service 结果保留。
+
+### `test_plan_and_compile_workflow_preserves_planner_error_classification`
+
+输入：
+
+- 用户请求：`Run bulk RNA-seq differential expression.`
+- `FakePlannerLlm` 返回非 JSON 文本。
+- `check=False`
+
+执行：
+
+- 调用 `plan_and_compile_workflow(..., llm=fake_llm, check=False)`。
+
+期望输出：
+
+- 抛出 `PlannerJsonError`。
+- 错误消息包含 `does not contain a JSON object`。
+
+覆盖点：
+
+- 自然语言 service 入口虽然改为通过 Orchestration Graph 执行，但仍保留既有 Planner 错误分类。
+- CLI/API 上层不需要为 P1.4 改动适配新的异常类型。
 
 ### `test_result_to_dict_exposes_json_ready_service_fields`
 

--- a/src/orchestration/__init__.py
+++ b/src/orchestration/__init__.py
@@ -1,5 +1,6 @@
 """Orchestration graph support package."""
 
+from src.orchestration.graph import build_orchestration_graph, orchestration_graph, route_after_planner
 from src.orchestration.state import (
     FailureStage,
     OrchestrationState,
@@ -11,7 +12,10 @@ from src.orchestration.state import (
 __all__ = [
     "FailureStage",
     "OrchestrationState",
+    "build_orchestration_graph",
     "build_initial_orchestration_state",
+    "orchestration_graph",
     "orchestration_failure_stage",
     "orchestration_succeeded",
+    "route_after_planner",
 ]

--- a/src/orchestration/graph.py
+++ b/src/orchestration/graph.py
@@ -1,0 +1,44 @@
+"""Natural-language orchestration graph shell."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable
+
+from langgraph.graph import END, START, StateGraph
+
+from src.orchestration.nodes.compiler import compile_planned_workflow_node
+from src.orchestration.nodes.planner import natural_language_planner_node
+from src.orchestration.state import OrchestrationState
+
+
+OrchestrationNode = Callable[[OrchestrationState], dict[str, Any]]
+logger = logging.getLogger(__name__)
+
+
+def route_after_planner(state: OrchestrationState):
+    """Stop after planner failures; otherwise delegate to the compiler graph."""
+    if state.get("errors") or state.get("plan") is None:
+        return END
+    return "compiler_graph"
+
+
+def build_orchestration_graph(
+    *,
+    planner_node: OrchestrationNode = natural_language_planner_node,
+    compiler_node: OrchestrationNode = compile_planned_workflow_node,
+):
+    """Build the P1 orchestration graph shell."""
+    builder = StateGraph(OrchestrationState)
+    builder.add_node("natural_language_planner", planner_node)
+    builder.add_node("compiler_graph", compiler_node)
+
+    builder.add_edge(START, "natural_language_planner")
+    builder.add_conditional_edges("natural_language_planner", route_after_planner)
+    builder.add_edge("compiler_graph", END)
+    return builder.compile()
+
+
+orchestration_graph = build_orchestration_graph()
+
+logger.info("Orchestration graph compiled.")

--- a/src/orchestration/nodes/__init__.py
+++ b/src/orchestration/nodes/__init__.py
@@ -1,9 +1,11 @@
 """Node implementations for the orchestration graph."""
 
+from src.orchestration.nodes.compiler import compile_planned_workflow_node, make_compile_planned_workflow_node
 from src.orchestration.nodes.planner import make_natural_language_planner_node, natural_language_planner_node
 
 __all__ = [
+    "compile_planned_workflow_node",
+    "make_compile_planned_workflow_node",
     "make_natural_language_planner_node",
     "natural_language_planner_node",
 ]
-

--- a/src/orchestration/nodes/compiler.py
+++ b/src/orchestration/nodes/compiler.py
@@ -1,0 +1,117 @@
+"""Compiler delegation node for the orchestration graph."""
+
+from __future__ import annotations
+
+from typing import Any, Callable, TYPE_CHECKING
+
+from src.orchestration.state import OrchestrationState
+
+if TYPE_CHECKING:
+    from src.services.workflow_service import WorkflowCompilationResult
+
+
+StructuredCompiler = Callable[[dict[str, Any], bool], "WorkflowCompilationResult"]
+CompilerNode = Callable[[OrchestrationState], dict[str, Any]]
+
+
+def compile_planned_workflow_node(state: OrchestrationState) -> dict[str, Any]:
+    """Compile the planner-produced Recipe Tool Plan using default services."""
+    return make_compile_planned_workflow_node()(state)
+
+
+def make_compile_planned_workflow_node(
+    compiler: StructuredCompiler | None = None,
+) -> CompilerNode:
+    """Create a compiler delegation node, optionally injecting the compiler."""
+
+    def node(state: OrchestrationState) -> dict[str, Any]:
+        started_event = _compiler_event(
+            "node.started",
+            "Compiler graph started.",
+            {"check": state["check"]},
+        )
+        plan = state["plan"]
+        if plan is None:
+            error = "Planner did not produce a Recipe Tool Plan."
+            return {
+                "compiler_result": None,
+                "errors": [error],
+                "events": [
+                    started_event,
+                    _compiler_event(
+                        "node.failed",
+                        "Compiler graph was not invoked.",
+                        {"error": error},
+                    ),
+                ],
+            }
+
+        try:
+            compiler_fn = compiler or _default_structured_compiler
+            compiler_result = compiler_fn(plan, state["check"])
+        except Exception as exc:
+            return {
+                "compiler_result": None,
+                "errors": [str(exc)],
+                "events": [
+                    started_event,
+                    _compiler_event(
+                        "node.failed",
+                        "Compiler graph failed unexpectedly.",
+                        {
+                            "error_type": exc.__class__.__name__,
+                            "error": str(exc),
+                        },
+                    ),
+                ],
+            }
+
+        if compiler_result.succeeded:
+            event_type = "node.completed"
+            summary = "Compiler graph completed."
+        else:
+            event_type = "node.failed"
+            summary = "Compiler graph completed with diagnostics."
+
+        return {
+            "compiler_result": compiler_result,
+            "events": [
+                started_event,
+                _compiler_event(event_type, summary, _compiler_result_payload(compiler_result)),
+            ],
+        }
+
+    return node
+
+
+def _default_structured_compiler(parsed_json: dict[str, Any], check: bool) -> "WorkflowCompilationResult":
+    from src.services.workflow_service import compile_structured_workflow
+
+    return compile_structured_workflow(parsed_json, check=check)
+
+
+def _compiler_result_payload(result: "WorkflowCompilationResult") -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "succeeded": result.succeeded,
+        "check_performed": result.check_performed,
+    }
+    if result.analysis_errors:
+        payload["analysis_errors"] = result.analysis_errors
+    if result.validation_message:
+        payload["validation_message"] = result.validation_message
+    return payload
+
+
+def _compiler_event(
+    event_type: str,
+    summary: str,
+    payload: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    event: dict[str, Any] = {
+        "type": event_type,
+        "node": "compiler_graph",
+        "summary": summary,
+    }
+    if payload is not None:
+        event["payload"] = payload
+    return event

--- a/src/orchestration/nodes/compiler.py
+++ b/src/orchestration/nodes/compiler.py
@@ -50,9 +50,10 @@ def make_compile_planned_workflow_node(
             compiler_fn = compiler or _default_structured_compiler
             compiler_result = compiler_fn(plan, state["check"])
         except Exception as exc:
+            error = _exception_message(exc)
             return {
                 "compiler_result": None,
-                "errors": [str(exc)],
+                "errors": [error],
                 "events": [
                     started_event,
                     _compiler_event(
@@ -60,7 +61,7 @@ def make_compile_planned_workflow_node(
                         "Compiler graph failed unexpectedly.",
                         {
                             "error_type": exc.__class__.__name__,
-                            "error": str(exc),
+                            "error": error,
                         },
                     ),
                 ],
@@ -100,6 +101,12 @@ def _compiler_result_payload(result: "WorkflowCompilationResult") -> dict[str, A
     if result.validation_message:
         payload["validation_message"] = result.validation_message
     return payload
+
+
+def _exception_message(exc: Exception) -> str:
+    error_type = exc.__class__.__name__
+    message = str(exc)
+    return f"{error_type}: {message}" if message else error_type
 
 
 def _compiler_event(

--- a/src/orchestration/state.py
+++ b/src/orchestration/state.py
@@ -3,12 +3,9 @@
 from __future__ import annotations
 
 import operator
-from typing import Any, Literal, TYPE_CHECKING
+from typing import Any, Literal
 
 from typing_extensions import Annotated, TypedDict
-
-if TYPE_CHECKING:
-    from src.services.workflow_service import WorkflowCompilationResult
 
 
 FailureStage = Literal["orchestration", "compiler"]
@@ -23,7 +20,7 @@ class OrchestrationState(TypedDict):
     plan: dict[str, Any] | None
     planner_prompt: str | None
     planner_raw_response: str | None
-    compiler_result: WorkflowCompilationResult | None
+    compiler_result: Any | None
     errors: Annotated[list[str], operator.add]
     events: Annotated[list[dict[str, Any]], operator.add]
 

--- a/src/orchestration/state.py
+++ b/src/orchestration/state.py
@@ -3,12 +3,18 @@
 from __future__ import annotations
 
 import operator
-from typing import Any, Literal
+from typing import Any, Literal, Protocol
 
 from typing_extensions import Annotated, TypedDict
 
 
 FailureStage = Literal["orchestration", "compiler"]
+
+
+class CompilerResultLike(Protocol):
+    """Minimal compiler result surface consumed by orchestration helpers."""
+
+    succeeded: bool
 
 
 class OrchestrationState(TypedDict):
@@ -20,7 +26,7 @@ class OrchestrationState(TypedDict):
     plan: dict[str, Any] | None
     planner_prompt: str | None
     planner_raw_response: str | None
-    compiler_result: Any | None
+    compiler_result: CompilerResultLike | None
     errors: Annotated[list[str], operator.add]
     events: Annotated[list[dict[str, Any]], operator.add]
 

--- a/src/services/workflow_service.py
+++ b/src/services/workflow_service.py
@@ -1,16 +1,26 @@
 """Workflow planning and compilation service entry points."""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Any, Callable, Mapping, cast
 
 from src.catalog.loader import ToolCatalog
 from src.graph import MAX_REPAIR_ATTEMPTS, compiler_graph
 from src.nodes.checker import checker_node
-from src.nl_planner import DEFAULT_PLANNER_MODEL, PlannerLlm, create_natural_language_plan
+from src.nl_planner import (
+    DEFAULT_PLANNER_MODEL,
+    NaturalLanguagePlanningError,
+    PlannerCatalogError,
+    PlannerJsonError,
+    PlannerLlm,
+    PlannerSchemaError,
+)
 from src.nodes.analyzer import analyzer_node
 from src.nodes.ir_normalizer import ir_normalizer_node
 from src.nodes.renderer import renderer_node
 from src.nodes.repairer import repairer_node
+from src.orchestration.graph import build_orchestration_graph
+from src.orchestration.nodes.planner import make_natural_language_planner_node
+from src.orchestration.state import OrchestrationState, build_initial_orchestration_state
 from src.recipes.loader import RecipeCatalog
 from src.state import WorkflowState
 from src.tools.validator import VALIDATOR_MISSING_MARKER
@@ -77,21 +87,34 @@ def plan_and_compile_workflow(
     tool_catalog: ToolCatalog | None = None,
     recipe_catalog: RecipeCatalog | None = None,
 ) -> WorkflowCompilationResult:
-    """Plan from natural language, then compile the resulting Recipe Tool Plan."""
-    plan_result = create_natural_language_plan(
-        request,
-        model=model,
+    """Plan from natural language through the orchestration graph, then compile."""
+    planner_node = make_natural_language_planner_node(
         llm=llm,
         tool_catalog=tool_catalog,
         recipe_catalog=recipe_catalog,
     )
-    state = _run_compiler(plan_result.plan, check=check)
-    return _result_from_state(
-        state,
-        plan=plan_result.plan,
-        check=check,
-        planner_prompt=plan_result.planner_prompt,
-        planner_raw_response=plan_result.raw_response,
+    graph = build_orchestration_graph(planner_node=planner_node)
+    orchestration_state = cast(
+        OrchestrationState,
+        graph.invoke(
+            build_initial_orchestration_state(
+                request,
+                planner_model=model,
+                check=check,
+            )
+        ),
+    )
+    if orchestration_state["errors"]:
+        _raise_orchestration_error(orchestration_state)
+
+    compiler_result = orchestration_state["compiler_result"]
+    if compiler_result is None:
+        raise RuntimeError("orchestration graph did not produce a compiler result")
+
+    return replace(
+        compiler_result,
+        planner_prompt=orchestration_state["planner_prompt"],
+        planner_raw_response=orchestration_state["planner_raw_response"],
     )
 
 
@@ -221,6 +244,39 @@ def _is_recipe_tool_plan(parsed_json: dict[str, Any]) -> bool:
     if not isinstance(workflow, dict):
         return False
     return "recipe" in workflow and "tool_calls" in workflow
+
+
+def _raise_orchestration_error(state: OrchestrationState) -> None:
+    message = state["errors"][-1] if state["errors"] else "orchestration graph failed"
+    failed_event = _last_failed_event(state)
+    if failed_event and failed_event.get("node") == "compiler_graph":
+        raise RuntimeError(message)
+
+    error_type = _event_error_type(failed_event)
+    exception_type = {
+        "NaturalLanguagePlanningError": NaturalLanguagePlanningError,
+        "PlannerJsonError": PlannerJsonError,
+        "PlannerSchemaError": PlannerSchemaError,
+        "PlannerCatalogError": PlannerCatalogError,
+    }.get(error_type, NaturalLanguagePlanningError)
+    raise exception_type(message)
+
+
+def _last_failed_event(state: OrchestrationState) -> dict[str, Any] | None:
+    for event in reversed(state["events"]):
+        if event.get("type") == "node.failed":
+            return event
+    return None
+
+
+def _event_error_type(event: dict[str, Any] | None) -> str | None:
+    if event is None:
+        return None
+    payload = event.get("payload")
+    if not isinstance(payload, dict):
+        return None
+    error_type = payload.get("error_type")
+    return error_type if isinstance(error_type, str) else None
 
 
 def _analyze_with_repair(

--- a/src/services/workflow_service.py
+++ b/src/services/workflow_service.py
@@ -112,7 +112,7 @@ def plan_and_compile_workflow(
         raise RuntimeError("orchestration graph did not produce a compiler result")
 
     return replace(
-        compiler_result,
+        cast(WorkflowCompilationResult, compiler_result),
         planner_prompt=orchestration_state["planner_prompt"],
         planner_raw_response=orchestration_state["planner_raw_response"],
     )
@@ -258,8 +258,12 @@ def _raise_orchestration_error(state: OrchestrationState) -> None:
         "PlannerJsonError": PlannerJsonError,
         "PlannerSchemaError": PlannerSchemaError,
         "PlannerCatalogError": PlannerCatalogError,
-    }.get(error_type, NaturalLanguagePlanningError)
-    raise exception_type(message)
+    }.get(error_type)
+    if exception_type is not None:
+        raise exception_type(message)
+    if error_type:
+        raise RuntimeError(f"{error_type}: {message}")
+    raise NaturalLanguagePlanningError(message)
 
 
 def _last_failed_event(state: OrchestrationState) -> dict[str, Any] | None:

--- a/tests/test_orchestration_graph.py
+++ b/tests/test_orchestration_graph.py
@@ -194,6 +194,33 @@ class OrchestrationGraphTests(unittest.TestCase):
             ["missing required workflow input 'sample_groups'"],
         )
 
+    def test_compiler_exception_errors_include_exception_type(self):
+        class EmptyCompilerError(Exception):
+            def __str__(self):
+                return ""
+
+        plan = sample_plan()
+
+        def compiler(parsed_json, check):
+            raise EmptyCompilerError()
+
+        graph = build_orchestration_graph(
+            planner_node=planner_success_node(plan),
+            compiler_node=make_compile_planned_workflow_node(compiler=compiler),
+        )
+        state = build_initial_orchestration_state(
+            "Run RNA-seq DEG.",
+            planner_model=DEFAULT_PLANNER_MODEL,
+        )
+
+        final_state = graph.invoke(state)
+
+        self.assertEqual(final_state["compiler_result"], None)
+        self.assertEqual(final_state["errors"], ["EmptyCompilerError"])
+        self.assertEqual(final_state["events"][-1]["type"], "node.failed")
+        self.assertEqual(final_state["events"][-1]["payload"]["error_type"], "EmptyCompilerError")
+        self.assertEqual(final_state["events"][-1]["payload"]["error"], "EmptyCompilerError")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_orchestration_graph.py
+++ b/tests/test_orchestration_graph.py
@@ -1,0 +1,199 @@
+import unittest
+
+from src.nl_planner import DEFAULT_PLANNER_MODEL
+from src.orchestration.graph import build_orchestration_graph, orchestration_graph
+from src.orchestration.nodes import make_compile_planned_workflow_node
+from src.orchestration.state import (
+    build_initial_orchestration_state,
+    orchestration_failure_stage,
+    orchestration_succeeded,
+)
+from src.services.workflow_service import WorkflowCompilationResult, build_initial_state
+
+
+def sample_plan() -> dict:
+    return {
+        "workflow": {
+            "name": "RNASeqDEG",
+            "recipe": "rnaseq_differential_expression",
+            "tool_calls": [],
+        }
+    }
+
+
+def compilation_result(
+    plan: dict,
+    *,
+    check: bool,
+    succeeded: bool = True,
+    analysis_errors: list[str] | None = None,
+) -> WorkflowCompilationResult:
+    workflow_state = build_initial_state(plan)
+    workflow_state["workflow_ir"] = {"workflow": {"name": "RNASeqDEG"}}
+    workflow_state["current_wdl"] = "version 1.0\nworkflow RNASeqDEG {}" if succeeded else ""
+    workflow_state["analysis_errors"] = analysis_errors or []
+    workflow_state["validation_message"] = (
+        "WDL syntax validation skipped (--no-check)." if not check else "valid WDL"
+    )
+    workflow_state["is_valid"] = check and succeeded
+    return WorkflowCompilationResult(
+        plan=plan,
+        workflow_ir=workflow_state["workflow_ir"],
+        wdl=workflow_state["current_wdl"],
+        analysis_errors=workflow_state["analysis_errors"],
+        analysis_warnings=[],
+        repair_actions=[],
+        validation_message=workflow_state["validation_message"],
+        is_valid=workflow_state["is_valid"],
+        succeeded=succeeded,
+        check_performed=check,
+        state=workflow_state,
+    )
+
+
+def planner_success_node(plan: dict):
+    def node(state):
+        return {
+            "plan": plan,
+            "planner_prompt": "planner prompt",
+            "planner_raw_response": "{}",
+            "errors": [],
+            "events": [
+                {"type": "node.started", "node": "planner", "summary": "Planner started."},
+                {"type": "node.completed", "node": "planner", "summary": "Planner completed."},
+                {
+                    "type": "artifact.updated",
+                    "node": "planner",
+                    "summary": "Plan artifact updated.",
+                    "payload": {"artifact": "plan"},
+                },
+            ],
+        }
+
+    return node
+
+
+class OrchestrationGraphTests(unittest.TestCase):
+    def test_default_orchestration_graph_is_invokable(self):
+        self.assertTrue(callable(orchestration_graph.invoke))
+
+    def test_orchestration_graph_runs_planner_then_compiler(self):
+        plan = sample_plan()
+        compiler_calls = []
+
+        def compiler(parsed_json, check):
+            compiler_calls.append({"parsed_json": parsed_json, "check": check})
+            return compilation_result(parsed_json, check=check)
+
+        graph = build_orchestration_graph(
+            planner_node=planner_success_node(plan),
+            compiler_node=make_compile_planned_workflow_node(compiler=compiler),
+        )
+        state = build_initial_orchestration_state(
+            "Run RNA-seq DEG.",
+            planner_model=DEFAULT_PLANNER_MODEL,
+            check=False,
+        )
+
+        final_state = graph.invoke(state)
+
+        self.assertEqual(compiler_calls, [{"parsed_json": plan, "check": False}])
+        self.assertEqual(final_state["plan"], plan)
+        self.assertEqual(final_state["planner_prompt"], "planner prompt")
+        self.assertIsNotNone(final_state["compiler_result"])
+        self.assertTrue(final_state["compiler_result"].succeeded)
+        self.assertTrue(orchestration_succeeded(final_state))
+        self.assertIsNone(orchestration_failure_stage(final_state))
+        self.assertEqual(
+            [event["type"] for event in final_state["events"]],
+            [
+                "node.started",
+                "node.completed",
+                "artifact.updated",
+                "node.started",
+                "node.completed",
+            ],
+        )
+
+    def test_orchestration_graph_stops_after_planner_failure(self):
+        def planner_failure_node(state):
+            return {
+                "plan": None,
+                "planner_prompt": None,
+                "planner_raw_response": None,
+                "errors": ["LLM planner JSON parsing failed: bad json"],
+                "events": [
+                    {"type": "node.started", "node": "planner", "summary": "Planner started."},
+                    {
+                        "type": "node.failed",
+                        "node": "planner",
+                        "summary": "Planner failed.",
+                        "payload": {"error_type": "PlannerJsonError"},
+                    },
+                ],
+            }
+
+        def compiler_should_not_run(state):
+            raise AssertionError("compiler graph should not run after planner failure")
+
+        graph = build_orchestration_graph(
+            planner_node=planner_failure_node,
+            compiler_node=compiler_should_not_run,
+        )
+        state = build_initial_orchestration_state(
+            "Run RNA-seq DEG.",
+            planner_model=DEFAULT_PLANNER_MODEL,
+        )
+
+        final_state = graph.invoke(state)
+
+        self.assertIsNone(final_state["compiler_result"])
+        self.assertIn("bad json", final_state["errors"][0])
+        self.assertFalse(orchestration_succeeded(final_state))
+        self.assertEqual(orchestration_failure_stage(final_state), "orchestration")
+        self.assertEqual(
+            [event["node"] for event in final_state["events"]],
+            ["planner", "planner"],
+        )
+
+    def test_orchestration_graph_preserves_compiler_failure_diagnostics(self):
+        plan = sample_plan()
+
+        def compiler(parsed_json, check):
+            return compilation_result(
+                parsed_json,
+                check=check,
+                succeeded=False,
+                analysis_errors=["missing required workflow input 'sample_groups'"],
+            )
+
+        graph = build_orchestration_graph(
+            planner_node=planner_success_node(plan),
+            compiler_node=make_compile_planned_workflow_node(compiler=compiler),
+        )
+        state = build_initial_orchestration_state(
+            "Run RNA-seq DEG.",
+            planner_model=DEFAULT_PLANNER_MODEL,
+            check=False,
+        )
+
+        final_state = graph.invoke(state)
+
+        self.assertEqual(final_state["errors"], [])
+        self.assertFalse(orchestration_succeeded(final_state))
+        self.assertEqual(orchestration_failure_stage(final_state), "compiler")
+        self.assertIsNotNone(final_state["compiler_result"])
+        self.assertEqual(
+            final_state["compiler_result"].analysis_errors,
+            ["missing required workflow input 'sample_groups'"],
+        )
+        self.assertEqual(final_state["events"][-1]["type"], "node.failed")
+        self.assertEqual(final_state["events"][-1]["node"], "compiler_graph")
+        self.assertEqual(
+            final_state["events"][-1]["payload"]["analysis_errors"],
+            ["missing required workflow input 'sample_groups'"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_orchestration_state.py
+++ b/tests/test_orchestration_state.py
@@ -1,4 +1,5 @@
 import unittest
+from types import SimpleNamespace
 
 from src.nl_planner import DEFAULT_PLANNER_MODEL
 from src.orchestration import (
@@ -117,6 +118,16 @@ class OrchestrationStateTests(unittest.TestCase):
             planner_prompt="planner prompt",
             planner_raw_response="{}",
         )
+
+        self.assertTrue(orchestration_succeeded(state))
+        self.assertIsNone(orchestration_failure_stage(state))
+
+    def test_orchestration_helpers_use_minimal_compiler_result_surface(self):
+        state = build_initial_orchestration_state(
+            "Run bulk RNA-seq differential expression.",
+            planner_model=DEFAULT_PLANNER_MODEL,
+        )
+        state["compiler_result"] = SimpleNamespace(succeeded=True)
 
         self.assertTrue(orchestration_succeeded(state))
         self.assertIsNone(orchestration_failure_stage(state))

--- a/tests/test_workflow_service.py
+++ b/tests/test_workflow_service.py
@@ -5,12 +5,14 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 from src.services.workflow_service import (
+    _raise_orchestration_error,
     _validate_with_repair,
     build_initial_state,
     compile_structured_workflow,
     plan_and_compile_workflow,
 )
 from src.nl_planner import PlannerJsonError
+from src.orchestration.state import build_initial_orchestration_state
 
 
 EXAMPLES_DIR = Path(__file__).parents[1] / "examples"
@@ -338,6 +340,24 @@ class WorkflowServiceTests(unittest.TestCase):
                 llm=fake_llm,
                 check=False,
             )
+
+    def test_orchestration_error_unknown_type_is_runtime_error(self):
+        state = build_initial_orchestration_state(
+            "Run bulk RNA-seq differential expression.",
+            planner_model="planner-model",
+        )
+        state["errors"].append("planner transport unavailable")
+        state["events"].append(
+            {
+                "type": "node.failed",
+                "node": "planner",
+                "summary": "Planner failed.",
+                "payload": {"error_type": "RuntimeError"},
+            }
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "RuntimeError: planner transport unavailable"):
+            _raise_orchestration_error(state)
 
     def test_result_to_dict_exposes_json_ready_service_fields(self):
         plan = load_example("rnaseq_deg_recipe_plan.json")

--- a/tests/test_workflow_service.py
+++ b/tests/test_workflow_service.py
@@ -10,6 +10,7 @@ from src.services.workflow_service import (
     compile_structured_workflow,
     plan_and_compile_workflow,
 )
+from src.nl_planner import PlannerJsonError
 
 
 EXAMPLES_DIR = Path(__file__).parents[1] / "examples"
@@ -327,6 +328,16 @@ class WorkflowServiceTests(unittest.TestCase):
         self.assertIn("RNASeqDEG", result.planner_raw_response or "")
         self.assertIn("workflow RNASeqDEG", result.wdl)
         self.assertEqual(len(fake_llm.prompts), 1)
+
+    def test_plan_and_compile_workflow_preserves_planner_error_classification(self):
+        fake_llm = FakePlannerLlm("not json")
+
+        with self.assertRaisesRegex(PlannerJsonError, "does not contain a JSON object"):
+            plan_and_compile_workflow(
+                "Run bulk RNA-seq differential expression.",
+                llm=fake_llm,
+                check=False,
+            )
 
     def test_result_to_dict_exposes_json_ready_service_fields(self):
         plan = load_example("rnaseq_deg_recipe_plan.json")


### PR DESCRIPTION
## Summary

- Add the P1 orchestration graph shell that routes natural-language planning into a compiler delegate.
- Add a compiler delegation node that passes the planner-produced Recipe Tool Plan to the existing structured compiler path.
- Route `plan_and_compile_workflow` through the orchestration graph while preserving planner trace fields and planner error classification.
- Document the updated P1 status and add orchestration graph test coverage.

## Notes

Run service and API event bridging remain a later P1 slice; structured inputs still compile directly through the Compiler Graph.

## Validation

- `.\.venv\Scripts\python.exe -m unittest discover -v`