### PR TITLE
Lock CLI and API routing boundaries

### DIFF
--- a/docs/p1-orchestration-graph-plan.md
+++ b/docs/p1-orchestration-graph-plan.md
@@ -256,6 +256,20 @@ API 路由：
 - `/api/compile` 不触发 Planner。
 - `/api/runs` 的历史快照可以看到 Planner plan 和 Compiler artifacts。
 
+已完成内容：
+
+- `--prompt` 与 `--prompt-file` 通过 `plan_and_compile_workflow` 进入 Orchestration Graph。
+- `--input` 通过 `compile_structured_workflow` 直接进入 Compiler Graph，不触发自然语言 Planner。
+- `POST /api/runs` 只创建并执行自然语言 run，后台进入 Orchestration Graph。
+- `POST /api/compile` 只创建并执行结构化 compile run，后台进入 Compiler Graph。
+- `GET /api/runs/{run_id}` 保留 run service 持久化的 Planner plan、Workflow IR、WDL 和 diagnostics。
+
+已满足验收：
+
+- CLI stdout/stderr 契约已由 `tests/test_cli.py` 覆盖。
+- `/api/compile` 与 `/api/runs` 的分层差异已由 `tests/api/test_routes.py` 覆盖。
+- 自然语言 run 的历史快照 artifacts 暴露已由 API route snapshot 测试覆盖。
+
 ### P1.7 事件与 artifacts
 
 目标：让前端和历史详情能够展示自然语言到编译结果的完整链路。

--- a/docs/test-cases.md
+++ b/docs/test-cases.md
@@ -48,11 +48,11 @@ powershell -ExecutionPolicy Bypass -File scripts\check_p0.ps1 `
 - `tests/test_tiny_run.py`：没有 miniwdl、Docker/Podman、本地镜像或 tiny 输入文件时跳过真实 tiny run。
 - `tests/test_container_build.py`：纯单元测试，不调用 Docker；只验证容器构建脚本的 tag contract。
 
-当前 P1.5 Service 层入口收口后的最近一次完整验证结果：
+当前 P1.6 CLI/API 路由收口后的最近一次完整验证结果：
 
 ```text
 .\.venv\Scripts\python.exe -m unittest discover -v
