### PR TITLE
Add approved catalog retriever baseline

### DIFF
--- a/docs/test-cases.md
+++ b/docs/test-cases.md
@@ -1168,6 +1168,102 @@ report_files = flatten([qc.html_report, qc.json_report, quantify.log_file])
 
 - Catalog output tags 可以驱动 MultiQC 输入自动收集。
 
+## `tests/test_catalog_retriever.py`
+
+该文件验证第一版 Approved Catalog Retriever。Retriever 只在本地已批准
+Recipe / Tool Catalog 中做确定性词法召回，不访问网络、不引入 embedding
+服务，也不承担正式 Catalog 准入职责。
+
+### `test_retrieves_rnaseq_recipe_and_key_tools`
+
+输入：
+
+- 自然语言 query：包含 bulk RNA-seq differential expression、FASTQ QC、
+  adapter trimming、transcript quantification、Salmon aggregation、
+  transcript-to-gene counts、DESeq2 DEG 和 workflow summary report。
+- 当前正式 Recipe Catalog。
+- 当前正式 Tool Catalog。
+
+执行：
+
+- 调用 `retrieve_catalog_context(..., top_k_recipes=3, top_k_tools=8)`。
+
+期望输出：
+
+- `strategy == "lexical_v1"`。
+- `fallback_used == False`。
+- top recipe 为 `rnaseq_differential_expression`。
+- tool 召回结果包含 `fastp`、`salmon`、`tximport`、`deseq2` 和 `multiqc`。
+- recipe/tool 结果包含非零 `score`、`matched_terms`、`matched_fields` 和 `reason`。
+- tool 结果包含 `trust_status == "catalog-approved"`。
+
+覆盖点：
+
+- R1 retriever 可以从正式 catalog 中召回 RNA-seq DEG 所需 recipe 和关键工具。
+- 输出契约使用稳定 JSON key，便于后续 Planner、API、SSE 和前端复用。
+
+### `test_tokenizer_supports_rnaseq_variants_and_cjk_ngrams`
+
+输入：
+
+- 文本：`做差异表达 RNAseq`。
+
+执行：
+
+- 调用 `tokenize_for_retrieval(...)`。
+
+期望输出：
+
+- token 包含 `rna`、`seq` 和 `rnaseq`。
+- CJK token 包含单字 token 和重叠 2-gram，例如 `差`、`差异` 和 `表达`。
+
+覆盖点：
+
+- tokenization 在零新增依赖前提下支持常见 RNA-seq 写法和中文 query。
+
+### `test_no_match_fallback_records_reason_and_approved_tools`
+
+输入：
+
+- 无匹配 query：`zzzz qqqq`。
+- 当前正式 Recipe Catalog。
+- 当前正式 Tool Catalog。
+
+执行：
+
+- 调用 `retrieve_catalog_context(..., top_k_recipes=2, top_k_tools=3)`。
+
+期望输出：
+
+- `fallback_used == True`。
+- `fallback_reason` 说明 recipe 和 tool recall 均无匹配。
+- fallback recipe/tool 结果的 `score == 0.0`，`matched_terms == []`。
+- fallback tool 仍包含 `trust_status == "catalog-approved"`。
+
+覆盖点：
+
+- 低置信度召回不会静默返回空结果，会记录可审计 fallback 原因。
+- fallback 结果仍限定在 approved local catalog 内。
+
+### `test_rejects_empty_query`
+
+输入：
+
+- 空白 query：`"  "`。
+
+执行：
+
+- 调用 `retrieve_catalog_context(...)`。
+
+期望输出：
+
+- 抛出 `ValueError`。
+- 错误消息包含 `query must not be empty`。
+
+覆盖点：
+
+- Retriever 在进入 scoring 前拒绝不可分析的空 query。
+
 ## `tests/test_catalog_service.py`
 
 该文件验证 W0 catalog 查询服务。服务层返回 JSON-ready 的 recipe/tool 记录，供 FastAPI 的 catalog 查询端点复用。
