### PR TITLE
Stabilize run events and artifact history

### DIFF
--- a/docs/p1-orchestration-graph-plan.md
+++ b/docs/p1-orchestration-graph-plan.md
@@ -300,6 +300,7 @@ node.completed renderer
 artifact.updated wdl
 node.started checker
 validation.completed
+artifact.updated diagnostics
 run.completed
 ```
 
@@ -308,6 +309,20 @@ run.completed
 - 成功 run 和失败 run 都能回放关键阶段。
 - 修复发生时，`workflow_ir` artifact 更新先于 `repair.applied` 事件。
 - 事件 payload 使用结构化字段，不依赖前端拼装业务语义。
+
+已完成内容：
+
+- run service 在 diagnostics 保存后、`run.completed` 前发出 `artifact.updated` diagnostics 事件。
+- diagnostics 事件 payload 使用结构化字段记录 artifact 名称、错误/警告/修复计数、校验状态和成功状态。
+- 成功自然语言 run 的 planner、compiler delegate、Compiler Graph、artifact 和 diagnostics 事件可按历史顺序回放。
+- Planner 失败不会写入 plan、Workflow IR 或 WDL artifacts，只会记录失败 diagnostics。
+- Compiler 失败时可保留已发出的 plan / Workflow IR partial artifacts，并记录最终 diagnostics。
+
+已满足验收：
+
+- 成功 run 和失败 run 的关键阶段回放已由 `tests/test_run_service.py` 覆盖。
+- `workflow_ir` artifact 更新先于 `repair.applied` 的持久化顺序已由 run service repair 测试覆盖。
+- artifact 与 diagnostics 事件 payload 结构化字段已由 run service 测试覆盖。
 
 ### P1.8 测试与文档
 

--- a/docs/test-cases.md
+++ b/docs/test-cases.md
@@ -48,11 +48,11 @@ powershell -ExecutionPolicy Bypass -File scripts\check_p0.ps1 `
 - `tests/test_tiny_run.py`：没有 miniwdl、Docker/Podman、本地镜像或 tiny 输入文件时跳过真实 tiny run。
 - `tests/test_container_build.py`：纯单元测试，不调用 Docker；只验证容器构建脚本的 tag contract。
 
-当前 P1.6 CLI/API 路由收口后的最近一次完整验证结果：
+当前 P1.7 事件与 artifacts 收口后的最近一次完整验证结果：
 
 ```text
 .\.venv\Scripts\python.exe -m unittest discover -v
-Ran 172 tests
+Ran 178 tests
 OK (skipped=2)
 ```
 
@@ -717,10 +717,37 @@ OK (skipped=2)
 - Workflow IR 名称为 `RNASeqDEG`。
 - WDL 包含 `workflow RNASeqDEG`。
 - events 包含 `run.created`、`artifact.updated`，最后一条为 `run.completed`。
+- 倒数第二条事件为 `artifact.updated` diagnostics，并包含 `artifact == "diagnostics"` 与 `succeeded == true`。
 
 覆盖点：
 
 - 结构化编译 run 会持久化详情页所需元数据、产物、诊断和事件回放记录。
+- diagnostics 保存后会通过结构化 artifact 事件通知历史/SSE 消费方刷新。
+
+### `test_structured_compile_run_replays_repair_artifact_before_repair_event`
+
+输入：
+
+- 从 `examples/rnaseq_workflow_ir.json` 读取 Workflow IR，并反转 calls 形成 forward reference。
+- `check=False`
+
+执行：
+
+- 创建并执行结构化 compile run。
+- 读取 snapshot 与 events。
+
+期望输出：
+
+- snapshot `status == "succeeded"`。
+- diagnostics 包含 repair actions。
+- snapshot Workflow IR calls 被修复为 `["qc", "align"]`。
+- `artifact.updated` workflow_ir 事件在 `repair.applied` 事件前出现。
+- `repair.applied` payload 包含结构化 `repair_actions`。
+
+覆盖点：
+
+- 修复发生时，历史事件先通知 Workflow IR artifact 更新，再记录 repair action。
+- 前端和 SSE 消费方不需要根据 summary 文案推断 repair 后的 artifact 类型。
 
 ### `test_natural_language_run_succeeds_after_planning`
 
