### PR TITLE
Consolidate service layer entrypoints

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -95,7 +95,7 @@ Web 产品化遵循以下目标：
 
 ## 当前端到端调用链路与编译子图
 
-当前自然语言服务入口已具备 P1 Orchestration Graph 外壳。`plan_and_compile_workflow` 会构造 `OrchestrationState`，运行 `src.orchestration.graph`，先通过 Planner node 生成 Recipe Tool Plan，再由上层 compiler delegate node 调用下层 **Compiler Graph**。`src/graph.py` 仍然是面向结构化输入的 Compiler Graph，结构化调试入口继续绕过自然语言编排层。
+当前自然语言服务入口已具备 P1 Orchestration Graph 外壳。`plan_and_compile_workflow` 会构造 `OrchestrationState`，运行 `src.orchestration.graph`，先通过 Planner node 生成 Recipe Tool Plan，再由上层 compiler delegate node 调用下层 **Compiler Graph**。`src/graph.py` 仍然是面向结构化输入的 Compiler Graph，结构化调试入口继续绕过自然语言编排层。Run service 的自然语言执行入口也通过 `plan_and_compile_workflow` 获取 planner、orchestration 和 compiler 事件，避免在 API run 层重复手写 Planner 到 Compiler 的编排。
 
 ### 当前端到端调用链路
 

--- a/docs/p1-orchestration-graph-plan.md
+++ b/docs/p1-orchestration-graph-plan.md
@@ -215,17 +215,21 @@ START
 | `plan_and_compile_workflow` | 自然语言输入调用 Orchestration Graph |
 | `compile_workflow` | 兼容旧调用，必要时保留为结构化入口别名 |
 
-建议结果：
+已落地结果：
 
-- 继续使用或扩展 `WorkflowCompilationResult`。
-- 自然语言结果应保留 `planner_prompt` 和 `planner_raw_response`。
-- Planner 失败应映射为明确异常或失败 result，API 层再转换为 run diagnostics。
+- 继续使用 `WorkflowCompilationResult` 作为 CLI、API 和 run service 共享的稳定结果对象。
+- `plan_and_compile_workflow` 接受自然语言请求，构造 Orchestration Graph，并保留 `planner_prompt` 与 `planner_raw_response`。
+- `compile_structured_workflow` 继续作为结构化输入入口，直接进入 Compiler Graph，不触发自然语言 Planner。
+- `compile_workflow` 保留为旧调用兼容别名，返回结构化编译的 `WorkflowState`。
+- `RunService.execute_natural_language_run` 不再手写 Planner 到 Compiler 的线性编排，而是调用 `plan_and_compile_workflow`。
+- `plan_and_compile_workflow` 支持可选 `event_callback`，能够覆盖 Planner、上层 `compiler_graph` delegate 和下层 Compiler Graph 事件。
+- run service 可通过 service event callback 持久化 plan、planner trace、Workflow IR、WDL 和 diagnostics。
 
-验收：
+已满足验收：
 
 - `plan_and_compile_workflow` 内不再手写 Planner 到 Compiler 的线性编排。
 - `compile_structured_workflow` 不需要 `DEEPSEEK_API_KEY`。
-- event callback 能覆盖 Planner 和 Compiler 阶段，或由 run service 统一桥接两层事件。
+- event callback 能覆盖 Planner 和 Compiler 阶段，并由 run service 统一桥接到 run history / SSE 事件。
 
 ### P1.6 CLI 与 API 路由
 
@@ -401,9 +405,9 @@ run.completed
 - [x] 结构化入口在没有 `DEEPSEEK_API_KEY` 时可运行。
 - [x] Planner 失败不会进入 Compiler Graph。
 - [x] Compiler Graph 失败保留 Analyzer/Checker diagnostics。
-- [ ] Planner 事件和 plan artifact 可被 run history 或 SSE 回放。
-- [ ] CLI stdout/stderr 契约保持不变。
-- [ ] API route tests 覆盖 `/api/runs` 和 `/api/compile` 的分层差异。
+- [x] Planner 事件和 plan artifact 可被 run history 或 SSE 回放。
+- [x] CLI stdout/stderr 契约保持不变。
+- [x] API route tests 覆盖 `/api/runs` 和 `/api/compile` 的分层差异。
 - [x] `docs/test-cases.md` 在测试覆盖意图变化时已同步更新。
 - [x] 相关单元测试通过。
 

--- a/docs/test-cases.md
+++ b/docs/test-cases.md
@@ -48,11 +48,11 @@ powershell -ExecutionPolicy Bypass -File scripts\check_p0.ps1 `
 - `tests/test_tiny_run.py`：没有 miniwdl、Docker/Podman、本地镜像或 tiny 输入文件时跳过真实 tiny run。
 - `tests/test_container_build.py`：纯单元测试，不调用 Docker；只验证容器构建脚本的 tag contract。
 
-当前 W2 Run 事件与 P0 文档同步收口后的最近一次完整验证结果：
+当前 P1.5 Service 层入口收口后的最近一次完整验证结果：
 
 ```text