@@ -2951,6 +3047,7 @@ npm run test:graph
 - Catalog runtime docker 必填约束。
 - Recipe Tool Plan 到 Workflow IR 的 resolver 主路径。
 - Catalog 查询服务的 recipe/tool JSON-ready 输出。
+- Approved Catalog Retriever 的词法召回、CJK tokenization、fallback 原因和 JSON-ready 输出契约。
 - Analyzer 对引用、optional input、scatter output 类型提升的处理。
 - Renderer 对 call、scatter、array flatten、workflow output 和 task 的 WDL 渲染。
 - Deterministic repairer 对 call 顺序和 output 字面量的安全修复。

--- a/src/catalog/__init__.py
+++ b/src/catalog/__init__.py
@@ -1,4 +1,5 @@
 from src.catalog.loader import ToolCatalog, load_tool_catalog
+from src.catalog.retriever import retrieve_catalog_context, tokenize_for_retrieval
 from src.catalog.resolver import resolve_tool_plan
 from src.catalog.schema import ToolSpec
 
@@ -7,5 +8,7 @@ __all__ = [
     "ToolCatalog",
     "ToolSpec",
     "load_tool_catalog",
+    "retrieve_catalog_context",
     "resolve_tool_plan",
+    "tokenize_for_retrieval",
 ]