@@ -747,6 +774,32 @@ OK (skipped=2)
 - 自然语言 run service 入口只依赖稳定 workflow service，不再手写 Planner 到 Compiler 的线性编排。
 - API run 层通过 callback 接收 service 事件。
 
+### `test_natural_language_run_replays_key_events_and_artifacts`
+
+输入：
+
+- 自然语言请求：`Run RNA-seq DEG.`
+- mock `plan_and_compile_workflow(...)` 通过 `event_callback` 发出 planner、compiler delegate、Compiler Graph、artifact 和 validation 事件，并返回成功结果。
+
+执行：
+
+- 创建并执行自然语言 run。
+- 读取 run snapshot 与 events。
+
+期望输出：
+
+- snapshot artifacts 包含 Planner plan、Workflow IR 和 WDL。
+- snapshot diagnostics 表示 run 成功。
+- event history 以 `run.created` 开始，并依次包含 planner started/completed、plan artifact、compiler_graph started、Compiler Graph 节点事件、WDL artifact、validation completed。
+- 倒数第二条为 diagnostics artifact 更新，最后一条为 `run.completed`。
+- artifact 顺序为 `plan`、`workflow_ir`、`wdl`、`diagnostics`。
+- diagnostics artifact payload 包含错误数、修复数、`check_performed` 和 `succeeded` 等结构化字段。
+
+覆盖点：
+
+- 成功自然语言 run 可以被前端和历史详情按关键阶段回放。
+- artifact 事件 payload 使用结构化字段，不依赖前端解析 summary 文案。
+
 ### `test_natural_language_run_preserves_empty_planner_observability_fields`
 
 输入：
@@ -768,12 +821,12 @@ OK (skipped=2)
 
 - 空字符串 trace 与 `None` 语义区分保留，便于后续调试真实 planner 行为。
 
-### `test_natural_language_compile_exception_preserves_planner_artifacts`
+### `test_natural_language_compile_exception_preserves_partial_artifacts`
 
 输入：
 
 - 自然语言请求：`Run RNA-seq DEG.`
-- mock `plan_and_compile_workflow(...)` 先通过 `event_callback` 发出 plan artifact 更新，再抛出 `RuntimeError("compiler exploded")`
+- mock `plan_and_compile_workflow(...)` 先通过 `event_callback` 发出 plan 和 Workflow IR artifact 更新，再抛出 `RuntimeError("compiler exploded")`
 
 执行：
 
@@ -783,13 +836,16 @@ OK (skipped=2)
 期望输出：
 
 - snapshot `status == "failed"`。
-- snapshot artifacts 仍保留 planner 产出的 plan。
+- snapshot artifacts 仍保留 planner 产出的 plan 和 compiler 已产出的 Workflow IR。
+- snapshot WDL 仍为空字符串。
 - diagnostics validation message 包含 `compiler exploded`。
 - events 包含 compiler failure，并以 `run.completed` 结束。
+- artifact 顺序为 `plan`、`workflow_ir`、`diagnostics`。
 
 覆盖点：
 
-- 即使自然语言 run 在 compiler 阶段失败，已产生的 planner artifact 仍可被历史详情和 SSE 回放读取。
+- 即使自然语言 run 在 compiler 阶段失败，已产生的 partial artifacts 仍可被历史详情和 SSE 回放读取。
+- 失败 run 也会在完成前发出 diagnostics artifact 更新事件。
 
 ### `test_natural_language_planner_error_is_persisted_as_failed_run`
 
@@ -806,12 +862,15 @@ OK (skipped=2)
 期望输出：
 
 - snapshot `status == "failed"`。
+- snapshot 不包含 plan、Workflow IR 或 WDL artifact。
 - diagnostics validation message 包含 planner 错误。
 - events 包含 `node.failed`。
+- artifact 顺序只包含 `diagnostics`。
 
 覆盖点：
 
 - Planner 错误由 workflow service 分类并传递给 run service，run service 只负责持久化失败状态与诊断。