-.venv\Scripts\python.exe -m unittest discover -v
-Ran 161 tests
+.\.venv\Scripts\python.exe -m unittest discover -v
+Ran 170 tests
 OK (skipped=2)
 ```
 
@@ -683,7 +683,7 @@ OK (skipped=2)
 
 ## `tests/test_run_service.py`
 
-该文件验证 persistent run lifecycle service。Service 层连接 API DTO、RunRepository、自然语言 planner 和 deterministic compiler graph，FastAPI routes 只调用 service 方法。
+该文件验证 persistent run lifecycle service。Service 层连接 API DTO、RunRepository 和 workflow service；FastAPI routes 只调用 service 方法。自然语言 run 通过 `workflow_service.plan_and_compile_workflow` 进入 Orchestration Graph，不在 run service 内重复调用 planner 或结构化 compiler。
 
 ### `test_structured_compile_run_succeeds_and_records_events`
 
@@ -710,6 +710,97 @@ OK (skipped=2)
 覆盖点：
 
 - 结构化编译 run 会持久化详情页所需元数据、产物、诊断和事件回放记录。
+
+### `test_natural_language_run_succeeds_after_planning`
+
+输入：
+
+- 自然语言请求：`Run RNA-seq DEG.`
+- mock `workflow_service.plan_and_compile_workflow(...)` 返回成功的 `WorkflowCompilationResult`
+
+执行：
+
+- 通过 `RunService.create_natural_language_run(...)` 创建 run。
+- 调用 `RunService.execute_natural_language_run(...)`。
+- 读取 run snapshot。
+
+期望输出：
+
+- `plan_and_compile_workflow` 被调用一次。
+- 调用参数包含自然语言 request、`check=False` 和 `event_callback`。
+- snapshot `status == "succeeded"`。
+- snapshot artifacts 包含 Recipe Tool Plan 和 WDL。
+
+覆盖点：
+
+- 自然语言 run service 入口只依赖稳定 workflow service，不再手写 Planner 到 Compiler 的线性编排。
+- API run 层通过 callback 接收 service 事件。
+
+### `test_natural_language_run_preserves_empty_planner_observability_fields`
+
+输入：
+
+- 自然语言请求：`Run RNA-seq DEG.`
+- mock `plan_and_compile_workflow(...)` 返回 `planner_prompt == ""` 和 `planner_raw_response == ""`
+
+执行：
+
+- 创建并执行自然语言 run。
+- 直接读取 SQLite `run_artifacts` 表。
+
+期望输出：
+
+- `planner_prompt` 保存为空字符串。
+- `planner_raw_response` 保存为空字符串。
+
+覆盖点：
+
+- 空字符串 trace 与 `None` 语义区分保留，便于后续调试真实 planner 行为。
+
+### `test_natural_language_compile_exception_preserves_planner_artifacts`
+
+输入：
+
+- 自然语言请求：`Run RNA-seq DEG.`
+- mock `plan_and_compile_workflow(...)` 先通过 `event_callback` 发出 plan artifact 更新，再抛出 `RuntimeError("compiler exploded")`
+
+执行：
+
+- 创建并执行自然语言 run。
+- 读取 snapshot 与 events。
+
+期望输出：
+
+- snapshot `status == "failed"`。
+- snapshot artifacts 仍保留 planner 产出的 plan。
+- diagnostics validation message 包含 `compiler exploded`。
+- events 包含 compiler failure，并以 `run.completed` 结束。
+
+覆盖点：
+
+- 即使自然语言 run 在 compiler 阶段失败，已产生的 planner artifact 仍可被历史详情和 SSE 回放读取。
+
+### `test_natural_language_planner_error_is_persisted_as_failed_run`
+
+输入：
+
+- 自然语言请求：`Run RNA-seq DEG.`
+- mock `plan_and_compile_workflow(...)` 抛出 `NaturalLanguagePlanningError`
+
+执行：
+
+- 创建并执行自然语言 run。
+- 读取 snapshot 与 events。
+
+期望输出：
+
+- snapshot `status == "failed"`。
+- diagnostics validation message 包含 planner 错误。
+- events 包含 `node.failed`。
+
+覆盖点：
+
+- Planner 错误由 workflow service 分类并传递给 run service，run service 只负责持久化失败状态与诊断。
 
 ### `test_list_runs_returns_api_summaries`
 
@@ -2078,6 +2169,32 @@ Agent 占位逻辑。
 - 自然语言入口通过 Orchestration Graph 先生成 Recipe Tool Plan，再进入确定性编译链路。
 - LLM 仍不直接生成最终 WDL。
 - planner observability 信息被 service 结果保留。
+
+### `test_plan_and_compile_workflow_event_callback_covers_planner_and_compiler`
+
+输入：
+
+- 用户请求：`Run bulk RNA-seq differential expression.`
+- `FakePlannerLlm` 返回 RNA-seq Recipe Tool Plan JSON。
+- `check=False`
+- 注入 `event_callback` 收集 service 事件。
+
+执行：
+
+- 调用 `plan_and_compile_workflow(..., event_callback=event_callback)`。
+
+期望输出：
+
+- `result.succeeded == True`。
+- 事件以 planner started/completed/plan artifact 开始。
+- 随后进入上层 `compiler_graph` delegate。
+- 事件中包含下层 Compiler Graph 的 `ir_normalizer`、`workflow_ir` artifact、`wdl` artifact 和最终 compiler delegate 完成事件。
+- plan artifact 事件的 state 中包含 planner 生成的 Recipe Tool Plan。
+
+覆盖点：
+
+- 自然语言 service 入口的 event callback 覆盖 Planner、Orchestration Graph delegate 和 Compiler Graph 阶段。
+- run service/API 可以不重复编排节点，只通过 workflow service 事件桥接 run history / SSE。
 
 ### `test_plan_and_compile_workflow_preserves_planner_error_classification`
 

--- a/src/orchestration/nodes/compiler.py
+++ b/src/orchestration/nodes/compiler.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Callable, TYPE_CHECKING
+from typing import Any, Callable, Mapping, TYPE_CHECKING
 
 from src.orchestration.state import OrchestrationState
 
@@ -11,6 +11,10 @@ if TYPE_CHECKING:
 
 
 StructuredCompiler = Callable[[dict[str, Any], bool], "WorkflowCompilationResult"]
+OrchestrationEventCallback = Callable[
+    [str, str | None, str, Mapping[str, Any] | None, dict[str, Any] | None],
+    None,
+]
 CompilerNode = Callable[[OrchestrationState], dict[str, Any]]
 
 
@@ -21,6 +25,7 @@ def compile_planned_workflow_node(state: OrchestrationState) -> dict[str, Any]:
 
 def make_compile_planned_workflow_node(
     compiler: StructuredCompiler | None = None,
+    event_callback: OrchestrationEventCallback | None = None,
 ) -> CompilerNode:
     """Create a compiler delegation node, optionally injecting the compiler."""
 
@@ -30,10 +35,11 @@ def make_compile_planned_workflow_node(
             "Compiler graph started.",
             {"check": state["check"]},
         )
+        _emit_compiler_event_callback(event_callback, started_event, state)
         plan = state["plan"]
         if plan is None:
             error = "Planner did not produce a Recipe Tool Plan."
-            return {
+            update: dict[str, Any] = {
                 "compiler_result": None,
                 "errors": [error],
                 "events": [
@@ -45,13 +51,15 @@ def make_compile_planned_workflow_node(
                     ),
                 ],
             }
+            _emit_compiler_event_callback(event_callback, update["events"][1], update)
+            return update
 
         try:
             compiler_fn = compiler or _default_structured_compiler
             compiler_result = compiler_fn(plan, state["check"])
         except Exception as exc:
             error = _exception_message(exc)
-            return {
+            update = {
                 "compiler_result": None,
                 "errors": [error],
                 "events": [
@@ -66,6 +74,8 @@ def make_compile_planned_workflow_node(
                     ),
                 ],
             }
+            _emit_compiler_event_callback(event_callback, update["events"][1], update)
+            return update
 
         if compiler_result.succeeded:
             event_type = "node.completed"
@@ -74,13 +84,15 @@ def make_compile_planned_workflow_node(
             event_type = "node.failed"
             summary = "Compiler graph completed with diagnostics."
 
-        return {
+        update = {
             "compiler_result": compiler_result,
             "events": [
                 started_event,
                 _compiler_event(event_type, summary, _compiler_result_payload(compiler_result)),
             ],
         }
+        _emit_compiler_event_callback(event_callback, update["events"][1], update)
+        return update
 
     return node
 
@@ -122,3 +134,19 @@ def _compiler_event(
     if payload is not None:
         event["payload"] = payload
     return event
+
+
+def _emit_compiler_event_callback(
+    event_callback: OrchestrationEventCallback | None,
+    event: dict[str, Any],
+    state: Mapping[str, Any] | None,
+) -> None:
+    if event_callback is None:
+        return
+    event_callback(
+        event["type"],
+        event.get("node"),
+        event["summary"],
+        state,
+        event.get("payload"),
+    )

--- a/src/orchestration/nodes/planner.py
+++ b/src/orchestration/nodes/planner.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Callable
+from typing import Any, Callable, Mapping
 
 from src.catalog.loader import ToolCatalog
 from src.nl_planner import (
@@ -14,6 +14,10 @@ from src.orchestration.state import OrchestrationState
 from src.recipes.loader import RecipeCatalog
 
 
+OrchestrationEventCallback = Callable[
+    [str, str | None, str, Mapping[str, Any] | None, dict[str, Any] | None],
+    None,
+]
 PlannerNode = Callable[[OrchestrationState], dict[str, Any]]
 
 
@@ -27,6 +31,7 @@ def make_natural_language_planner_node(
     llm: PlannerLlm | None = None,
     tool_catalog: ToolCatalog | None = None,
     recipe_catalog: RecipeCatalog | None = None,
+    event_callback: OrchestrationEventCallback | None = None,
 ) -> PlannerNode:
     """Create a planner node, optionally injecting dependencies for tests."""
 
@@ -36,6 +41,7 @@ def make_natural_language_planner_node(
             "Natural-language planner started.",
             {"model": state["planner_model"]},
         )
+        _emit_planner_event(event_callback, started_event, state)
 
         try:
             plan_result = create_natural_language_plan(
@@ -46,7 +52,7 @@ def make_natural_language_planner_node(
                 recipe_catalog=recipe_catalog,
             )
         except NaturalLanguagePlanningError as exc:
-            return {
+            update: dict[str, Any] = {
                 "plan": None,
                 "planner_prompt": None,
                 "planner_raw_response": None,
@@ -63,8 +69,10 @@ def make_natural_language_planner_node(
                     ),
                 ],
             }
+            _emit_planner_events(event_callback, update["events"][1:], update)
+            return update
         except Exception as exc:
-            return {
+            update = {
                 "plan": None,
                 "planner_prompt": None,
                 "planner_raw_response": None,
@@ -81,8 +89,10 @@ def make_natural_language_planner_node(
                     ),
                 ],
             }
+            _emit_planner_events(event_callback, update["events"][1:], update)
+            return update
 
-        return {
+        update = {
             "plan": plan_result.plan,
             "planner_prompt": plan_result.planner_prompt,
             "planner_raw_response": plan_result.raw_response,
@@ -97,6 +107,8 @@ def make_natural_language_planner_node(
                 ),
             ],
         }
+        _emit_planner_events(event_callback, update["events"][1:], update)
+        return update
 
     return node
 
@@ -114,3 +126,28 @@ def _planner_event(
     if payload is not None:
         event["payload"] = payload
     return event
+
+
+def _emit_planner_events(
+    event_callback: OrchestrationEventCallback | None,
+    events: list[dict[str, Any]],
+    state: Mapping[str, Any] | None,
+) -> None:
+    for event in events:
+        _emit_planner_event(event_callback, event, state)
+
+
+def _emit_planner_event(
+    event_callback: OrchestrationEventCallback | None,
+    event: dict[str, Any],
+    state: Mapping[str, Any] | None,
+) -> None:
+    if event_callback is None:
+        return
+    event_callback(
+        event["type"],
+        event.get("node"),
+        event["summary"],
+        state,
+        event.get("payload"),
+    )

--- a/src/services/run_repository.py
+++ b/src/services/run_repository.py
@@ -243,6 +243,19 @@ class RunRepository:
             ).fetchall()
         return [_row_to_event(row) for row in rows]
 
+    def has_event_type(self, run_id: str, event_type: RunEventType) -> bool:
+        with self._connect() as connection:
+            row = connection.execute(
+                """
+                SELECT 1
+                FROM run_events
+                WHERE run_id = ? AND type = ?
+                LIMIT 1
+                """,
+                (run_id, event_type.value),
+            ).fetchone()
+        return row is not None
+
     def save_artifacts(
         self,
         run_id: str,

--- a/src/services/run_repository.py
+++ b/src/services/run_repository.py
@@ -276,6 +276,35 @@ class RunRepository:
                 ),
             )
 
+    def save_plan_artifact(
+        self,
+        run_id: str,
+        plan: dict[str, Any],
+        *,
+        planner_prompt: str | None = None,
+        planner_raw_response: str | None = None,
+    ) -> None:
+        with self._connect() as connection:
+            connection.execute(
+                """
+                INSERT INTO run_artifacts (
+                    run_id, plan_json, workflow_ir_json, wdl,
+                    planner_prompt, planner_raw_response
+                )
+                VALUES (?, ?, '{}', '', ?, ?)
+                ON CONFLICT(run_id) DO UPDATE SET
+                    plan_json = excluded.plan_json,
+                    planner_prompt = excluded.planner_prompt,
+                    planner_raw_response = excluded.planner_raw_response
+                """,
+                (
+                    run_id,
+                    _to_json(plan),
+                    planner_prompt,
+                    planner_raw_response,
+                ),
+            )
+
     def save_workflow_ir_artifact(self, run_id: str, workflow_ir: dict[str, Any]) -> None:
         with self._connect() as connection:
             connection.execute(

--- a/src/services/run_service.py
+++ b/src/services/run_service.py
@@ -326,8 +326,7 @@ class RunService:
         summary: str,
         exc: Exception,
     ) -> None:
-        events = self.repository.list_events(run_id)
-        if any(event.type == RunEventType.NODE_FAILED for event in events):
+        if self.repository.has_event_type(run_id, RunEventType.NODE_FAILED):
             return
         self.repository.append_event(
             run_id=run_id,

--- a/src/services/run_service.py
+++ b/src/services/run_service.py
@@ -21,7 +21,7 @@ from src.api.models import (
     WorkflowArtifacts,
     WorkflowRunSnapshotResponse,
 )
-from src.nl_planner import DEFAULT_PLANNER_MODEL, NaturalLanguagePlanningError, create_natural_language_plan
+from src.nl_planner import DEFAULT_PLANNER_MODEL, NaturalLanguagePlanningError
 from src.services import workflow_service
 from src.services.run_repository import RunRepository
 from src.services.workflow_service import WorkflowCompilationResult
@@ -79,75 +79,34 @@ class RunService:
     def execute_natural_language_run(self, run_id: str, request: NaturalLanguageRunRequest) -> None:
         self.repository.update_status(run_id, RunStatus.RUNNING)
         planner_model = request.planner_model or DEFAULT_PLANNER_MODEL
-        self.repository.append_event(
-            run_id=run_id,
-            event_type=RunEventType.NODE_STARTED,
-            node="planner",
-            summary="Natural-language planner started.",
-            payload={"model": planner_model},
-        )
 
         try:
-            plan_result = create_natural_language_plan(request.request, model=planner_model)
+            result = workflow_service.plan_and_compile_workflow(
+                request.request,
+                model=planner_model,
+                check=request.check,
+                event_callback=self._workflow_event_callback(run_id),
+            )
         except NaturalLanguagePlanningError as exc:
-            self.repository.append_event(
-                run_id=run_id,
-                event_type=RunEventType.NODE_FAILED,
+            self._append_failed_event_if_missing(
+                run_id,
                 node="planner",
                 summary="Natural-language planner failed.",
-                payload={"error": str(exc)},
+                exc=exc,
             )
             self._fail_run(run_id, str(exc), check_performed=request.check)
             return
         except Exception as exc:
-            self.repository.append_event(
-                run_id=run_id,
-                event_type=RunEventType.NODE_FAILED,
-                node="planner",
-                summary="Natural-language planner failed unexpectedly.",
-                payload={"error": str(exc)},
+            self._append_failed_event_if_missing(
+                run_id,
+                node="compiler",
+                summary="Workflow compiler failed.",
+                exc=exc,
             )
             self._fail_run(run_id, str(exc), check_performed=request.check)
             return
 
-        self.repository.append_event(
-            run_id=run_id,
-            event_type=RunEventType.NODE_COMPLETED,
-            node="planner",
-            summary="Natural-language planner completed.",
-            payload={"model": planner_model},
-        )
-        self.repository.save_artifacts(
-            run_id,
-            WorkflowArtifacts(plan=plan_result.plan),
-            planner_prompt=plan_result.planner_prompt,
-            planner_raw_response=plan_result.raw_response,
-        )
-        self.repository.append_event(
-            run_id=run_id,
-            event_type=RunEventType.ARTIFACT_UPDATED,
-            node="planner",
-            summary="Recipe Tool Plan artifact updated.",
-            payload={"artifact": "plan"},
-        )
-
-        try:
-            result = workflow_service.compile_structured_workflow(
-                plan_result.plan,
-                check=request.check,
-                event_callback=self._compiler_event_callback(run_id),
-            )
-        except Exception as exc:
-            self._append_compiler_failed_event(run_id, exc)
-            self._fail_run(run_id, str(exc), check_performed=request.check)
-            return
-
-        self._complete_run(
-            run_id,
-            result,
-            planner_prompt=plan_result.planner_prompt,
-            planner_raw_response=plan_result.raw_response,
-        )
+        self._complete_run(run_id, result)
 
     def execute_structured_compile_run(self, run_id: str, request: CompileWorkflowRequest) -> None:
         self.repository.update_status(run_id, RunStatus.RUNNING)
@@ -155,7 +114,7 @@ class RunService:
             result = workflow_service.compile_structured_workflow(
                 request.payload,
                 check=request.check,
-                event_callback=self._compiler_event_callback(run_id),
+                event_callback=self._workflow_event_callback(run_id),
             )
         except Exception as exc:
             self._append_compiler_failed_event(run_id, exc)
@@ -319,6 +278,9 @@ class RunService:
         )
 
     def _compiler_event_callback(self, run_id: str):
+        return self._workflow_event_callback(run_id)
+
+    def _workflow_event_callback(self, run_id: str):
         def callback(event_type: str, node: str | None, summary: str, state, payload):
             self._persist_updated_artifact(run_id, event_type, state, payload)
             self.repository.append_event(
@@ -338,10 +300,42 @@ class RunService:
             return
 
         artifact = payload.get("artifact")
-        if artifact == "workflow_ir":
+        if artifact == "plan":
+            plan = state.get("plan")
+            if isinstance(plan, dict):
+                planner_prompt = state.get("planner_prompt")
+                planner_raw_response = state.get("planner_raw_response")
+                self.repository.save_plan_artifact(
+                    run_id,
+                    plan,
+                    planner_prompt=planner_prompt if isinstance(planner_prompt, str) else None,
+                    planner_raw_response=(
+                        planner_raw_response if isinstance(planner_raw_response, str) else None
+                    ),
+                )
+        elif artifact == "workflow_ir":
             self.repository.save_workflow_ir_artifact(run_id, state.get("workflow_ir") or {})
         elif artifact == "wdl":
             self.repository.save_wdl_artifact(run_id, state.get("current_wdl") or "")
+
+    def _append_failed_event_if_missing(
+        self,
+        run_id: str,
+        *,
+        node: str,
+        summary: str,
+        exc: Exception,
+    ) -> None:
+        events = self.repository.list_events(run_id)
+        if any(event.type == RunEventType.NODE_FAILED for event in events):
+            return
+        self.repository.append_event(
+            run_id=run_id,
+            event_type=RunEventType.NODE_FAILED,
+            node=node,
+            summary=summary,
+            payload={"error": str(exc)},
+        )
 
 
 _default_run_service: RunService | None = None

--- a/src/services/workflow_service.py
+++ b/src/services/workflow_service.py
@@ -19,6 +19,7 @@ from src.nodes.ir_normalizer import ir_normalizer_node
 from src.nodes.renderer import renderer_node
 from src.nodes.repairer import repairer_node
 from src.orchestration.graph import build_orchestration_graph
+from src.orchestration.nodes.compiler import make_compile_planned_workflow_node
 from src.orchestration.nodes.planner import make_natural_language_planner_node
 from src.orchestration.state import OrchestrationState, build_initial_orchestration_state
 from src.recipes.loader import RecipeCatalog
@@ -28,6 +29,10 @@ from src.tools.validator import VALIDATOR_MISSING_MARKER
 
 CompilerEventCallback = Callable[
     [str, str | None, str, WorkflowState, dict[str, Any] | None],
+    None,
+]
+WorkflowEventCallback = Callable[
+    [str, str | None, str, Mapping[str, Any] | None, dict[str, Any] | None],
     None,
 ]
 
@@ -86,14 +91,20 @@ def plan_and_compile_workflow(
     llm: PlannerLlm | None = None,
     tool_catalog: ToolCatalog | None = None,
     recipe_catalog: RecipeCatalog | None = None,
+    event_callback: WorkflowEventCallback | None = None,
 ) -> WorkflowCompilationResult:
     """Plan from natural language through the orchestration graph, then compile."""
     planner_node = make_natural_language_planner_node(
         llm=llm,
         tool_catalog=tool_catalog,
         recipe_catalog=recipe_catalog,
+        event_callback=event_callback,
     )
-    graph = build_orchestration_graph(planner_node=planner_node)
+    compiler_node = make_compile_planned_workflow_node(
+        compiler=_compiler_with_callback(event_callback),
+        event_callback=event_callback,
+    )
+    graph = build_orchestration_graph(planner_node=planner_node, compiler_node=compiler_node)
     orchestration_state = cast(
         OrchestrationState,
         graph.invoke(
@@ -116,6 +127,22 @@ def plan_and_compile_workflow(
         planner_prompt=orchestration_state["planner_prompt"],
         planner_raw_response=orchestration_state["planner_raw_response"],
     )
+
+
+def _compiler_with_callback(
+    event_callback: WorkflowEventCallback | None,
+) -> Callable[[dict[str, Any], bool], WorkflowCompilationResult] | None:
+    if event_callback is None:
+        return None
+
+    def compile_with_events(parsed_json: dict[str, Any], check: bool) -> WorkflowCompilationResult:
+        return compile_structured_workflow(
+            parsed_json,
+            check=check,
+            event_callback=event_callback,
+        )
+
+    return compile_with_events
 
 
 def build_initial_state(

--- a/src/services/workflow_service.py
+++ b/src/services/workflow_service.py
@@ -27,14 +27,12 @@ from src.state import WorkflowState
 from src.tools.validator import VALIDATOR_MISSING_MARKER
 
 
-CompilerEventCallback = Callable[
-    [str, str | None, str, WorkflowState, dict[str, Any] | None],
-    None,
-]
+WorkflowEventState = Mapping[str, Any] | None
 WorkflowEventCallback = Callable[
-    [str, str | None, str, Mapping[str, Any] | None, dict[str, Any] | None],
+    [str, str | None, str, WorkflowEventState, dict[str, Any] | None],
     None,
 ]
+CompilerEventCallback = WorkflowEventCallback
 
 
 @dataclass(frozen=True)

--- a/tests/test_run_repository.py
+++ b/tests/test_run_repository.py
@@ -65,6 +65,35 @@ class RunRepositoryTests(unittest.TestCase):
             self.assertEqual([event.sequence for event in events], [1, 2])
             self.assertEqual(events[1].node, "ir_normalizer")
 
+    def test_has_event_type_checks_event_existence(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repository = RunRepository(Path(temp_dir) / "runs.sqlite3")
+            repository.create_run(
+                run_id="run_001",
+                kind="structured_compile",
+                request={},
+                check_performed=False,
+                events_url="/api/runs/run_001/events",
+            )
+
+            self.assertFalse(repository.has_event_type("run_001", RunEventType.NODE_FAILED))
+
+            repository.append_event(
+                run_id="run_001",
+                event_type=RunEventType.NODE_STARTED,
+                node="compiler",
+                summary="Workflow compiler started.",
+            )
+            self.assertFalse(repository.has_event_type("run_001", RunEventType.NODE_FAILED))
+
+            repository.append_event(
+                run_id="run_001",
+                event_type=RunEventType.NODE_FAILED,
+                node="compiler",
+                summary="Workflow compiler failed.",
+            )
+            self.assertTrue(repository.has_event_type("run_001", RunEventType.NODE_FAILED))
+
     def test_repository_returns_none_for_unknown_run_snapshot(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             repository = RunRepository(Path(temp_dir) / "runs.sqlite3")

--- a/tests/test_run_service.py
+++ b/tests/test_run_service.py
@@ -2,8 +2,8 @@ import asyncio
 import json
 import tempfile
 import unittest
+from dataclasses import replace
 from pathlib import Path
-from types import SimpleNamespace
 from unittest.mock import patch
 
 from src.api.models import (
@@ -17,6 +17,7 @@ from src.api.models import (
 from src.nl_planner import NaturalLanguagePlanningError
 from src.services.run_repository import RunRepository
 from src.services.run_service import RunService
+from src.services.workflow_service import compile_structured_workflow
 
 
 EXAMPLES_DIR = Path(__file__).parents[1] / "examples"
@@ -24,6 +25,19 @@ EXAMPLES_DIR = Path(__file__).parents[1] / "examples"
 
 def load_example(name: str) -> dict:
     return json.loads((EXAMPLES_DIR / name).read_text(encoding="utf-8"))
+
+
+def natural_language_result(
+    plan: dict,
+    *,
+    planner_prompt: str = "planner prompt",
+    planner_raw_response: str | None = None,
+):
+    return replace(
+        compile_structured_workflow(plan, check=False),
+        planner_prompt=planner_prompt,
+        planner_raw_response=planner_raw_response if planner_raw_response is not None else json.dumps(plan),
+    )
 
 
 class RunServiceTests(unittest.TestCase):
@@ -145,15 +159,19 @@ class RunServiceTests(unittest.TestCase):
             service = RunService(RunRepository(Path(temp_dir) / "runs.sqlite3"))
             plan = load_example("rnaseq_deg_recipe_plan.json")
             request = NaturalLanguageRunRequest(request="Run RNA-seq DEG.", check=False)
-            plan_result = SimpleNamespace(
-                plan=plan,
-                planner_prompt="planner prompt",
-                raw_response=json.dumps(plan),
-            )
+            result = natural_language_result(plan)
 
-            with patch("src.services.run_service.create_natural_language_plan", return_value=plan_result):
+            with patch(
+                "src.services.run_service.workflow_service.plan_and_compile_workflow",
+                return_value=result,
+            ) as plan_and_compile:
                 accepted = service.create_natural_language_run(request)
                 service.execute_natural_language_run(accepted.run_id, request)
+
+            plan_and_compile.assert_called_once()
+            self.assertEqual(plan_and_compile.call_args.args, ("Run RNA-seq DEG.",))
+            self.assertEqual(plan_and_compile.call_args.kwargs["check"], False)
+            self.assertIn("event_callback", plan_and_compile.call_args.kwargs)
 
             snapshot = service.get_snapshot(accepted.run_id)
             self.assertIsNotNone(snapshot)
@@ -167,13 +185,12 @@ class RunServiceTests(unittest.TestCase):
             service = RunService(RunRepository(Path(temp_dir) / "runs.sqlite3"))
             plan = load_example("rnaseq_deg_recipe_plan.json")
             request = NaturalLanguageRunRequest(request="Run RNA-seq DEG.", check=False)
-            plan_result = SimpleNamespace(
-                plan=plan,
-                planner_prompt="",
-                raw_response="",
-            )
+            result = natural_language_result(plan, planner_prompt="", planner_raw_response="")
 
-            with patch("src.services.run_service.create_natural_language_plan", return_value=plan_result):
+            with patch(
+                "src.services.run_service.workflow_service.plan_and_compile_workflow",
+                return_value=result,
+            ):
                 accepted = service.create_natural_language_run(request)
                 service.execute_natural_language_run(accepted.run_id, request)
 
@@ -197,18 +214,25 @@ class RunServiceTests(unittest.TestCase):
             service = RunService(RunRepository(Path(temp_dir) / "runs.sqlite3"))
             plan = load_example("rnaseq_deg_recipe_plan.json")
             request = NaturalLanguageRunRequest(request="Run RNA-seq DEG.", check=False)
-            plan_result = SimpleNamespace(
-                plan=plan,
-                planner_prompt="planner prompt",
-                raw_response=json.dumps(plan),
-            )
 
-            with (
-                patch("src.services.run_service.create_natural_language_plan", return_value=plan_result),
-                patch(
-                    "src.services.run_service.workflow_service.compile_structured_workflow",
-                    side_effect=RuntimeError("compiler exploded"),
-                ),
+            def service_failure(*args, **kwargs):
+                event_callback = kwargs["event_callback"]
+                event_callback(
+                    "artifact.updated",
+                    "planner",
+                    "Recipe Tool Plan artifact updated.",
+                    {
+                        "plan": plan,
+                        "planner_prompt": "planner prompt",
+                        "planner_raw_response": json.dumps(plan),
+                    },
+                    {"artifact": "plan"},
+                )
+                raise RuntimeError("compiler exploded")
+
+            with patch(
+                "src.services.run_service.workflow_service.plan_and_compile_workflow",
+                side_effect=service_failure,
             ):
                 accepted = service.create_natural_language_run(request)
                 service.execute_natural_language_run(accepted.run_id, request)
@@ -236,7 +260,7 @@ class RunServiceTests(unittest.TestCase):
             request = NaturalLanguageRunRequest(request="Run RNA-seq DEG.", check=False)
 
             with patch(
-                "src.services.run_service.create_natural_language_plan",
+                "src.services.run_service.workflow_service.plan_and_compile_workflow",
                 side_effect=NaturalLanguagePlanningError("LLM planner JSON parsing failed"),
             ):
                 accepted = service.create_natural_language_run(request)

--- a/tests/test_workflow_service.py
+++ b/tests/test_workflow_service.py
@@ -331,6 +331,51 @@ class WorkflowServiceTests(unittest.TestCase):
         self.assertIn("workflow RNASeqDEG", result.wdl)
         self.assertEqual(len(fake_llm.prompts), 1)
 
+    def test_plan_and_compile_workflow_event_callback_covers_planner_and_compiler(self):
+        plan = load_example("rnaseq_deg_recipe_plan.json")
+        fake_llm = FakePlannerLlm(json.dumps(plan))
+        events = []
+
+        def event_callback(event_type, node, summary, state, payload):
+            events.append(
+                {
+                    "type": event_type,
+                    "node": node,
+                    "summary": summary,
+                    "state": state,
+                    "payload": payload or {},
+                }
+            )
+
+        result = plan_and_compile_workflow(
+            "Run bulk RNA-seq differential expression.",
+            llm=fake_llm,
+            check=False,
+            event_callback=event_callback,
+        )
+
+        self.assertTrue(result.succeeded, result.analysis_errors)
+        event_keys = [(event["type"], event["node"]) for event in events]
+        self.assertEqual(
+            event_keys[:4],
+            [
+                ("node.started", "planner"),
+                ("node.completed", "planner"),
+                ("artifact.updated", "planner"),
+                ("node.started", "compiler_graph"),
+            ],
+        )
+        self.assertIn(("node.started", "ir_normalizer"), event_keys)
+        artifact_events = [
+            event for event in events if event["type"] == "artifact.updated"
+        ]
+        self.assertIn({"artifact": "workflow_ir"}, [event["payload"] for event in artifact_events])
+        self.assertIn({"artifact": "wdl"}, [event["payload"] for event in artifact_events])
+        self.assertEqual(event_keys[-1], ("node.completed", "compiler_graph"))
+
+        plan_event = next(event for event in artifact_events if event["payload"] == {"artifact": "plan"})
+        self.assertEqual(plan_event["state"]["plan"], plan)
+
     def test_plan_and_compile_workflow_preserves_planner_error_classification(self):
         fake_llm = FakePlannerLlm("not json")
 


### PR DESCRIPTION
## Summary

- Route natural-language run execution through `plan_and_compile_workflow` instead of duplicating planner-to-compiler orchestration in run service.
- Add service event callbacks covering planner, orchestration delegate, and compiler graph events for run history/SSE bridging.
- Persist plan artifacts and planner trace updates from service events while keeping structured compilation on `compile_structured_workflow`.
- Update P1 documentation and test-case notes for the service-layer entrypoint boundary.

## Validation

- `.\.venv\Scripts\python.exe -m unittest discover -v`
- Result: `170 tests OK, skipped=2`