--- a/src/catalog/retriever.py
+++ b/src/catalog/retriever.py
@@ -1,0 +1,380 @@
+"""Deterministic retrieval over approved local recipe and tool catalogs."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from typing import Any, TypeVar
+
+from src.catalog.loader import ToolCatalog
+from src.catalog.schema import ToolSpec
+from src.recipes.loader import RecipeCatalog
+from src.recipes.schema import RecipeSpec
+
+
+LEXICAL_RETRIEVER_STRATEGY = "lexical_v1"
+CATALOG_APPROVED_TRUST_STATUS = "catalog-approved"
+_TOKEN_PATTERN = re.compile(r"[a-z0-9]+")
+
+
+@dataclass(frozen=True)
+class _WeightedField:
+    name: str
+    text: str
+    weight: float
+
+
+@dataclass(frozen=True)
+class _ScoredItem:
+    item: RecipeSpec | ToolSpec
+    score: float
+    matched_terms: list[str]
+    matched_fields: list[str]
+
+
+_CatalogItem = TypeVar("_CatalogItem", RecipeSpec, ToolSpec)
+
+
+def retrieve_catalog_context(
+    query: str,
+    tool_catalog: ToolCatalog,
+    recipe_catalog: RecipeCatalog,
+    top_k_recipes: int = 3,
+    top_k_tools: int = 8,
+) -> dict[str, Any]:
+    """Retrieve approved recipe and tool candidates for a natural-language query."""
+    normalized_query = query.strip()
+    if not normalized_query:
+        raise ValueError("query must not be empty")
+    if top_k_recipes < 1:
+        raise ValueError("top_k_recipes must be >= 1")
+    if top_k_tools < 1:
+        raise ValueError("top_k_tools must be >= 1")
+
+    query_tokens = tokenize_for_retrieval(normalized_query)
+    recipe_matches = _rank_recipes(query_tokens, recipe_catalog)[:top_k_recipes]
+    tool_matches = _rank_tools(query_tokens, tool_catalog)[:top_k_tools]
+
+    fallback_used = False
+    fallback_reasons: list[str] = []
+
+    if not recipe_matches:
+        fallback_used = True
+        fallback_reasons.append("recipe recall returned no matches; used complete recipe catalog")
+        recipes = _fallback_recipe_results(recipe_catalog, top_k_recipes)
+    else:
+        recipes = [_recipe_result(match) for match in recipe_matches]
+
+    if not tool_matches:
+        fallback_used = True
+        fallback_tools = _allowed_tools_from_recipe_results(recipes, recipe_catalog, tool_catalog)
+        if fallback_tools:
+            fallback_reasons.append(
+                "tool recall returned no matches; used allowed tools from retrieved recipes"
+            )
+            tools = [_fallback_tool_result(tool) for tool in fallback_tools[:top_k_tools]]
+        else:
+            fallback_reasons.append("tool recall returned no matches; used complete tool catalog")
+            tools = _fallback_tool_results(tool_catalog, top_k_tools)
+    else:
+        tools = [_tool_result(match) for match in tool_matches]
+
+    return {
+        "query": normalized_query,
+        "strategy": LEXICAL_RETRIEVER_STRATEGY,
+        "recipes": recipes,
+        "tools": tools,
+        "fallback_used": fallback_used,
+        "fallback_reason": "; ".join(fallback_reasons) if fallback_reasons else None,
+    }
+
+
+def tokenize_for_retrieval(text: str) -> list[str]:
+    """Tokenize catalog text and natural-language queries without external dependencies."""
+    normalized = _normalize_common_variants(text.lower())
+    tokens = [token for token in _TOKEN_PATTERN.findall(normalized) if len(token) > 1]
+
+    for cjk_sequence in _cjk_sequences(normalized):
+        tokens.extend(cjk_sequence)
+        tokens.extend(
+            cjk_sequence[index : index + 2]
+            for index in range(0, max(len(cjk_sequence) - 1, 0))
+        )
+
+    return _unique_preserving_order(tokens)
+
+
+def _normalize_common_variants(text: str) -> str:
+    return re.sub(r"\brnaseq\b", "rna seq rnaseq", text)
+
+
+def _cjk_sequences(text: str) -> list[str]:
+    sequences: list[str] = []
+    current: list[str] = []
+    for char in text:
+        if _is_cjk(char):
+            current.append(char)
+            continue
+        if current:
+            sequences.append("".join(current))
+            current = []
+    if current:
+        sequences.append("".join(current))
+    return sequences
+
+
+def _is_cjk(char: str) -> bool:
+    codepoint = ord(char)
+    return (
+        0x3400 <= codepoint <= 0x4DBF
+        or 0x4E00 <= codepoint <= 0x9FFF
+        or 0x3040 <= codepoint <= 0x30FF
+        or 0xAC00 <= codepoint <= 0xD7AF
+    )
+
+
+def _rank_recipes(query_tokens: list[str], recipe_catalog: RecipeCatalog) -> list[_ScoredItem]:
+    return _rank_items(
+        recipe_catalog.all(),
+        query_tokens,
+        fields_for_item=_recipe_fields,
+        stable_key=lambda recipe: (recipe.id,),
+    )
+
+
+def _rank_tools(query_tokens: list[str], tool_catalog: ToolCatalog) -> list[_ScoredItem]:
+    return _rank_items(
+        tool_catalog.all(),
+        query_tokens,
+        fields_for_item=_tool_fields,
+        stable_key=lambda tool: (tool.id, _version_sort_key(tool.version)),
+    )
+
+
+def _rank_items(
+    items: Sequence[_CatalogItem],
+    query_tokens: list[str],
+    *,
+    fields_for_item: Callable[[_CatalogItem], list[_WeightedField]],
+    stable_key: Callable[[_CatalogItem], tuple[Any, ...]],
+) -> list[_ScoredItem]:
+    matches = [
+        scored
+        for scored in (
+            _score_item(item, query_tokens, fields_for_item(item))
+            for item in items
+        )
+        if scored.score > 0
+    ]
+    return sorted(matches, key=lambda match: (-match.score, *stable_key(match.item)))
+
+
+def _score_item(
+    item: RecipeSpec | ToolSpec,
+    query_tokens: list[str],
+    fields: list[_WeightedField],
+) -> _ScoredItem:
+    score = 0.0
+    matched_terms: list[str] = []
+    matched_fields: list[str] = []
+
+    for field in fields:
+        field_tokens = set(tokenize_for_retrieval(field.text))
+        field_matches = [token for token in query_tokens if token in field_tokens]
+        if not field_matches:
+            continue
+        unique_matches = _unique_preserving_order(field_matches)
+        score += len(unique_matches) * field.weight
+        matched_terms.extend(unique_matches)
+        matched_fields.append(field.name)
+
+    return _ScoredItem(
+        item=item,
+        score=score,
+        matched_terms=_unique_preserving_order(matched_terms),
+        matched_fields=_unique_preserving_order(matched_fields),
+    )
+
+
+def _recipe_fields(recipe: RecipeSpec) -> list[_WeightedField]:
+    fields = [
+        _WeightedField("id", recipe.id, 5.0),
+        _WeightedField("name", recipe.name, 4.0),
+        _WeightedField("aliases", " ".join(recipe.aliases), 5.0),
+        _WeightedField("description", recipe.description, 3.0),
+        _WeightedField("required_inputs.name", " ".join(recipe.required_inputs), 2.0),
+        _WeightedField(
+            "required_inputs.description",
+            " ".join(
+                spec.description or ""
+                for spec in recipe.required_inputs.values()
+            ),
+            1.0,
+        ),
+        _WeightedField("steps.id", " ".join(step.id for step in recipe.steps), 2.0),
+        _WeightedField("steps.role", " ".join(step.role for step in recipe.steps), 4.0),
+        _WeightedField(
+            "steps.allowed_tools",
+            " ".join(tool_id for step in recipe.steps for tool_id in step.allowed_tools),
+            2.0,
+        ),
+    ]
+    return fields
+
+
+def _tool_fields(tool: ToolSpec) -> list[_WeightedField]:
+    return [
+        _WeightedField("id", tool.id, 5.0),
+        _WeightedField("version", tool.version, 0.5),
+        _WeightedField("aliases", " ".join(tool.aliases), 5.0),
+        _WeightedField("description", tool.description, 3.0),
+        _WeightedField("inputs.name", " ".join(tool.inputs), 2.0),
+        _WeightedField("inputs.type", " ".join(spec.type for spec in tool.inputs.values()), 1.0),
+        _WeightedField(
+            "inputs.description",
+            " ".join(spec.description or "" for spec in tool.inputs.values()),
+            1.0,
+        ),
+        _WeightedField("params.name", " ".join(tool.params), 2.0),
+        _WeightedField("params.type", " ".join(spec.type for spec in tool.params.values()), 1.0),
+        _WeightedField(
+            "params.description",
+            " ".join(spec.description or "" for spec in tool.params.values()),
+            1.0,
+        ),
+        _WeightedField("outputs.name", " ".join(tool.outputs), 2.0),
+        _WeightedField(
+            "outputs.description",
+            " ".join(spec.description or "" for spec in tool.outputs.values()),
+            1.0,
+        ),
+        _WeightedField(
+            "outputs.tags",
+            " ".join(tag for spec in tool.outputs.values() for tag in spec.tags),
+            2.0,
+        ),
+        _WeightedField("runtime.docker", tool.runtime.docker or "", 0.5),
+    ]
+
+
+def _recipe_result(match: _ScoredItem) -> dict[str, Any]:
+    recipe = _as_recipe(match.item)
+    return {
+        "id": recipe.id,
+        "score": _json_score(match.score),
+        "matched_terms": match.matched_terms,
+        "matched_fields": match.matched_fields,
+        "reason": _match_reason("recipe", match.matched_terms, match.matched_fields),
+    }
+
+
+def _tool_result(match: _ScoredItem) -> dict[str, Any]:
+    tool = _as_tool(match.item)
+    return {
+        "id": tool.id,
+        "version": tool.version,
+        "score": _json_score(match.score),
+        "matched_terms": match.matched_terms,
+        "matched_fields": match.matched_fields,
+        "trust_status": CATALOG_APPROVED_TRUST_STATUS,
+        "reason": _match_reason("tool", match.matched_terms, match.matched_fields),
+    }
+
+
+def _fallback_recipe_results(recipe_catalog: RecipeCatalog, top_k: int) -> list[dict[str, Any]]:
+    return [
+        _fallback_recipe_result(recipe)
+        for recipe in sorted(recipe_catalog.all(), key=lambda recipe: recipe.id)[:top_k]
+    ]
+
+
+def _fallback_tool_results(tool_catalog: ToolCatalog, top_k: int) -> list[dict[str, Any]]:
+    return [
+        _fallback_tool_result(tool)
+        for tool in sorted(tool_catalog.all(), key=lambda tool: (tool.id, _version_sort_key(tool.version)))[:top_k]
+    ]
+
+
+def _fallback_recipe_result(recipe: RecipeSpec) -> dict[str, Any]:
+    return {
+        "id": recipe.id,
+        "score": 0.0,
+        "matched_terms": [],
+        "matched_fields": [],
+        "reason": "Fallback result from approved recipe catalog.",
+    }
+
+
+def _fallback_tool_result(tool: ToolSpec) -> dict[str, Any]:
+    return {
+        "id": tool.id,
+        "version": tool.version,
+        "score": 0.0,
+        "matched_terms": [],
+        "matched_fields": [],
+        "trust_status": CATALOG_APPROVED_TRUST_STATUS,
+        "reason": "Fallback result from approved tool catalog.",
+    }
+
+
+def _allowed_tools_from_recipe_results(
+    recipes: list[dict[str, Any]],
+    recipe_catalog: RecipeCatalog,
+    tool_catalog: ToolCatalog,
+) -> list[ToolSpec]:
+    allowed_tool_ids: set[str] = set()
+    for recipe_result in recipes:
+        try:
+            recipe = recipe_catalog.get(str(recipe_result["id"]))
+        except KeyError:
+            continue
+        allowed_tool_ids.update(tool_id for step in recipe.steps for tool_id in step.allowed_tools)
+
+    return [
+        tool
+        for tool in sorted(tool_catalog.all(), key=lambda tool: (tool.id, _version_sort_key(tool.version)))
+        if tool.id in allowed_tool_ids
+    ]
+
+
+def _match_reason(kind: str, matched_terms: list[str], matched_fields: list[str]) -> str:
+    terms = ", ".join(matched_terms[:6])
+    fields = ", ".join(matched_fields[:4])
+    return f"Matched approved catalog {kind} fields ({fields}) using terms: {terms}."
+
+
+def _json_score(score: float) -> float:
+    return round(score, 3)
+
+
+def _unique_preserving_order(values: list[str]) -> list[str]:
+    unique: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        if value in seen:
+            continue
+        unique.append(value)
+        seen.add(value)
+    return unique
+
+
+def _version_sort_key(version: str) -> tuple[Any, ...]:
+    parts: list[Any] = []
+    for part in re.split(r"([0-9]+)", version):
+        if not part:
+            continue
+        parts.append(int(part) if part.isdigit() else part)
+    return tuple(parts)
+
+
+def _as_recipe(item: RecipeSpec | ToolSpec) -> RecipeSpec:
+    if isinstance(item, RecipeSpec):
+        return item
+    raise TypeError("expected RecipeSpec")
+
+
+def _as_tool(item: RecipeSpec | ToolSpec) -> ToolSpec:
+    if isinstance(item, ToolSpec):
+        return item
+    raise TypeError("expected ToolSpec")

--- a/tests/test_catalog_retriever.py
+++ b/tests/test_catalog_retriever.py
@@ -1,0 +1,91 @@
+import unittest
+
+from src.catalog import load_tool_catalog, retrieve_catalog_context, tokenize_for_retrieval
+from src.recipes import load_recipe_catalog
+
+
+class CatalogRetrieverTests(unittest.TestCase):
+    def setUp(self):
+        self.tool_catalog = load_tool_catalog()
+        self.recipe_catalog = load_recipe_catalog(tool_catalog=self.tool_catalog)
+
+    def test_retrieves_rnaseq_recipe_and_key_tools(self):
+        result = retrieve_catalog_context(
+            (
+                "Build a bulk RNA-seq differential expression workflow with FASTQ QC, "
+                "adapter trimming, transcript quantification, Salmon aggregation, "
+                "transcript to gene counts, DESeq2 DEG, and workflow summary report."
+            ),
+            self.tool_catalog,
+            self.recipe_catalog,
+            top_k_recipes=3,
+            top_k_tools=8,
+        )
+
+        self.assertEqual(result["strategy"], "lexical_v1")
+        self.assertFalse(result["fallback_used"])
+        self.assertIsNone(result["fallback_reason"])
+        self.assertEqual(result["recipes"][0]["id"], "rnaseq_differential_expression")
+
+        tool_ids = {tool["id"] for tool in result["tools"]}
+        self.assertTrue(
+            {"fastp", "salmon", "tximport", "deseq2", "multiqc"}.issubset(tool_ids),
+            result["tools"],
+        )
+
+        recipe = result["recipes"][0]
+        self.assertGreater(recipe["score"], 0)
+        self.assertTrue(recipe["matched_terms"])
+        self.assertTrue(recipe["matched_fields"])
+        self.assertIn("Matched approved catalog recipe", recipe["reason"])
+
+        deseq2 = next(tool for tool in result["tools"] if tool["id"] == "deseq2")
+        self.assertGreater(deseq2["score"], 0)
+        self.assertIn("differential", deseq2["matched_terms"])
+        self.assertTrue(deseq2["matched_fields"])
+        self.assertEqual(deseq2["trust_status"], "catalog-approved")
+        self.assertIn("Matched approved catalog tool", deseq2["reason"])
+
+    def test_tokenizer_supports_rnaseq_variants_and_cjk_ngrams(self):
+        tokens = tokenize_for_retrieval("做差异表达 RNAseq")
+
+        self.assertIn("rna", tokens)
+        self.assertIn("seq", tokens)
+        self.assertIn("rnaseq", tokens)
+        self.assertIn("差", tokens)
+        self.assertIn("差异", tokens)
+        self.assertIn("表达", tokens)
+
+    def test_no_match_fallback_records_reason_and_approved_tools(self):
+        result = retrieve_catalog_context(
+            "zzzz qqqq",
+            self.tool_catalog,
+            self.recipe_catalog,
+            top_k_recipes=2,
+            top_k_tools=3,
+        )
+
+        self.assertTrue(result["fallback_used"])
+        self.assertIn("recipe recall returned no matches", result["fallback_reason"])
+        self.assertIn("tool recall returned no matches", result["fallback_reason"])
+        self.assertGreaterEqual(len(result["recipes"]), 1)
+        self.assertEqual(result["recipes"][0]["score"], 0.0)
+        self.assertEqual(result["recipes"][0]["matched_terms"], [])
+        self.assertIn("Fallback result", result["recipes"][0]["reason"])
+        self.assertEqual(len(result["tools"]), 3)
+        for tool in result["tools"]:
+            self.assertEqual(tool["trust_status"], "catalog-approved")
+            self.assertEqual(tool["matched_terms"], [])
+            self.assertIn("Fallback result", tool["reason"])
+
+    def test_rejects_empty_query(self):
+        with self.assertRaisesRegex(ValueError, "query must not be empty"):
+            retrieve_catalog_context(
+                "  ",
+                self.tool_catalog,
+                self.recipe_catalog,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add a deterministic approved catalog retriever for local recipe/tool metadata.
- Return JSON-ready retrieval artifacts with scores, matched terms, matched fields, reasons, trust status, and fallback details.
- Cover RNA-seq DEG retrieval, CJK/RNA-seq tokenization, fallback behavior, and empty-query validation.
- Document the new retriever test cases.

## Scope
- This PR implements the R1 retriever core only.
- Planner prompt integration, run artifacts/SSE, API models, and frontend display remain follow-up work.
- No embedding service, vector database, or network dependency is introduced.

## Validation
- `.\.venv\Scripts\python.exe -m unittest tests.test_catalog_retriever tests.test_catalog_service tests.test_catalog -v`