+- Planner 失败不会误写 Compiler artifacts。
 
 ### `test_list_runs_returns_api_summaries`
 

--- a/src/services/run_service.py
+++ b/src/services/run_service.py
@@ -231,19 +231,18 @@ class RunService:
             planner_prompt=planner_prompt if planner_prompt is not None else result.planner_prompt,
             planner_raw_response=planner_raw_response if planner_raw_response is not None else result.planner_raw_response,
         )
-        self.repository.save_diagnostics(
-            run_id,
-            DiagnosticReport(
-                analysis_errors=result.analysis_errors,
-                analysis_warnings=result.analysis_warnings,
-                repair_actions=result.repair_actions,
-                validation_message=result.validation_message,
-                is_valid=result.is_valid,
-                succeeded=result.succeeded,
-                check_performed=result.check_performed,
-            ),
+        diagnostics = DiagnosticReport(
+            analysis_errors=result.analysis_errors,
+            analysis_warnings=result.analysis_warnings,
+            repair_actions=result.repair_actions,
+            validation_message=result.validation_message,
+            is_valid=result.is_valid,
+            succeeded=result.succeeded,
+            check_performed=result.check_performed,
         )
+        self.repository.save_diagnostics(run_id, diagnostics)
         final_status = RunStatus.SUCCEEDED if result.succeeded else RunStatus.FAILED
+        self._append_diagnostics_artifact_event(run_id, diagnostics)
         self.repository.complete_run(
             run_id=run_id,
             status=final_status,
@@ -252,15 +251,14 @@ class RunService:
         )
 
     def _fail_run(self, run_id: str, message: str, *, check_performed: bool) -> None:
-        self.repository.save_diagnostics(
-            run_id,
-            DiagnosticReport(
-                analysis_errors=[message],
-                validation_message=message,
-                succeeded=False,
-                check_performed=check_performed,
-            ),
+        diagnostics = DiagnosticReport(
+            analysis_errors=[message],
+            validation_message=message,
+            succeeded=False,
+            check_performed=check_performed,
         )
+        self.repository.save_diagnostics(run_id, diagnostics)
+        self._append_diagnostics_artifact_event(run_id, diagnostics)
         self.repository.complete_run(
             run_id=run_id,
             status=RunStatus.FAILED,
@@ -275,6 +273,23 @@ class RunService:
             node="compiler",
             summary="Workflow compiler failed.",
             payload={"error": str(exc)},
+        )
+
+    def _append_diagnostics_artifact_event(self, run_id: str, diagnostics: DiagnosticReport) -> None:
+        self.repository.append_event(
+            run_id=run_id,
+            event_type=RunEventType.ARTIFACT_UPDATED,
+            node="diagnostics",
+            summary="Diagnostics artifact updated.",
+            payload={
+                "artifact": "diagnostics",
+                "analysis_error_count": len(diagnostics.analysis_errors),
+                "analysis_warning_count": len(diagnostics.analysis_warnings),
+                "repair_action_count": len(diagnostics.repair_actions),
+                "check_performed": diagnostics.check_performed,
+                "is_valid": diagnostics.is_valid,
+                "succeeded": diagnostics.succeeded,
+            },
         )
 
     def _compiler_event_callback(self, run_id: str):

--- a/tests/test_run_service.py
+++ b/tests/test_run_service.py
@@ -40,6 +40,12 @@ def natural_language_result(
     )
 
 
+def repairable_forward_reference_ir() -> dict:
+    workflow_ir = load_example("rnaseq_workflow_ir.json")
+    workflow_ir["workflow"]["calls"].reverse()
+    return workflow_ir
+
+
 class RunServiceTests(unittest.TestCase):
     def test_structured_compile_run_succeeds_and_records_events(self):
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -70,7 +76,48 @@ class RunServiceTests(unittest.TestCase):
             event_types = [event.type for event in events]
             self.assertIn(RunEventType.RUN_CREATED, event_types)
             self.assertIn(RunEventType.ARTIFACT_UPDATED, event_types)
+            self.assertEqual(events[-2].type, RunEventType.ARTIFACT_UPDATED)
+            self.assertEqual(events[-2].node, "diagnostics")
+            self.assertEqual(events[-2].payload["artifact"], "diagnostics")
+            self.assertTrue(events[-2].payload["succeeded"])
             self.assertEqual(events[-1].type, RunEventType.RUN_COMPLETED)
+
+    def test_structured_compile_run_replays_repair_artifact_before_repair_event(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            service = RunService(RunRepository(Path(temp_dir) / "runs.sqlite3"))
+            request = CompileWorkflowRequest(
+                payload=repairable_forward_reference_ir(),
+                check=False,
+            )
+
+            accepted = service.create_structured_compile_run(request)
+            service.execute_structured_compile_run(accepted.run_id, request)
+
+            snapshot = service.get_snapshot(accepted.run_id)
+            self.assertIsNotNone(snapshot)
+            assert snapshot is not None
+            self.assertEqual(snapshot.status, RunStatus.SUCCEEDED)
+            self.assertTrue(snapshot.diagnostics.repair_actions)
+            self.assertEqual(
+                [call["id"] for call in snapshot.artifacts.workflow_ir["workflow"]["calls"]],
+                ["qc", "align"],
+            )
+
+            events = service.get_events(accepted.run_id)
+            self.assertIsNotNone(events)
+            assert events is not None
+            repair_index = next(
+                index for index, event in enumerate(events) if event.type == RunEventType.REPAIR_APPLIED
+            )
+            workflow_ir_update_index = max(
+                index
+                for index, event in enumerate(events[:repair_index])
+                if event.type == RunEventType.ARTIFACT_UPDATED
+                and event.node == "repairer"
+                and event.payload.get("artifact") == "workflow_ir"
+            )
+            self.assertLess(workflow_ir_update_index, repair_index)
+            self.assertIn("Reordered workflow steps", events[repair_index].payload["repair_actions"][0])
 
     def test_structured_compile_run_default_check_records_validation_event(self):
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -180,6 +227,173 @@ class RunServiceTests(unittest.TestCase):
             self.assertEqual(snapshot.artifacts.plan, plan)
             self.assertIn("workflow RNASeqDEG", snapshot.artifacts.wdl)
 
+    def test_natural_language_run_replays_key_events_and_artifacts(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            service = RunService(RunRepository(Path(temp_dir) / "runs.sqlite3"))
+            plan = load_example("rnaseq_deg_recipe_plan.json")
+            request = NaturalLanguageRunRequest(request="Run RNA-seq DEG.", check=False)
+            result = natural_language_result(plan)
+
+            def service_success(*args, **kwargs):
+                event_callback = kwargs["event_callback"]
+                event_callback(
+                    RunEventType.NODE_STARTED.value,
+                    "planner",
+                    "Natural-language planner started.",
+                    {"planner_model": "deepseek-v4-pro"},
+                    {"model": "deepseek-v4-pro"},
+                )
+                event_callback(
+                    RunEventType.NODE_COMPLETED.value,
+                    "planner",
+                    "Natural-language planner completed.",
+                    {"plan": plan},
+                    {},
+                )
+                event_callback(
+                    RunEventType.ARTIFACT_UPDATED.value,
+                    "planner",
+                    "Recipe Tool Plan artifact updated.",
+                    {
+                        "plan": plan,
+                        "planner_prompt": result.planner_prompt,
+                        "planner_raw_response": result.planner_raw_response,
+                    },
+                    {"artifact": "plan"},
+                )
+                event_callback(
+                    RunEventType.NODE_STARTED.value,
+                    "compiler_graph",
+                    "Compiler graph started.",
+                    {"plan": plan},
+                    {"check": False},
+                )
+                event_callback(
+                    RunEventType.NODE_STARTED.value,
+                    "ir_normalizer",
+                    "IR normalizer started.",
+                    result.state,
+                    {},
+                )
+                event_callback(
+                    RunEventType.NODE_COMPLETED.value,
+                    "ir_normalizer",
+                    "IR normalizer completed.",
+                    result.state,
+                    {},
+                )
+                event_callback(
+                    RunEventType.ARTIFACT_UPDATED.value,
+                    "ir_normalizer",
+                    "Workflow IR artifact updated.",
+                    result.state,
+                    {"artifact": "workflow_ir"},
+                )
+                event_callback(
+                    RunEventType.NODE_STARTED.value,
+                    "analyzer",
+                    "Analyzer started.",
+                    result.state,
+                    {},
+                )
+                event_callback(
+                    RunEventType.NODE_COMPLETED.value,
+                    "analyzer",
+                    "Analyzer completed.",
+                    result.state,
+                    {},
+                )
+                event_callback(
+                    RunEventType.NODE_STARTED.value,
+                    "renderer",
+                    "Renderer started.",
+                    result.state,
+                    {},
+                )
+                event_callback(
+                    RunEventType.NODE_COMPLETED.value,
+                    "renderer",
+                    "Renderer completed.",
+                    result.state,
+                    {},
+                )
+                event_callback(
+                    RunEventType.ARTIFACT_UPDATED.value,
+                    "renderer",
+                    "WDL artifact updated.",
+                    result.state,
+                    {"artifact": "wdl"},
+                )
+                event_callback(
+                    RunEventType.VALIDATION_COMPLETED.value,
+                    "checker",
+                    "WDL syntax validation skipped (--no-check).",
+                    result.state,
+                    {"is_valid": False, "check_performed": False},
+                )
+                event_callback(
+                    RunEventType.NODE_COMPLETED.value,
+                    "compiler_graph",
+                    "Compiler graph completed.",
+                    {"compiler_result": result},
+                    {"succeeded": True, "check_performed": False},
+                )
+                return result
+
+            with patch(
+                "src.services.run_service.workflow_service.plan_and_compile_workflow",
+                side_effect=service_success,
+            ):
+                accepted = service.create_natural_language_run(request)
+                service.execute_natural_language_run(accepted.run_id, request)
+
+            snapshot = service.get_snapshot(accepted.run_id)
+            self.assertIsNotNone(snapshot)
+            assert snapshot is not None
+            self.assertEqual(snapshot.artifacts.plan, plan)
+            self.assertEqual(snapshot.artifacts.workflow_ir["workflow"]["name"], "RNASeqDEG")
+            self.assertIn("workflow RNASeqDEG", snapshot.artifacts.wdl)
+            self.assertTrue(snapshot.diagnostics.succeeded)
+
+            events = service.get_events(accepted.run_id)
+            self.assertIsNotNone(events)
+            assert events is not None
+            event_keys = [(event.type.value, event.node) for event in events]
+            self.assertEqual(
+                event_keys[:5],
+                [
+                    ("run.created", None),
+                    ("node.started", "planner"),
+                    ("node.completed", "planner"),
+                    ("artifact.updated", "planner"),
+                    ("node.started", "compiler_graph"),
+                ],
+            )
+            self.assertIn(("node.started", "ir_normalizer"), event_keys)
+            self.assertIn(("node.completed", "analyzer"), event_keys)
+            self.assertIn(("artifact.updated", "renderer"), event_keys)
+            self.assertIn(("validation.completed", "checker"), event_keys)
+            self.assertEqual(event_keys[-2:], [("artifact.updated", "diagnostics"), ("run.completed", None)])
+            artifact_order = [
+                (event.payload.get("artifact"), event.node)
+                for event in events
+                if event.type == RunEventType.ARTIFACT_UPDATED
+            ]
+            self.assertEqual(
+                artifact_order,
+                [
+                    ("plan", "planner"),
+                    ("workflow_ir", "ir_normalizer"),
+                    ("wdl", "renderer"),
+                    ("diagnostics", "diagnostics"),
+                ],
+            )
+            diagnostics_event = events[-2]
+            self.assertEqual(diagnostics_event.payload["analysis_error_count"], 0)
+            self.assertEqual(diagnostics_event.payload["repair_action_count"], 0)
+            self.assertFalse(diagnostics_event.payload["check_performed"])
+            self.assertTrue(diagnostics_event.payload["succeeded"])
+
     def test_natural_language_run_preserves_empty_planner_observability_fields(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             service = RunService(RunRepository(Path(temp_dir) / "runs.sqlite3"))
@@ -209,10 +423,11 @@ class RunServiceTests(unittest.TestCase):
             self.assertEqual(row["planner_prompt"], "")
             self.assertEqual(row["planner_raw_response"], "")
 
-    def test_natural_language_compile_exception_preserves_planner_artifacts(self):
+    def test_natural_language_compile_exception_preserves_partial_artifacts(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             service = RunService(RunRepository(Path(temp_dir) / "runs.sqlite3"))
             plan = load_example("rnaseq_deg_recipe_plan.json")
+            workflow_ir = compile_structured_workflow(plan, check=False).workflow_ir
             request = NaturalLanguageRunRequest(request="Run RNA-seq DEG.", check=False)
 
             def service_failure(*args, **kwargs):
@@ -228,6 +443,13 @@ class RunServiceTests(unittest.TestCase):
                     },
                     {"artifact": "plan"},
                 )
+                event_callback(
+                    "artifact.updated",
+                    "ir_normalizer",
+                    "Workflow IR artifact updated.",
+                    {"workflow_ir": workflow_ir, "current_wdl": ""},
+                    {"artifact": "workflow_ir"},
+                )
                 raise RuntimeError("compiler exploded")
 
             with patch(
@@ -242,6 +464,8 @@ class RunServiceTests(unittest.TestCase):
             assert snapshot is not None
             self.assertEqual(snapshot.status, RunStatus.FAILED)
             self.assertEqual(snapshot.artifacts.plan, plan)
+            self.assertEqual(snapshot.artifacts.workflow_ir["workflow"]["name"], "RNASeqDEG")
+            self.assertEqual(snapshot.artifacts.wdl, "")
             self.assertIn("compiler exploded", snapshot.diagnostics.validation_message)
 
             events = service.get_events(accepted.run_id)
@@ -252,6 +476,12 @@ class RunServiceTests(unittest.TestCase):
             ]
             self.assertEqual(len(compiler_failures), 1)
             self.assertEqual(compiler_failures[0].payload["error"], "compiler exploded")
+            artifact_order = [
+                event.payload.get("artifact")
+                for event in events
+                if event.type == RunEventType.ARTIFACT_UPDATED
+            ]
+            self.assertEqual(artifact_order, ["plan", "workflow_ir", "diagnostics"])
             self.assertEqual(events[-1].type, RunEventType.RUN_COMPLETED)
 
     def test_natural_language_planner_error_is_persisted_as_failed_run(self):
@@ -270,12 +500,21 @@ class RunServiceTests(unittest.TestCase):
             self.assertIsNotNone(snapshot)
             assert snapshot is not None
             self.assertEqual(snapshot.status, RunStatus.FAILED)
+            self.assertIsNone(snapshot.artifacts.plan)
+            self.assertEqual(snapshot.artifacts.workflow_ir, {})
+            self.assertEqual(snapshot.artifacts.wdl, "")
             self.assertIn("LLM planner JSON parsing failed", snapshot.diagnostics.validation_message)
 
             events = service.get_events(accepted.run_id)
             self.assertIsNotNone(events)
             assert events is not None
             self.assertIn(RunEventType.NODE_FAILED, [event.type for event in events])
+            artifact_order = [
+                event.payload.get("artifact")
+                for event in events
+                if event.type == RunEventType.ARTIFACT_UPDATED
+            ]
+            self.assertEqual(artifact_order, ["diagnostics"])
 
     def test_sse_stream_formats_events_until_run_completed(self):
         with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
## Summary

- Emit a structured diagnostics artifact event before `run.completed` so run history and SSE consumers can refresh diagnostics deterministically.
- Strengthen run service coverage for successful natural-language replay, planner failure, compiler partial artifacts, and repair event ordering.
- Document the P1.7 event/artifact contract and update the test-case validation snapshot.

## Validation

- `.\.venv\Scripts\python.exe -m unittest tests.test_run_service tests.test_workflow_service -v`
- `.\.venv\Scripts\python.exe -m unittest discover -v`
- Result: `178 tests OK, skipped=2`
- `git diff --check`