-Ran 170 tests
+Ran 172 tests
 OK (skipped=2)
 ```
 
@@ -501,6 +501,7 @@ OK (skipped=2)
 - `examples/rnaseq_deg_recipe_plan.json`
 - mock `run_service.create_structured_compile_run(...)` 返回 `RunAcceptedResponse`。
 - mock `run_service.execute_structured_compile_run(...)` 作为后台任务。
+- mock 自然语言 run service 方法，验证不会被调用。
 - HTTP 请求：`POST /api/compile`
 
 执行：
@@ -512,11 +513,13 @@ OK (skipped=2)
 - HTTP status 为 `202`。
 - response 包含 `run_id`、`status == "created"` 和 `events_url`。
 - route 调用 run 创建 service，并安排结构化编译后台执行。
+- 自然语言 run service 没有被调用。
 
 覆盖点：
 
 - 结构化编译 endpoint 复用 run service。
 - API 层不直接调用 Analyzer / Renderer / Checker。
+- `/api/compile` 保持结构化入口边界，不触发自然语言 Planner 路径。
 
 ### `test_compile_rejects_empty_payload`
 
@@ -543,6 +546,7 @@ OK (skipped=2)
 
 - mock `run_service.create_natural_language_run(...)` 返回 `RunAcceptedResponse`。
 - mock `run_service.execute_natural_language_run(...)` 作为后台任务。
+- mock 结构化 compile run service 方法，验证不会被调用。
 - HTTP 请求：`POST /api/runs`
 - 请求体：`{"request": "Run RNA-seq DEG.", "check": false}`
 
@@ -555,12 +559,14 @@ OK (skipped=2)
 - HTTP status 为 `202`。
 - response 包含 `run_id`、`status == "created"` 和 `events_url`。
 - route 调用 run 创建 service，并安排自然语言 run 后台执行。
+- 结构化 compile run service 没有被调用。
 
 覆盖点：
 
 - 自然语言 run endpoint 复用 run service。
 - FastAPI route 只负责 HTTP 输入输出和后台任务调度。
 - W2 `/api/runs` 是异步 run 创建接口，不直接返回编译结果。
+- `/api/runs` 保持自然语言 Orchestration Graph 入口边界。
 
 ### `test_create_run_passes_requested_planner_model`
 
@@ -612,6 +618,7 @@ OK (skipped=2)
 输入：
 
 - mock `run_service.get_snapshot(...)` 返回 `WorkflowRunSnapshotResponse`。
+- snapshot 包含自然语言 run 的 plan、Workflow IR、WDL 和 diagnostics。
 - HTTP 请求：`GET /api/runs/run_123`
 
 执行：
@@ -622,10 +629,14 @@ OK (skipped=2)
 
 - HTTP status 为 `200`。
 - response `run_id == "run_123"`。
+- response 保留 `kind == "natural_language"`。
+- response artifacts 包含 Planner plan、Compiler Workflow IR 和 WDL。
+- response diagnostics 保留 `succeeded` 与 `check_performed`。
 
 覆盖点：
 
 - run snapshot endpoint 从 run service 读取持久化快照。
+- 自然语言 run history 可通过 API route 暴露 Planner plan 和 Compiler artifacts。
 
 ### `test_stream_run_events`
 
@@ -2518,6 +2529,37 @@ qc.html_report + qc.json_report
 - `--print-plan` 将 plan 输出到 stdout。
 - `--output` 将 WDL 写入文件。
 - `--no-check` 跳过 WDL checker。
+
+### `test_cli_prompt_file_uses_natural_language_service`
+
+输入：
+
+- CLI args：
+
+```text
+--prompt-file examples/rnaseq_deg_request.txt
+--output <tmp>/rnaseq_deg.wdl
+--no-check
+```
+
+- mock `main.plan_and_compile_workflow` 返回合法 RNA-seq plan 的编译结果。
+
+执行：
+
+- 调用 `cli.main(...)`。
+
+期望输出：
+
+- exit code 为 `0`。
+- `plan_and_compile_workflow` 被调用一次，参数为 prompt 文件内容、默认 planner model 和 `check=False`。
+- stdout 为空，因为 WDL 写入了 `--output` 指定文件，且没有请求打印 plan 或 IR。
+- 输出文件 `<tmp>/rnaseq_deg.wdl` 包含 `workflow RNASeqDEG`。
+
+覆盖点：
+
+- `--prompt-file` 和 `--prompt` 一样走自然语言 workflow service。
+- prompt 文件路径不会被误当作结构化 `--input`。
+- 指定 `--output` 时，CLI 不向 stdout 写入非请求 artifact。
 
 ### `test_cli_structured_input_uses_structured_service_without_planner`
 

--- a/tests/api/test_routes.py
+++ b/tests/api/test_routes.py
@@ -6,7 +6,15 @@ from unittest.mock import patch
 from fastapi.testclient import TestClient
 
 from src.api.app import create_app
-from src.api.models import RunAcceptedResponse, RunListResponse, RunStatus, RunSummary, WorkflowRunSnapshotResponse
+from src.api.models import (
+    DiagnosticReport,
+    RunAcceptedResponse,
+    RunListResponse,
+    RunStatus,
+    RunSummary,
+    WorkflowArtifacts,
+    WorkflowRunSnapshotResponse,
+)
 from src.services.catalog_service import get_recipe, get_tool, list_recipes, list_tools
 
 
@@ -107,6 +115,8 @@ class ApiRouteTests(unittest.TestCase):
         with (
             patch("src.api.routes.workflows.run_service.create_structured_compile_run", return_value=accepted) as create_run,
             patch("src.api.routes.workflows.run_service.execute_structured_compile_run") as execute_run,
+            patch("src.api.routes.workflows.run_service.create_natural_language_run") as create_natural_language_run,
+            patch("src.api.routes.workflows.run_service.execute_natural_language_run") as execute_natural_language_run,
         ):
             response = self.client.post(
                 "/api/compile",
@@ -116,6 +126,8 @@ class ApiRouteTests(unittest.TestCase):
         self.assertEqual(response.status_code, 202)
         create_run.assert_called_once()
         execute_run.assert_called_once()
+        create_natural_language_run.assert_not_called()
+        execute_natural_language_run.assert_not_called()
         body = response.json()
         self.assertEqual(body["run_id"], "run_123")
         self.assertEqual(body["status"], "created")
@@ -139,6 +151,8 @@ class ApiRouteTests(unittest.TestCase):
         with (
             patch("src.api.routes.workflows.run_service.create_natural_language_run", return_value=accepted) as create_run,
             patch("src.api.routes.workflows.run_service.execute_natural_language_run") as execute_run,
+            patch("src.api.routes.workflows.run_service.create_structured_compile_run") as create_structured_run,
+            patch("src.api.routes.workflows.run_service.execute_structured_compile_run") as execute_structured_run,
         ):
             response = self.client.post(
                 "/api/runs",
@@ -148,6 +162,8 @@ class ApiRouteTests(unittest.TestCase):
         self.assertEqual(response.status_code, 202)
         create_run.assert_called_once()
         execute_run.assert_called_once()
+        create_structured_run.assert_not_called()
+        execute_structured_run.assert_not_called()
         self.assertEqual(response.json()["run_id"], "run_456")
 
     def test_create_run_passes_requested_planner_model(self):
@@ -210,11 +226,24 @@ class ApiRouteTests(unittest.TestCase):
         self.assertEqual(body["total"], 42)
 
     def test_get_run_returns_snapshot(self):
+        plan = load_example("rnaseq_deg_recipe_plan.json")
         snapshot = WorkflowRunSnapshotResponse(
             run_id="run_123",
             status=RunStatus.SUCCEEDED,
+            kind="natural_language",
             request="Run RNA-seq DEG.",
             events_url="/api/runs/run_123/events",
+            artifacts=WorkflowArtifacts(
+                plan=plan,
+                workflow_ir={"workflow": {"name": "RNASeqDEG"}},
+                wdl="version 1.0\nworkflow RNASeqDEG {}",
+            ),
+            diagnostics=DiagnosticReport(
+                validation_message="WDL syntax validation skipped (--no-check).",
+                is_valid=False,
+                succeeded=True,
+                check_performed=False,
+            ),
         )
 
         with patch("src.api.routes.workflows.run_service.get_snapshot", return_value=snapshot) as get_snapshot:
@@ -222,7 +251,14 @@ class ApiRouteTests(unittest.TestCase):
 
         self.assertEqual(response.status_code, 200)
         get_snapshot.assert_called_once_with("run_123")
-        self.assertEqual(response.json()["run_id"], "run_123")
+        body = response.json()
+        self.assertEqual(body["run_id"], "run_123")
+        self.assertEqual(body["kind"], "natural_language")
+        self.assertEqual(body["artifacts"]["plan"]["workflow"]["recipe"], "rnaseq_differential_expression")
+        self.assertEqual(body["artifacts"]["workflow_ir"]["workflow"]["name"], "RNASeqDEG")
+        self.assertIn("workflow RNASeqDEG", body["artifacts"]["wdl"])
+        self.assertTrue(body["diagnostics"]["succeeded"])
+        self.assertFalse(body["diagnostics"]["check_performed"])
 
     def test_get_run_not_found(self):
         with patch("src.api.routes.workflows.run_service.get_snapshot", return_value=None):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -54,6 +54,33 @@ class CliTests(unittest.TestCase):
             self.assertIn('"recipe": "rnaseq_differential_expression"', stdout.getvalue())
             self.assertIn("workflow RNASeqDEG", output_path.read_text(encoding="utf-8"))
 
+    def test_cli_prompt_file_uses_natural_language_service(self):
+        planned = cli.load_workflow_input(EXAMPLES_DIR / "rnaseq_deg_recipe_plan.json")
+        result = compile_structured_workflow(planned, check=False)
+        request = (EXAMPLES_DIR / "rnaseq_deg_request.txt").read_text(encoding="utf-8").strip()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "rnaseq_deg.wdl"
+            stdout = io.StringIO()
+            stderr = io.StringIO()
+
+            with patch("main.plan_and_compile_workflow", return_value=result) as service:
+                with redirect_stdout(stdout), redirect_stderr(stderr):
+                    exit_code = cli.main(
+                        [
+                            "--prompt-file",
+                            str(EXAMPLES_DIR / "rnaseq_deg_request.txt"),
+                            "--output",
+                            str(output_path),
+                            "--no-check",
+                        ]
+                    )
+
+            self.assertEqual(exit_code, 0, stderr.getvalue())
+            service.assert_called_once_with(request, model=cli.DEFAULT_PLANNER_MODEL, check=False)
+            self.assertEqual(stdout.getvalue(), "")
+            self.assertIn("workflow RNASeqDEG", output_path.read_text(encoding="utf-8"))
+
     def test_cli_structured_input_uses_structured_service_without_planner(self):
         planned = cli.load_workflow_input(EXAMPLES_DIR / "rnaseq_deg_recipe_plan.json")
         result = compile_structured_workflow(planned, check=False)


### PR DESCRIPTION
## Summary

- Add CLI coverage for `--prompt-file` to lock natural-language routing through `plan_and_compile_workflow`.
- Strengthen API route tests so `/api/compile` stays on the structured compile path and `/api/runs` stays on the natural-language run path.
- Verify run snapshots expose Planner plan, Workflow IR, WDL, and diagnostics through the API route.
- Update P1.6 planning and test-case documentation with the completed routing boundary coverage.

## Validation

- `.\.venv\Scripts\python.exe -m unittest tests.test_cli tests.api.test_routes -v`
- `.\.venv\Scripts\python.exe -m unittest discover -v`
- Result: `172 tests OK, skipped=2`
- `git diff --check`