### PR TITLE
Add workflow DAG view

### DIFF
--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 
 import { SiteFooter } from "@/components/site-footer";
 import { SiteHeader } from "@/components/site-header";
+import "@xyflow/react/dist/style.css";
 import "./globals.css";
 
 export const metadata: Metadata = {

--- a/web/app/runs/[runId]/page.tsx
+++ b/web/app/runs/[runId]/page.tsx
@@ -13,6 +13,7 @@ import Link from "next/link";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { WorkflowGraphPanel } from "@/components/workflow-graph/workflow-graph";
 import { getRunSnapshot } from "@/lib/api";
 import type { JsonObject, RunStatus, WorkflowRunSnapshotResponse } from "@/lib/types";
 import { RunArtifactsPanel } from "./run-artifacts-panel";
@@ -197,6 +198,11 @@ function RunDetail({ snapshot }: { snapshot: WorkflowRunSnapshotResponse }) {
         <DiagnosticsSummary snapshot={snapshot} />
       </section>
 
+      <WorkflowGraphPanel
+        workflowIr={snapshot.artifacts.workflow_ir}
+        eventsUrl={snapshot.events_url}
+        status={snapshot.status}
+      />
       <RunEventsTimeline eventsUrl={snapshot.events_url} status={snapshot.status} />
       <RunArtifactsPanel artifacts={snapshot.artifacts} diagnostics={snapshot.diagnostics} />
     </>

--- a/web/app/runs/[runId]/run-events-timeline.tsx
+++ b/web/app/runs/[runId]/run-events-timeline.tsx
@@ -12,29 +12,14 @@ import { useEffect, useState } from "react";
 
 import { Badge } from "@/components/ui/badge";
 import { buildRunEventsUrl } from "@/lib/api";
-import type { JsonObject, RunEvent, RunEventType, RunStatus } from "@/lib/types";
-
-const eventTypes: RunEventType[] = [
-  "run.created",
-  "node.started",
-  "node.completed",
-  "node.failed",
-  "artifact.updated",
-  "repair.applied",
-  "validation.completed",
-  "run.completed",
-];
-
-const eventLabels: Record<RunEventType, string> = {
-  "run.created": "Run 创建",
-  "node.started": "节点开始",
-  "node.completed": "节点完成",
-  "node.failed": "节点失败",
-  "artifact.updated": "产物更新",
-  "repair.applied": "修复应用",
-  "validation.completed": "校验完成",
-  "run.completed": "Run 完成",
-};
+import {
+  isTerminalRunStatus,
+  mergeRunEvent,
+  parseRunEventMessage,
+  runEventLabels,
+  runEventTypes,
+} from "@/lib/run-events";
+import type { RunEvent, RunStatus } from "@/lib/types";
 
 const eventDateTimeFormat = new Intl.DateTimeFormat("zh-CN", {
   month: "2-digit",
@@ -43,10 +28,6 @@ const eventDateTimeFormat = new Intl.DateTimeFormat("zh-CN", {
   minute: "2-digit",
   second: "2-digit",
 });
-
-function isTerminalRunStatus(status: RunStatus): boolean {
-  return status === "succeeded" || status === "failed";
-}
 
 function getEventIcon(event: RunEvent) {
   if (event.type === "node.failed" || event.payload.status === "failed") {
@@ -67,60 +48,6 @@ function getEventIcon(event: RunEvent) {
 
 function formatDateTime(value: string): string {
   return eventDateTimeFormat.format(new Date(value));
-}
-
-function mergeEvent(events: RunEvent[], nextEvent: RunEvent): RunEvent[] {
-  const bySequence = new Map(events.map((event) => [event.sequence, event]));
-  bySequence.set(nextEvent.sequence, nextEvent);
-  return Array.from(bySequence.values()).sort((left, right) => left.sequence - right.sequence);
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function isRunEventType(value: unknown): value is RunEventType {
-  return typeof value === "string" && eventTypes.includes(value as RunEventType);
-}
-
-function parseRunEvent(message: MessageEvent<string>): RunEvent | null {
-  try {
-    const parsed: unknown = JSON.parse(message.data);
-    if (!isRecord(parsed)) {
-      return null;
-    }
-
-    const { event_id, node, payload, run_id, sequence, summary, timestamp, type } = parsed;
-    if (
-      typeof event_id !== "string" ||
-      typeof run_id !== "string" ||
-      typeof sequence !== "number" ||
-      !Number.isInteger(sequence) ||
-      sequence < 1 ||
-      !isRunEventType(type) ||
-      typeof timestamp !== "string" ||
-      Number.isNaN(Date.parse(timestamp)) ||
-      typeof summary !== "string" ||
-      !(node === null || typeof node === "string") ||
-      !isRecord(payload)
-    ) {
-      return null;
-    }
-
-    return {
-      event_id,
-      run_id,
-      sequence,
-      type,
-      timestamp,
-      summary,
-      node,
-      payload: payload as JsonObject,
-    };
-  } catch (error) {
-    console.error("Failed to parse run event.", error);
-    return null;
-  }
 }
 
 export function RunEventsTimeline({
@@ -154,13 +81,13 @@ export function RunEventsTimeline({
       }
     };
 
-    const handlers = eventTypes.map((eventType) => {
+    const handlers = runEventTypes.map((eventType) => {
       const handler = (message: MessageEvent<string>) => {
-        const parsed = parseRunEvent(message);
+        const parsed = parseRunEventMessage(message);
         if (!parsed) {
           return;
         }
-        setEvents((currentEvents) => mergeEvent(currentEvents, parsed));
+        setEvents((currentEvents) => mergeRunEvent(currentEvents, parsed));
         if (parsed.type === "run.completed") {
           setIsConnected(false);
           eventSource.close();
@@ -211,7 +138,7 @@ export function RunEventsTimeline({
               <div className="min-w-0">
                 <div className="flex flex-wrap items-center gap-2">
                   <Badge variant="outline">#{event.sequence}</Badge>
-                  <span className="font-medium">{eventLabels[event.type]}</span>
+                  <span className="font-medium">{runEventLabels[event.type]}</span>
                   {event.node ? <Badge variant="secondary">{event.node}</Badge> : null}
                 </div>
                 <p className="mt-2 break-words text-sm leading-6 text-muted-foreground">

--- a/web/components/workflow-graph/graph-empty-state.tsx
+++ b/web/components/workflow-graph/graph-empty-state.tsx
@@ -1,0 +1,15 @@
+import { GitBranch } from "lucide-react";
+
+export function GraphEmptyState() {
+  return (
+    <div className="rounded-md border bg-background p-5">
+      <div className="flex items-center gap-2 font-semibold">
+        <GitBranch className="h-5 w-5 text-primary" />
+        DAG 尚不可用
+      </div>
+      <p className="mt-2 text-sm leading-6 text-muted-foreground">
+        当前 run 尚未保存可展示的 Workflow IR。
+      </p>
+    </div>
+  );
+}

--- a/web/components/workflow-graph/node-detail-panel.tsx
+++ b/web/components/workflow-graph/node-detail-panel.tsx
@@ -1,0 +1,211 @@
+"use client";
+
+import { Activity, AlertCircle, Box, FileOutput, GitBranch, Info } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { runEventLabels } from "@/lib/run-events";
+import type { JsonValue, RunEvent } from "@/lib/types";
+import type {
+  WorkflowGraphExpression,
+  WorkflowGraphNode,
+  WorkflowGraphTaskOutput,
+} from "@/lib/workflow-graph";
+import type { WorkflowGraphNodeStatus } from "./workflow-node";
+
+const statusLabels: Record<WorkflowGraphNodeStatus, string> = {
+  pending: "Pending",
+  running: "Running",
+  completed: "Completed",
+  failed: "Failed",
+  unavailable: "Unavailable",
+};
+
+function formatExpression(value: WorkflowGraphExpression): string {
+  return Array.isArray(value) ? value.join("\n") : value;
+}
+
+function KeyValueList({ values }: { values: Record<string, string> }) {
+  const entries = Object.entries(values);
+  if (!entries.length) {
+    return <div className="text-sm text-muted-foreground">暂无记录。</div>;
+  }
+
+  return (
+    <div className="grid gap-2">
+      {entries.map(([key, value]) => (
+        <div key={key} className="grid gap-1 rounded-md border bg-background p-3">
+          <div className="text-xs font-medium text-muted-foreground">{key}</div>
+          <pre className="whitespace-pre-wrap break-words font-mono text-xs leading-5">{value}</pre>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function outputValues(outputs: Record<string, WorkflowGraphTaskOutput>): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(outputs).map(([name, output]) => [
+      name,
+      [output.type, output.value].filter(Boolean).join(" = ") || "未记录",
+    ]),
+  );
+}
+
+function runtimeValues(runtime: Record<string, JsonValue>): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(runtime).map(([key, value]) => [key, JSON.stringify(value)]),
+  );
+}
+
+export function NodeDetailPanel({
+  node,
+  relatedEvents,
+  status,
+}: {
+  node: WorkflowGraphNode | null;
+  relatedEvents: RunEvent[];
+  status: WorkflowGraphNodeStatus;
+}) {
+  if (!node) {
+    return (
+      <aside className="rounded-md border bg-white p-5">
+        <div className="flex items-center gap-2 font-semibold">
+          <Info className="h-5 w-5 text-primary" />
+          节点详情
+        </div>
+        <p className="mt-2 text-sm leading-6 text-muted-foreground">请选择图中的节点。</p>
+      </aside>
+    );
+  }
+
+  const metadata = node.metadata;
+
+  return (
+    <aside className="rounded-md border bg-white p-5">
+      <div className="flex flex-wrap items-center gap-2">
+        <h3 className="font-semibold">{node.label}</h3>
+        <Badge variant="outline">{node.kind}</Badge>
+        <Badge variant="secondary">{statusLabels[status]}</Badge>
+      </div>
+      <p className="mt-2 break-all font-mono text-xs text-muted-foreground">{node.sourceStepId}</p>
+
+      {metadata.workflowInput ? (
+        <section className="mt-5">
+          <div className="mb-2 flex items-center gap-2 text-sm font-semibold">
+            <Info className="h-4 w-4 text-primary" />
+            Workflow input
+          </div>
+          <KeyValueList values={{ type: metadata.workflowInput.type }} />
+        </section>
+      ) : null}
+
+      {metadata.call ? (
+        <>
+          <section className="mt-5">
+            <div className="mb-2 flex items-center gap-2 text-sm font-semibold">
+              <Box className="h-4 w-4 text-primary" />
+              Task
+            </div>
+            <KeyValueList values={{ task: metadata.call.task ?? "未记录" }} />
+          </section>
+          <section className="mt-5">
+            <div className="mb-2 text-sm font-semibold">Inputs</div>
+            <KeyValueList
+              values={Object.fromEntries(
+                Object.entries(metadata.call.inputs).map(([name, value]) => [
+                  name,
+                  formatExpression(value),
+                ]),
+              )}
+            />
+          </section>
+          <section className="mt-5">
+            <div className="mb-2 text-sm font-semibold">Outputs</div>
+            <KeyValueList values={outputValues(metadata.call.outputs)} />
+          </section>
+          <section className="mt-5">
+            <div className="mb-2 text-sm font-semibold">Runtime</div>
+            <KeyValueList values={runtimeValues(metadata.call.runtime)} />
+          </section>
+        </>
+      ) : null}
+
+      {metadata.scatter ? (
+        <section className="mt-5">
+          <div className="mb-2 flex items-center gap-2 text-sm font-semibold">
+            <GitBranch className="h-4 w-4 text-primary" />
+            Scatter
+          </div>
+          <KeyValueList
+            values={{
+              item: metadata.scatter.item ?? "未记录",
+              over: metadata.scatter.over ?? "未记录",
+            }}
+          />
+        </section>
+      ) : null}
+
+      {metadata.workflowOutput ? (
+        <section className="mt-5">
+          <div className="mb-2 flex items-center gap-2 text-sm font-semibold">
+            <FileOutput className="h-4 w-4 text-primary" />
+            Workflow output
+          </div>
+          <KeyValueList
+            values={{
+              expression: formatExpression(metadata.workflowOutput.expression),
+            }}
+          />
+        </section>
+      ) : null}
+
+      {node.metadata.call?.unresolvedReferences.length ||
+      node.metadata.scatter?.unresolvedReferences.length ||
+      node.metadata.workflowOutput?.unresolvedReferences.length ? (
+        <section className="mt-5 rounded-md border border-destructive/40 bg-background p-4">
+          <div className="flex items-center gap-2 text-sm font-semibold text-destructive">
+            <AlertCircle className="h-4 w-4" />
+            Unresolved references
+          </div>
+          <ul className="mt-3 grid gap-2 text-xs leading-5 text-muted-foreground">
+            {[
+              ...(node.metadata.call?.unresolvedReferences ?? []),
+              ...(node.metadata.scatter?.unresolvedReferences ?? []),
+              ...(node.metadata.workflowOutput?.unresolvedReferences ?? []),
+            ].map((reference) => (
+              <li key={`${reference.expression}:${reference.reason}`} className="break-words">
+                {reference.reason}: {reference.expression}
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+
+      <section className="mt-5">
+        <div className="mb-2 flex items-center gap-2 text-sm font-semibold">
+          <Activity className="h-4 w-4 text-primary" />
+          Related events
+        </div>
+        {relatedEvents.length ? (
+          <div className="grid gap-2">
+            {relatedEvents.slice(-4).map((event) => (
+              <div key={event.event_id} className="rounded-md border bg-background p-3">
+                <div className="flex flex-wrap items-center gap-2 text-xs">
+                  <Badge variant="outline">#{event.sequence}</Badge>
+                  <span className="font-medium">{runEventLabels[event.type]}</span>
+                </div>
+                <p className="mt-2 break-words text-xs leading-5 text-muted-foreground">
+                  {event.summary}
+                </p>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div className="rounded-md border bg-background p-3 text-sm text-muted-foreground">
+            暂无关联事件。
+          </div>
+        )}
+      </section>
+    </aside>
+  );
+}

--- a/web/components/workflow-graph/node-detail-panel.tsx
+++ b/web/components/workflow-graph/node-detail-panel.tsx
@@ -79,6 +79,11 @@ export function NodeDetailPanel({
   }
 
   const metadata = node.metadata;
+  const unresolvedReferences = [
+    ...(metadata.call?.unresolvedReferences ?? []),
+    ...(metadata.scatter?.unresolvedReferences ?? []),
+    ...(metadata.workflowOutput?.unresolvedReferences ?? []),
+  ];
 
   return (
     <aside className="rounded-md border bg-white p-5">
@@ -159,21 +164,24 @@ export function NodeDetailPanel({
         </section>
       ) : null}
 
-      {node.metadata.call?.unresolvedReferences.length ||
-      node.metadata.scatter?.unresolvedReferences.length ||
-      node.metadata.workflowOutput?.unresolvedReferences.length ? (
+      {unresolvedReferences.length ? (
         <section className="mt-5 rounded-md border border-destructive/40 bg-background p-4">
           <div className="flex items-center gap-2 text-sm font-semibold text-destructive">
             <AlertCircle className="h-4 w-4" />
             Unresolved references
           </div>
           <ul className="mt-3 grid gap-2 text-xs leading-5 text-muted-foreground">
-            {[
-              ...(node.metadata.call?.unresolvedReferences ?? []),
-              ...(node.metadata.scatter?.unresolvedReferences ?? []),
-              ...(node.metadata.workflowOutput?.unresolvedReferences ?? []),
-            ].map((reference) => (
-              <li key={`${reference.expression}:${reference.reason}`} className="break-words">
+            {unresolvedReferences.map((reference, index) => (
+              <li
+                key={[
+                  reference.ownerId,
+                  reference.reference ?? "expression",
+                  reference.expression,
+                  reference.reason,
+                  index,
+                ].join(":")}
+                className="break-words"
+              >
                 {reference.reason}: {reference.expression}
               </li>
             ))}

--- a/web/components/workflow-graph/workflow-graph.tsx
+++ b/web/components/workflow-graph/workflow-graph.tsx
@@ -100,7 +100,10 @@ export function WorkflowGraphPanel({
     [graph.nodes],
   );
   const nodeViews = useMemo(() => buildNodeViews(graph, events, status), [events, graph, status]);
-  const { edges, nodes } = useMemo(() => toReactFlowElements(graph, nodeViews), [graph, nodeViews]);
+  const { edges, nodes } = useMemo(
+    () => toReactFlowElements(graph, nodeViews, selectedNodeId),
+    [graph, nodeViews, selectedNodeId],
+  );
 
   useEffect(() => {
     if (!graph.nodes.length) {
@@ -275,6 +278,7 @@ function buildNodeViews(
 function toReactFlowElements(
   graph: WorkflowGraph,
   nodeViews: Map<string, GraphNodeView>,
+  selectedNodeId: string | null,
 ): { edges: Edge[]; nodes: WorkflowGraphReactNode[] } {
   const layouts = calculateNodeLayouts(graph);
   const nodes = graph.nodes.map((graphNode): PositionedNode => {
@@ -301,7 +305,7 @@ function toReactFlowElements(
       className: cn(graphNode.kind === "scatter" && "workflow-graph-scatter-node"),
       extent: graphNode.parentId ? "parent" : undefined,
       parentId: graphNode.parentId ?? undefined,
-      selected: false,
+      selected: graphNode.id === selectedNodeId,
       style: {
         height: layout.height,
         width: layout.width,

--- a/web/components/workflow-graph/workflow-graph.tsx
+++ b/web/components/workflow-graph/workflow-graph.tsx
@@ -1,0 +1,476 @@
+"use client";
+
+import {
+  Background,
+  Controls,
+  MarkerType,
+  MiniMap,
+  ReactFlow,
+  ReactFlowProvider,
+  type Edge,
+  type NodeMouseHandler,
+} from "@xyflow/react";
+import { GitBranch, Loader2 } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { buildRunEventsUrl } from "@/lib/api";
+import {
+  isTerminalRunStatus,
+  mergeRunEvent,
+  parseRunEventMessage,
+  readPayloadString,
+  runEventTypes,
+} from "@/lib/run-events";
+import type { JsonObject, RunEvent, RunStatus } from "@/lib/types";
+import {
+  buildWorkflowGraph,
+  type WorkflowGraph,
+  type WorkflowGraphEdge,
+  type WorkflowGraphNode,
+} from "@/lib/workflow-graph";
+import { cn } from "@/lib/utils";
+import { GraphEmptyState } from "./graph-empty-state";
+import { NodeDetailPanel } from "./node-detail-panel";
+import {
+  WorkflowNode,
+  type WorkflowGraphNodeStatus,
+  type WorkflowGraphReactNode,
+} from "./workflow-node";
+
+const nodeTypes = {
+  workflowGraphNode: WorkflowNode,
+};
+
+const streamLabels: Record<WorkflowGraphStreamState, string> = {
+  disabled: "无事件流",
+  connecting: "连接中",
+  connected: "读取事件",
+  closed: "事件结束",
+  error: "事件流中断",
+};
+
+type WorkflowGraphStreamState = "disabled" | "connecting" | "connected" | "closed" | "error";
+
+type PositionedNode = WorkflowGraphReactNode & {
+  parentId?: string;
+  extent?: "parent";
+};
+
+type NodeLayout = {
+  height: number;
+  width: number;
+  x: number;
+  y: number;
+};
+
+type GraphNodeView = {
+  node: WorkflowGraphNode;
+  relatedEvents: RunEvent[];
+  status: WorkflowGraphNodeStatus;
+};
+
+export function WorkflowGraphPanel({
+  eventsUrl,
+  status,
+  workflowIr,
+}: {
+  eventsUrl: string | null;
+  status: RunStatus;
+  workflowIr: JsonObject;
+}) {
+  const graph = useMemo(() => buildWorkflowGraph(workflowIr), [workflowIr]);
+  const { events, streamState } = useWorkflowGraphEvents(eventsUrl, status);
+  const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
+
+  const graphNodesById = useMemo(
+    () => new Map(graph.nodes.map((node) => [node.id, node])),
+    [graph.nodes],
+  );
+  const nodeViews = useMemo(() => buildNodeViews(graph, events, status), [events, graph, status]);
+  const { edges, nodes } = useMemo(() => toReactFlowElements(graph, nodeViews), [graph, nodeViews]);
+
+  useEffect(() => {
+    if (!graph.nodes.length) {
+      setSelectedNodeId(null);
+      return;
+    }
+
+    setSelectedNodeId((currentNodeId) => {
+      if (currentNodeId && graphNodesById.has(currentNodeId)) {
+        return currentNodeId;
+      }
+      return graph.nodes.find((node) => node.kind === "call")?.id ?? graph.nodes[0].id;
+    });
+  }, [graph.nodes, graphNodesById]);
+
+  const selectedNode = selectedNodeId ? graphNodesById.get(selectedNodeId) ?? null : null;
+  const selectedView = selectedNodeId ? nodeViews.get(selectedNodeId) : null;
+  const handleNodeClick: NodeMouseHandler = (_, node) => {
+    setSelectedNodeId(node.id);
+  };
+
+  return (
+    <section className="mt-6 rounded-md border bg-white p-5">
+      <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+        <div>
+          <div className="flex items-center gap-2">
+            <GitBranch className="h-5 w-5 text-primary" />
+            <h2 className="font-semibold">Workflow DAG</h2>
+            <Badge variant="outline">{graph.nodes.length} nodes</Badge>
+            <Badge variant="outline">{graph.edges.length} edges</Badge>
+          </div>
+          <p className="mt-2 text-sm leading-6 text-muted-foreground">
+            基于 Workflow IR 的 inputs、steps、scatter 和 outputs 构建依赖图。
+          </p>
+        </div>
+        <Badge
+          variant={streamState === "connected" ? "secondary" : "outline"}
+          className="gap-1.5"
+        >
+          {streamState === "connected" || streamState === "connecting" ? (
+            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          ) : null}
+          {streamLabels[streamState]}
+        </Badge>
+      </div>
+
+      {graph.nodes.length ? (
+        <div className="mt-5 grid gap-4 lg:grid-cols-[minmax(0,1fr)_22rem]">
+          <div className="h-[34rem] overflow-hidden rounded-md border bg-background">
+            <ReactFlowProvider>
+              <ReactFlow
+                fitView
+                fitViewOptions={{ padding: 0.18 }}
+                maxZoom={1.4}
+                minZoom={0.35}
+                nodeTypes={nodeTypes}
+                nodes={nodes}
+                edges={edges}
+                nodesConnectable={false}
+                nodesDraggable={false}
+                onNodeClick={handleNodeClick}
+                panOnScroll
+                selectionOnDrag
+              >
+                <Background gap={18} size={1} />
+                <MiniMap
+                  pannable
+                  zoomable
+                  nodeColor={(node) => getMiniMapColor(node as WorkflowGraphReactNode)}
+                  nodeStrokeWidth={3}
+                />
+                <Controls showInteractive={false} />
+              </ReactFlow>
+            </ReactFlowProvider>
+          </div>
+          <NodeDetailPanel
+            node={selectedNode}
+            relatedEvents={selectedView?.relatedEvents ?? []}
+            status={selectedView?.status ?? "unavailable"}
+          />
+        </div>
+      ) : (
+        <GraphEmptyState />
+      )}
+    </section>
+  );
+}
+
+function useWorkflowGraphEvents(
+  eventsUrl: string | null,
+  status: RunStatus,
+): { events: RunEvent[]; streamState: WorkflowGraphStreamState } {
+  const [events, setEvents] = useState<RunEvent[]>([]);
+  const [streamState, setStreamState] = useState<WorkflowGraphStreamState>(
+    eventsUrl ? "connecting" : "disabled",
+  );
+
+  useEffect(() => {
+    if (!eventsUrl) {
+      setStreamState("disabled");
+      return undefined;
+    }
+
+    let isClosed = false;
+    const eventSource = new EventSource(buildRunEventsUrl(eventsUrl));
+    setStreamState("connecting");
+
+    eventSource.onopen = () => {
+      if (!isClosed) {
+        setStreamState("connected");
+      }
+    };
+
+    eventSource.onerror = () => {
+      if (!isClosed) {
+        setStreamState(isTerminalRunStatus(status) ? "closed" : "error");
+      }
+      if (isTerminalRunStatus(status)) {
+        eventSource.close();
+      }
+    };
+
+    const handlers = runEventTypes.map((eventType) => {
+      const handler = (message: MessageEvent<string>) => {
+        const parsed = parseRunEventMessage(message);
+        if (!parsed) {
+          return;
+        }
+
+        setEvents((currentEvents) => mergeRunEvent(currentEvents, parsed));
+        if (parsed.type === "run.completed") {
+          setStreamState("closed");
+          eventSource.close();
+        }
+      };
+      eventSource.addEventListener(eventType, handler);
+      return { eventType, handler };
+    });
+
+    return () => {
+      isClosed = true;
+      handlers.forEach(({ eventType, handler }) => {
+        eventSource.removeEventListener(eventType, handler);
+      });
+      eventSource.close();
+    };
+  }, [eventsUrl, status]);
+
+  return { events, streamState };
+}
+
+function buildNodeViews(
+  graph: WorkflowGraph,
+  events: RunEvent[],
+  runStatus: RunStatus,
+): Map<string, GraphNodeView> {
+  return new Map(
+    graph.nodes.map((node) => {
+      const relatedEvents = events.filter((event) => eventBelongsToNode(event, node));
+      return [
+        node.id,
+        {
+          node,
+          relatedEvents,
+          status: getNodeStatus(relatedEvents, runStatus),
+        },
+      ];
+    }),
+  );
+}
+
+function toReactFlowElements(
+  graph: WorkflowGraph,
+  nodeViews: Map<string, GraphNodeView>,
+): { edges: Edge[]; nodes: WorkflowGraphReactNode[] } {
+  const layouts = calculateNodeLayouts(graph);
+  const nodes = graph.nodes.map((graphNode): PositionedNode => {
+    const layout = layouts.get(graphNode.id) ?? { height: 106, width: 252, x: 0, y: 0 };
+    const nodeView = nodeViews.get(graphNode.id);
+
+    return {
+      id: graphNode.id,
+      type: "workflowGraphNode",
+      data: {
+        graphNode,
+        eventCount: nodeView?.relatedEvents.length ?? 0,
+        status: nodeView?.status ?? "unavailable",
+      },
+      position: {
+        x: layout.x,
+        y: layout.y,
+      },
+      className: cn(graphNode.kind === "scatter" && "workflow-graph-scatter-node"),
+      extent: graphNode.parentId ? "parent" : undefined,
+      parentId: graphNode.parentId ?? undefined,
+      selected: false,
+      style: {
+        height: layout.height,
+        width: layout.width,
+      },
+    };
+  });
+
+  return {
+    edges: graph.edges.map(toReactFlowEdge),
+    nodes,
+  };
+}
+
+function toReactFlowEdge(edge: WorkflowGraphEdge): Edge {
+  const color = getEdgeColor(edge.kind);
+
+  return {
+    id: edge.id,
+    source: edge.source,
+    target: edge.target,
+    label: edge.label,
+    markerEnd: {
+      color,
+      type: MarkerType.ArrowClosed,
+    },
+    style: {
+      stroke: color,
+      strokeWidth: 2,
+    },
+    type: "smoothstep",
+  };
+}
+
+function calculateNodeLayouts(graph: WorkflowGraph): Map<string, NodeLayout> {
+  const levels = calculateNodeLevels(graph);
+  const childrenByParent = new Map<string, WorkflowGraphNode[]>();
+  const topLevelNodes = graph.nodes.filter((node) => {
+    if (!node.parentId) {
+      return true;
+    }
+
+    const children = childrenByParent.get(node.parentId) ?? [];
+    children.push(node);
+    childrenByParent.set(node.parentId, children);
+    return false;
+  });
+  const topLevelByColumn = new Map<number, WorkflowGraphNode[]>();
+
+  for (const node of topLevelNodes) {
+    const column = levels.get(node.id) ?? 0;
+    const nodesInColumn = topLevelByColumn.get(column) ?? [];
+    nodesInColumn.push(node);
+    topLevelByColumn.set(column, nodesInColumn);
+  }
+
+  const layouts = new Map<string, NodeLayout>();
+
+  for (const [column, nodesInColumn] of topLevelByColumn) {
+    let y = 0;
+    for (const node of nodesInColumn) {
+      const children = childrenByParent.get(node.id) ?? [];
+      const isScatter = node.kind === "scatter";
+      const height = isScatter ? Math.max(180, 96 + children.length * 92) : 106;
+      const width = isScatter ? 284 : 252;
+
+      layouts.set(node.id, {
+        height,
+        width,
+        x: column * 312,
+        y,
+      });
+
+      children.forEach((child, index) => {
+        layouts.set(child.id, {
+          height: 76,
+          width: 220,
+          x: 32,
+          y: 78 + index * 88,
+        });
+      });
+
+      y += height + 36;
+    }
+  }
+
+  return layouts;
+}
+
+function calculateNodeLevels(graph: WorkflowGraph): Map<string, number> {
+  const levels = new Map<string, number>(
+    graph.nodes.map((node) => [node.id, node.parentId ? 1 : 0]),
+  );
+  const parentByNodeId = new Map(graph.nodes.map((node) => [node.id, node.parentId]));
+
+  for (let index = 0; index < graph.nodes.length; index += 1) {
+    let changed = false;
+
+    for (const edge of graph.edges) {
+      const sourceParent = parentByNodeId.get(edge.source);
+      const targetParent = parentByNodeId.get(edge.target);
+      const sourceId = sourceParent ?? edge.source;
+      const targetId = targetParent ?? edge.target;
+
+      if (sourceId === targetId) {
+        continue;
+      }
+
+      const nextLevel = (levels.get(sourceId) ?? 0) + 1;
+      if (nextLevel > (levels.get(targetId) ?? 0)) {
+        levels.set(targetId, nextLevel);
+        changed = true;
+      }
+    }
+
+    if (!changed) {
+      break;
+    }
+  }
+
+  return levels;
+}
+
+function getNodeStatus(
+  relatedEvents: RunEvent[],
+  runStatus: RunStatus,
+): WorkflowGraphNodeStatus {
+  if (!relatedEvents.length) {
+    return runStatus === "running" ? "pending" : "unavailable";
+  }
+
+  const latestEvent = relatedEvents[relatedEvents.length - 1];
+  const payloadStatus = readPayloadString(latestEvent.payload, "status");
+
+  if (latestEvent.type === "node.failed" || payloadStatus === "failed") {
+    return "failed";
+  }
+  if (latestEvent.type === "node.started") {
+    return "running";
+  }
+  if (latestEvent.type === "node.completed" || payloadStatus === "succeeded") {
+    return "completed";
+  }
+
+  return "pending";
+}
+
+function eventBelongsToNode(event: RunEvent, node: WorkflowGraphNode): boolean {
+  const identifiers = new Set([node.id, node.label, node.sourceStepId]);
+
+  if (event.node && identifiers.has(event.node)) {
+    return true;
+  }
+
+  return [
+    "call_id",
+    "input_id",
+    "node_id",
+    "output_id",
+    "source_step_id",
+    "step_id",
+    "workflow_node_id",
+  ].some((key) => {
+    const value = readPayloadString(event.payload, key);
+    return value !== null && identifiers.has(value);
+  });
+}
+
+function getEdgeColor(kind: WorkflowGraphEdge["kind"]): string {
+  if (kind === "input") {
+    return "#0f766e";
+  }
+  if (kind === "output") {
+    return "#7c3aed";
+  }
+  return "#2563eb";
+}
+
+function getMiniMapColor(node: WorkflowGraphReactNode): string {
+  if (node.data.status === "failed") {
+    return "#ef4444";
+  }
+  if (node.data.status === "running") {
+    return "#2563eb";
+  }
+  if (node.data.status === "completed") {
+    return "#0f766e";
+  }
+  return "#94a3b8";
+}

--- a/web/components/workflow-graph/workflow-graph.tsx
+++ b/web/components/workflow-graph/workflow-graph.tsx
@@ -50,6 +50,18 @@ const streamLabels: Record<WorkflowGraphStreamState, string> = {
   error: "事件流中断",
 };
 
+const TOP_LEVEL_NODE_HEIGHT = 106;
+const TOP_LEVEL_NODE_WIDTH = 252;
+const SCATTER_HEADER_HEIGHT = 104;
+const SCATTER_NODE_WIDTH = 336;
+const CHILD_NODE_GAP = 18;
+const CHILD_NODE_HEIGHT = 78;
+const CHILD_NODE_WIDTH = 232;
+const CHILD_NODE_X = 52;
+const CHILD_NODE_Y = 94;
+const COLUMN_GAP = 380;
+const ROW_GAP = 32;
+
 type WorkflowGraphStreamState = "disabled" | "connecting" | "connected" | "closed" | "error";
 
 type PositionedNode = WorkflowGraphReactNode & {
@@ -137,7 +149,7 @@ export function WorkflowGraphPanel({
 
       {graph.nodes.length ? (
         <div className="mt-5 grid gap-4 lg:grid-cols-[minmax(0,1fr)_22rem]">
-          <div className="h-[34rem] overflow-hidden rounded-md border bg-background">
+          <div className="h-[38rem] overflow-hidden rounded-md border bg-background xl:h-[42rem]">
             <ReactFlowProvider>
               <ReactFlow
                 fitView
@@ -266,7 +278,12 @@ function toReactFlowElements(
 ): { edges: Edge[]; nodes: WorkflowGraphReactNode[] } {
   const layouts = calculateNodeLayouts(graph);
   const nodes = graph.nodes.map((graphNode): PositionedNode => {
-    const layout = layouts.get(graphNode.id) ?? { height: 106, width: 252, x: 0, y: 0 };
+    const layout = layouts.get(graphNode.id) ?? {
+      height: TOP_LEVEL_NODE_HEIGHT,
+      width: TOP_LEVEL_NODE_WIDTH,
+      x: 0,
+      y: 0,
+    };
     const nodeView = nodeViews.get(graphNode.id);
 
     return {
@@ -300,26 +317,42 @@ function toReactFlowElements(
 
 function toReactFlowEdge(edge: WorkflowGraphEdge): Edge {
   const color = getEdgeColor(edge.kind);
+  const label = shouldShowEdgeLabel(edge) ? edge.label : undefined;
 
   return {
     id: edge.id,
     source: edge.source,
     target: edge.target,
-    label: edge.label,
+    label,
+    labelBgBorderRadius: 4,
+    labelBgPadding: [4, 2],
+    labelBgStyle: {
+      fill: "#ffffff",
+      fillOpacity: 0.92,
+    },
+    labelShowBg: Boolean(label),
+    labelStyle: {
+      fill: "#334155",
+      fontSize: 10,
+      fontWeight: 600,
+    },
     markerEnd: {
       color,
       type: MarkerType.ArrowClosed,
     },
     style: {
       stroke: color,
+      strokeOpacity: edge.kind === "input" ? 0.78 : 0.92,
       strokeWidth: 2,
     },
     type: "smoothstep",
+    zIndex: edge.kind === "output" ? 3 : edge.kind === "dependency" ? 2 : 1,
   };
 }
 
 function calculateNodeLayouts(graph: WorkflowGraph): Map<string, NodeLayout> {
   const levels = calculateNodeLevels(graph);
+  const nodeById = new Map(graph.nodes.map((node) => [node.id, node]));
   const childrenByParent = new Map<string, WorkflowGraphNode[]>();
   const topLevelNodes = graph.nodes.filter((node) => {
     if (!node.parentId) {
@@ -341,34 +374,45 @@ function calculateNodeLayouts(graph: WorkflowGraph): Map<string, NodeLayout> {
   }
 
   const layouts = new Map<string, NodeLayout>();
+  const columns = [...topLevelByColumn.keys()].sort((left, right) => left - right);
 
-  for (const [column, nodesInColumn] of topLevelByColumn) {
+  for (const column of columns) {
+    const nodesInColumn = topLevelByColumn.get(column) ?? [];
     let y = 0;
     for (const node of nodesInColumn) {
       const children = childrenByParent.get(node.id) ?? [];
       const isScatter = node.kind === "scatter";
-      const height = isScatter ? Math.max(180, 96 + children.length * 92) : 106;
-      const width = isScatter ? 284 : 252;
+      const height = isScatter
+        ? Math.max(220, SCATTER_HEADER_HEIGHT + children.length * (CHILD_NODE_HEIGHT + CHILD_NODE_GAP))
+        : TOP_LEVEL_NODE_HEIGHT;
+      const width = isScatter ? SCATTER_NODE_WIDTH : TOP_LEVEL_NODE_WIDTH;
+      const sourceCenterY = getIncomingSourceCenterY(node.id, graph, layouts, nodeById);
+
+      if (sourceCenterY !== null) {
+        y = Math.max(y, sourceCenterY - height / 2);
+      }
 
       layouts.set(node.id, {
         height,
         width,
-        x: column * 312,
+        x: column * COLUMN_GAP,
         y,
       });
 
       children.forEach((child, index) => {
         layouts.set(child.id, {
-          height: 76,
-          width: 220,
-          x: 32,
-          y: 78 + index * 88,
+          height: CHILD_NODE_HEIGHT,
+          width: CHILD_NODE_WIDTH,
+          x: CHILD_NODE_X,
+          y: CHILD_NODE_Y + index * (CHILD_NODE_HEIGHT + CHILD_NODE_GAP),
         });
       });
 
-      y += height + 36;
+      y += height + ROW_GAP;
     }
   }
+
+  alignWorkflowInputs(graph, layouts, nodeById);
 
   return layouts;
 }
@@ -405,6 +449,109 @@ function calculateNodeLevels(graph: WorkflowGraph): Map<string, number> {
   }
 
   return levels;
+}
+
+function alignWorkflowInputs(
+  graph: WorkflowGraph,
+  layouts: Map<string, NodeLayout>,
+  nodeById: Map<string, WorkflowGraphNode>,
+): void {
+  const inputNodes = graph.nodes
+    .filter((node) => node.kind === "workflow-input" && node.parentId === null)
+    .map((node, index) => ({
+      desiredCenterY: getOutgoingTargetCenterY(node.id, graph, layouts, nodeById),
+      index,
+      node,
+    }))
+    .sort((left, right) => {
+      const leftY = left.desiredCenterY ?? Number.MAX_SAFE_INTEGER;
+      const rightY = right.desiredCenterY ?? Number.MAX_SAFE_INTEGER;
+      return leftY - rightY || left.index - right.index;
+    });
+
+  let nextY = 0;
+  for (const { desiredCenterY, node } of inputNodes) {
+    const layout = layouts.get(node.id);
+    if (!layout) {
+      continue;
+    }
+
+    const desiredY = desiredCenterY === null ? nextY : desiredCenterY - layout.height / 2;
+    layout.y = Math.max(0, nextY, desiredY);
+    nextY = layout.y + layout.height + ROW_GAP;
+  }
+}
+
+function getIncomingSourceCenterY(
+  nodeId: string,
+  graph: WorkflowGraph,
+  layouts: Map<string, NodeLayout>,
+  nodeById: Map<string, WorkflowGraphNode>,
+): number | null {
+  const centers = graph.edges
+    .filter((edge) => edge.target === nodeId)
+    .map((edge) => getAbsoluteCenterY(edge.source, layouts, nodeById))
+    .filter((center): center is number => center !== null);
+
+  return average(centers);
+}
+
+function getOutgoingTargetCenterY(
+  nodeId: string,
+  graph: WorkflowGraph,
+  layouts: Map<string, NodeLayout>,
+  nodeById: Map<string, WorkflowGraphNode>,
+): number | null {
+  const centers = graph.edges
+    .filter((edge) => edge.source === nodeId)
+    .map((edge) => getAbsoluteCenterY(edge.target, layouts, nodeById))
+    .filter((center): center is number => center !== null);
+
+  return average(centers);
+}
+
+function getAbsoluteCenterY(
+  nodeId: string,
+  layouts: Map<string, NodeLayout>,
+  nodeById: Map<string, WorkflowGraphNode>,
+): number | null {
+  const layout = getAbsoluteLayout(nodeId, layouts, nodeById);
+  return layout ? layout.y + layout.height / 2 : null;
+}
+
+function getAbsoluteLayout(
+  nodeId: string,
+  layouts: Map<string, NodeLayout>,
+  nodeById: Map<string, WorkflowGraphNode>,
+): NodeLayout | null {
+  const layout = layouts.get(nodeId);
+  const node = nodeById.get(nodeId);
+  if (!layout || !node) {
+    return null;
+  }
+
+  if (!node.parentId) {
+    return layout;
+  }
+
+  const parentLayout = getAbsoluteLayout(node.parentId, layouts, nodeById);
+  if (!parentLayout) {
+    return null;
+  }
+
+  return {
+    ...layout,
+    x: parentLayout.x + layout.x,
+    y: parentLayout.y + layout.y,
+  };
+}
+
+function average(values: number[]): number | null {
+  if (!values.length) {
+    return null;
+  }
+
+  return values.reduce((total, value) => total + value, 0) / values.length;
 }
 
 function getNodeStatus(
@@ -460,6 +607,10 @@ function getEdgeColor(kind: WorkflowGraphEdge["kind"]): string {
     return "#7c3aed";
   }
   return "#2563eb";
+}
+
+function shouldShowEdgeLabel(edge: WorkflowGraphEdge): boolean {
+  return edge.kind !== "input";
 }
 
 function getMiniMapColor(node: WorkflowGraphReactNode): string {

--- a/web/components/workflow-graph/workflow-node.tsx
+++ b/web/components/workflow-graph/workflow-node.tsx
@@ -53,6 +53,16 @@ const statusClassNames: Record<WorkflowGraphNodeStatus, string> = {
   unavailable: "border-muted-foreground/20 text-muted-foreground",
 };
 
+function formatEventCount(eventCount: number): string {
+  if (eventCount === 0) {
+    return "No events";
+  }
+  if (eventCount === 1) {
+    return "1 event";
+  }
+  return `${eventCount} events`;
+}
+
 export function WorkflowNode({ data, selected }: NodeProps<WorkflowGraphReactNode>) {
   const { graphNode, status, eventCount } = data;
   const Icon = kindIcons[graphNode.kind];
@@ -92,7 +102,7 @@ export function WorkflowNode({ data, selected }: NodeProps<WorkflowGraphReactNod
       {!isScatter ? (
         <div className="mt-3 flex items-center gap-1.5 text-xs text-muted-foreground">
           <Layers3 className="h-3.5 w-3.5" />
-          {eventCount ? `${eventCount} event` : "No event"}
+          {formatEventCount(eventCount)}
         </div>
       ) : (
         <div className="mt-3 text-xs leading-5 text-muted-foreground">per-sample group</div>

--- a/web/components/workflow-graph/workflow-node.tsx
+++ b/web/components/workflow-graph/workflow-node.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { Handle, Position, type Node, type NodeProps } from "@xyflow/react";
+import { Box, Database, FileOutput, GitBranch, Layers3 } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+import type { WorkflowGraphNode, WorkflowGraphNodeKind } from "@/lib/workflow-graph";
+
+export type WorkflowGraphNodeStatus =
+  | "pending"
+  | "running"
+  | "completed"
+  | "failed"
+  | "unavailable";
+
+export type WorkflowGraphNodeData = {
+  graphNode: WorkflowGraphNode;
+  status: WorkflowGraphNodeStatus;
+  eventCount: number;
+};
+
+export type WorkflowGraphReactNode = Node<WorkflowGraphNodeData, "workflowGraphNode">;
+
+const kindLabels: Record<WorkflowGraphNodeKind, string> = {
+  "workflow-input": "Input",
+  call: "Call",
+  scatter: "Scatter",
+  "workflow-output": "Output",
+};
+
+const statusLabels: Record<WorkflowGraphNodeStatus, string> = {
+  pending: "Pending",
+  running: "Running",
+  completed: "Completed",
+  failed: "Failed",
+  unavailable: "Unavailable",
+};
+
+const kindIcons: Record<WorkflowGraphNodeKind, LucideIcon> = {
+  "workflow-input": Database,
+  call: Box,
+  scatter: GitBranch,
+  "workflow-output": FileOutput,
+};
+
+const statusClassNames: Record<WorkflowGraphNodeStatus, string> = {
+  pending: "border-muted-foreground/30 text-muted-foreground",
+  running: "border-primary/40 bg-secondary text-primary",
+  completed: "border-primary/40 bg-secondary text-primary",
+  failed: "border-destructive/40 bg-destructive text-destructive-foreground",
+  unavailable: "border-muted-foreground/20 text-muted-foreground",
+};
+
+export function WorkflowNode({ data, selected }: NodeProps<WorkflowGraphReactNode>) {
+  const { graphNode, status, eventCount } = data;
+  const Icon = kindIcons[graphNode.kind];
+  const isScatter = graphNode.kind === "scatter";
+
+  return (
+    <div
+      className={cn(
+        "h-full rounded-md border bg-white p-3 shadow-sm transition-colors",
+        selected ? "border-primary ring-2 ring-primary/20" : "border-border",
+        isScatter && "bg-secondary/50",
+      )}
+    >
+      {graphNode.kind !== "workflow-input" ? (
+        <Handle
+          type="target"
+          position={Position.Left}
+          className="!h-2.5 !w-2.5 !border-2 !border-white !bg-primary"
+        />
+      ) : null}
+
+      <div className="flex min-w-0 items-start gap-2">
+        <div className="rounded-md border bg-background p-1.5">
+          <Icon className="h-4 w-4 text-primary" />
+        </div>
+        <div className="min-w-0">
+          <div className="truncate text-sm font-semibold">{graphNode.label}</div>
+          <div className="mt-1 flex flex-wrap gap-1.5">
+            <Badge variant="outline">{kindLabels[graphNode.kind]}</Badge>
+            <Badge variant="outline" className={statusClassNames[status]}>
+              {statusLabels[status]}
+            </Badge>
+          </div>
+        </div>
+      </div>
+
+      {!isScatter ? (
+        <div className="mt-3 flex items-center gap-1.5 text-xs text-muted-foreground">
+          <Layers3 className="h-3.5 w-3.5" />
+          {eventCount ? `${eventCount} event` : "No event"}
+        </div>
+      ) : (
+        <div className="mt-3 text-xs leading-5 text-muted-foreground">per-sample group</div>
+      )}
+
+      {graphNode.kind !== "workflow-output" ? (
+        <Handle
+          type="source"
+          position={Position.Right}
+          className="!h-2.5 !w-2.5 !border-2 !border-white !bg-primary"
+        />
+      ) : null}
+    </div>
+  );
+}

--- a/web/lib/run-events.ts
+++ b/web/lib/run-events.ts
@@ -1,0 +1,86 @@
+import type { JsonObject, RunEvent, RunEventType, RunStatus } from "@/lib/types";
+
+export const runEventTypes: RunEventType[] = [
+  "run.created",
+  "node.started",
+  "node.completed",
+  "node.failed",
+  "artifact.updated",
+  "repair.applied",
+  "validation.completed",
+  "run.completed",
+];
+
+export const runEventLabels: Record<RunEventType, string> = {
+  "run.created": "Run 创建",
+  "node.started": "节点开始",
+  "node.completed": "节点完成",
+  "node.failed": "节点失败",
+  "artifact.updated": "产物更新",
+  "repair.applied": "修复应用",
+  "validation.completed": "校验完成",
+  "run.completed": "Run 完成",
+};
+
+export function isTerminalRunStatus(status: RunStatus): boolean {
+  return status === "succeeded" || status === "failed";
+}
+
+export function mergeRunEvent(events: RunEvent[], nextEvent: RunEvent): RunEvent[] {
+  const bySequence = new Map(events.map((event) => [event.sequence, event]));
+  bySequence.set(nextEvent.sequence, nextEvent);
+  return Array.from(bySequence.values()).sort((left, right) => left.sequence - right.sequence);
+}
+
+export function parseRunEventMessage(message: MessageEvent<string>): RunEvent | null {
+  try {
+    const parsed: unknown = JSON.parse(message.data);
+    if (!isRecord(parsed)) {
+      return null;
+    }
+
+    const { event_id, node, payload, run_id, sequence, summary, timestamp, type } = parsed;
+    if (
+      typeof event_id !== "string" ||
+      typeof run_id !== "string" ||
+      typeof sequence !== "number" ||
+      !Number.isInteger(sequence) ||
+      sequence < 1 ||
+      !isRunEventType(type) ||
+      typeof timestamp !== "string" ||
+      Number.isNaN(Date.parse(timestamp)) ||
+      typeof summary !== "string" ||
+      !(node === null || typeof node === "string") ||
+      !isRecord(payload)
+    ) {
+      return null;
+    }
+
+    return {
+      event_id,
+      run_id,
+      sequence,
+      type,
+      timestamp,
+      summary,
+      node,
+      payload: payload as JsonObject,
+    };
+  } catch (error) {
+    console.error("Failed to parse run event.", error);
+    return null;
+  }
+}
+
+export function readPayloadString(payload: JsonObject, key: string): string | null {
+  const value = payload[key];
+  return typeof value === "string" ? value : null;
+}
+
+function isRunEventType(value: unknown): value is RunEventType {
+  return typeof value === "string" && runEventTypes.includes(value as RunEventType);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@radix-ui/react-slot": "^1.1.0",
+        "@xyflow/react": "^12.11.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^0.468.0",
@@ -1539,6 +1540,55 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
@@ -1584,7 +1634,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -2226,6 +2276,48 @@
         "win32"
       ]
     },
+    "node_modules/@xyflow/react": {
+      "version": "12.11.0",
+      "resolved": "https://registry.npmjs.org/@xyflow/react/-/react-12.11.0.tgz",
+      "integrity": "sha512-na4IO33FSs2OS72hASgZDmTYwFAkef7Z74uBUVrong3ARmQQHfnRUVaCFn1kTt5LbS6pK03TbYjCPGLjLFfziA==",
+      "license": "MIT",
+      "dependencies": {
+        "@xyflow/system": "0.0.77",
+        "classcat": "^5.0.3",
+        "zustand": "^4.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=17",
+        "@types/react-dom": ">=17",
+        "react": ">=17",
+        "react-dom": ">=17"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@xyflow/system": {
+      "version": "0.0.77",
+      "resolved": "https://registry.npmjs.org/@xyflow/system/-/system-0.0.77.tgz",
+      "integrity": "sha512-qCDCMCQAAgUu8yHnhloHG9F5mwPX5E+Wl8McpYIOPSSXfzFJJoZcwOcsDiAjitVKIg2de1WmJbCHfpcvxprsgg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-drag": "^3.0.7",
+        "@types/d3-interpolate": "^3.0.4",
+        "@types/d3-selection": "^3.0.10",
+        "@types/d3-transition": "^3.0.8",
+        "@types/d3-zoom": "^3.0.8",
+        "d3-drag": "^3.0.0",
+        "d3-interpolate": "^3.0.1",
+        "d3-selection": "^3.0.0",
+        "d3-zoom": "^3.0.0"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.17.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
@@ -2817,6 +2909,12 @@
         "url": "https://polar.sh/cva"
       }
     },
+    "node_modules/classcat": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/classcat/-/classcat-5.0.5.tgz",
+      "integrity": "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==",
+      "license": "MIT"
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
@@ -2901,6 +2999,111 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -6731,6 +6934,15 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -6863,6 +7075,34 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     }
   }

--- a/web/package.json
+++ b/web/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@radix-ui/react-slot": "^1.1.0",
+    "@xyflow/react": "^12.11.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.468.0",


### PR DESCRIPTION
## Summary

- Add a React Flow-based Workflow DAG panel to the run detail page.
- Visualize Workflow IR inputs, calls, scatter groups, outputs, and dependency edges.
- Add node detail inspection for task inputs, outputs, runtime metadata, unresolved references, and related run events.
- Share SSE event parsing between the timeline and DAG view.
- Include a small deterministic layout pass to improve readability without adding another layout engine.

## Dependency

- Add `@xyflow/react` for interactive DAG rendering.

## Validation

- `npm.cmd run test:graph`
- `npm.cmd run lint`
- `npm.cmd run build`