### PR TITLE
Add catalog retrieval run artifacts

### DIFF
--- a/docs/internal-catalog-rag-plan.md
+++ b/docs/internal-catalog-rag-plan.md
@@ -444,10 +444,10 @@ powershell -ExecutionPolicy Bypass -File scripts\check_p0.ps1
 - [x] Planner prompt 使用 retrieved context。
 - [x] 完整 Catalog validation 仍然执行。
 - [x] 结构化入口不依赖 retriever。
-- [ ] 自然语言 run 记录 retriever 事件。
-- [ ] Run snapshot 暴露 retrieval artifact。
+- [x] 自然语言 run 记录 retriever 事件。
+- [x] Run snapshot 暴露 retrieval artifact。
 - [ ] 前端能展示候选 recipe/tools 和 `trust_status`。
-- [ ] 单测覆盖成功、fallback 和错误边界。
+- [x] 单测覆盖成功、fallback 和错误边界。
 - [ ] 文档说明内部 RAG 与外部工具发现的边界。
 
 ## 面试展示叙述

--- a/docs/test-cases.md
+++ b/docs/test-cases.md
@@ -240,6 +240,7 @@ OK (skipped=2)
 期望输出：
 
 - artifacts 默认为空 Workflow IR 与空 WDL。
+- `catalog_retrieval` 默认为 `None`，结构化或尚未检索的 run 不伪造 retrieval artifact。
 - diagnostics 默认不是 succeeded。
 - `kind`、`created_at`、`updated_at` 和 `completed_at` 默认为 `None`。
 
@@ -618,7 +619,7 @@ OK (skipped=2)
 输入：
 
 - mock `run_service.get_snapshot(...)` 返回 `WorkflowRunSnapshotResponse`。
-- snapshot 包含自然语言 run 的 plan、Workflow IR、WDL 和 diagnostics。
+- snapshot 包含自然语言 run 的 catalog retrieval、plan、Workflow IR、WDL 和 diagnostics。
 - HTTP 请求：`GET /api/runs/run_123`
 
 执行：
@@ -630,13 +631,13 @@ OK (skipped=2)
 - HTTP status 为 `200`。
 - response `run_id == "run_123"`。
 - response 保留 `kind == "natural_language"`。
-- response artifacts 包含 Planner plan、Compiler Workflow IR 和 WDL。
+- response artifacts 包含 Catalog retrieval、Planner plan、Compiler Workflow IR 和 WDL。
 - response diagnostics 保留 `succeeded` 与 `check_performed`。
 
 覆盖点：
 
 - run snapshot endpoint 从 run service 读取持久化快照。
-- 自然语言 run history 可通过 API route 暴露 Planner plan 和 Compiler artifacts。
+- 自然语言 run history 可通过 API route 暴露 Catalog retrieval、Planner plan 和 Compiler artifacts。
 
 ### `test_stream_run_events`
 
@@ -661,6 +662,12 @@ OK (skipped=2)
 ## `tests/test_run_repository.py`
 
 该文件验证 SQLite-backed run repository。Repository 负责持久化 run、event、artifact 和 diagnostic 数据，并提供面向 service 层的查询能力；它不调用 planner、compiler 或 FastAPI route。
+
+新增 catalog retrieval artifact 覆盖：
+
+- 完整 `save_artifacts(...)` 会保存并读回 `catalog_retrieval`。
+- `save_catalog_retrieval_artifact(...)` 可先保存 retrieval artifact，后续 plan、Workflow IR、WDL 增量更新不会覆盖该字段。
+- 既有 SQLite `run_artifacts` 表会通过 schema migration 补齐 `catalog_retrieval_json` 列。
 
 ### `test_list_runs_returns_paginated_summaries_with_status_filter`
 
@@ -714,6 +721,7 @@ OK (skipped=2)
 - snapshot `status == "succeeded"`。
 - snapshot `kind == "structured_compile"`。
 - snapshot 包含 `created_at`、`updated_at` 和 `completed_at`。
+- structured compile snapshot 中 `catalog_retrieval == None`。
 - Workflow IR 名称为 `RNASeqDEG`。
 - WDL 包含 `workflow RNASeqDEG`。
 - events 包含 `run.created`、`artifact.updated`，最后一条为 `run.completed`。
@@ -767,7 +775,7 @@ OK (skipped=2)
 - `plan_and_compile_workflow` 被调用一次。
 - 调用参数包含自然语言 request、`check=False` 和 `event_callback`。
 - snapshot `status == "succeeded"`。
-- snapshot artifacts 包含 Recipe Tool Plan 和 WDL。
+- snapshot artifacts 包含 catalog retrieval、Recipe Tool Plan 和 WDL。
 
 覆盖点：
 
@@ -779,7 +787,7 @@ OK (skipped=2)
 输入：
 
 - 自然语言请求：`Run RNA-seq DEG.`
-- mock `plan_and_compile_workflow(...)` 通过 `event_callback` 发出 planner、compiler delegate、Compiler Graph、artifact 和 validation 事件，并返回成功结果。
+- mock `plan_and_compile_workflow(...)` 通过 `event_callback` 发出 catalog retriever、planner、compiler delegate、Compiler Graph、artifact 和 validation 事件，并返回成功结果。
 
 执行：
 
@@ -788,11 +796,11 @@ OK (skipped=2)
 
 期望输出：
 
-- snapshot artifacts 包含 Planner plan、Workflow IR 和 WDL。
+- snapshot artifacts 包含 Catalog retrieval、Planner plan、Workflow IR 和 WDL。
 - snapshot diagnostics 表示 run 成功。
-- event history 以 `run.created` 开始，并依次包含 planner started/completed、plan artifact、compiler_graph started、Compiler Graph 节点事件、WDL artifact、validation completed。
+- event history 以 `run.created` 开始，并依次包含 catalog_retriever started/completed、catalog_retrieval artifact、planner started/completed、plan artifact、compiler_graph started、Compiler Graph 节点事件、WDL artifact、validation completed。
 - 倒数第二条为 diagnostics artifact 更新，最后一条为 `run.completed`。
-- artifact 顺序为 `plan`、`workflow_ir`、`wdl`、`diagnostics`。
+- artifact 顺序为 `catalog_retrieval`、`plan`、`workflow_ir`、`wdl`、`diagnostics`。
 - diagnostics artifact payload 包含错误数、修复数、`check_performed` 和 `succeeded` 等结构化字段。
 
 覆盖点：
@@ -826,7 +834,7 @@ OK (skipped=2)
 输入：
 
 - 自然语言请求：`Run RNA-seq DEG.`
-- mock `plan_and_compile_workflow(...)` 先通过 `event_callback` 发出 plan 和 Workflow IR artifact 更新，再抛出 `RuntimeError("compiler exploded")`
+- mock `plan_and_compile_workflow(...)` 先通过 `event_callback` 发出 catalog retrieval、plan 和 Workflow IR artifact 更新，再抛出 `RuntimeError("compiler exploded")`
 
 执行：
 
@@ -836,11 +844,11 @@ OK (skipped=2)
 期望输出：
 
 - snapshot `status == "failed"`。
-- snapshot artifacts 仍保留 planner 产出的 plan 和 compiler 已产出的 Workflow IR。
+- snapshot artifacts 仍保留 retriever 产出的 catalog retrieval、planner 产出的 plan 和 compiler 已产出的 Workflow IR。
 - snapshot WDL 仍为空字符串。
 - diagnostics validation message 包含 `compiler exploded`。
 - events 包含 compiler failure，并以 `run.completed` 结束。
-- artifact 顺序为 `plan`、`workflow_ir`、`diagnostics`。
+- artifact 顺序为 `catalog_retrieval`、`plan`、`workflow_ir`、`diagnostics`。
 
 覆盖点：
 
@@ -2325,6 +2333,7 @@ Agent 占位逻辑。
 
 - `result.succeeded == True`。
 - `result.plan` 等于 mock LLM 返回的 plan。
+- `result.catalog_retrieval.strategy == "lexical_v1"`。
 - `result.planner_prompt` 包含 `Catalog:`。
 - `result.planner_raw_response` 包含 `RNASeqDEG`。
 - `result.wdl` 包含 `workflow RNASeqDEG`。
@@ -2334,7 +2343,7 @@ Agent 占位逻辑。
 
 - 自然语言入口通过 Orchestration Graph 先生成 Recipe Tool Plan，再进入确定性编译链路。
 - LLM 仍不直接生成最终 WDL。
-- planner observability 信息被 service 结果保留。
+- planner observability 信息和 raw catalog retrieval artifact 被 service 结果保留。
 
 ### `test_plan_and_compile_workflow_event_callback_covers_planner_and_compiler`
 
@@ -2352,9 +2361,10 @@ Agent 占位逻辑。
 期望输出：
 
 - `result.succeeded == True`。
-- 事件以 planner started/completed/plan artifact 开始。
+- 事件以 catalog_retriever started/completed/catalog_retrieval artifact 开始，然后进入 planner started/completed/plan artifact。
 - 随后进入上层 `compiler_graph` delegate。
 - 事件中包含下层 Compiler Graph 的 `ir_normalizer`、`workflow_ir` artifact、`wdl` artifact 和最终 compiler delegate 完成事件。
+- catalog retrieval artifact 事件的 state 中包含 `catalog_retrieval`。
 - plan artifact 事件的 state 中包含 planner 生成的 Recipe Tool Plan。
 
 覆盖点：
@@ -3306,6 +3316,7 @@ npm run test:graph
 - Recipe Tool Plan 到 Workflow IR 的 resolver 主路径。
 - Catalog 查询服务的 recipe/tool JSON-ready 输出。
 - Approved Catalog Retriever 的词法召回、CJK tokenization、fallback 原因和 JSON-ready 输出契约。
+- 自然语言 run 对 catalog retrieval artifact 的持久化、snapshot 暴露和 SSE 事件回放顺序。
 - Analyzer 对引用、optional input、scatter output 类型提升的处理。
 - Renderer 对 call、scatter、array flatten、workflow output 和 task 的 WDL 渲染。
 - Deterministic repairer 对 call 顺序和 output 字面量的安全修复。

--- a/src/api/models/workflows.py
+++ b/src/api/models/workflows.py
@@ -73,6 +73,7 @@ class WorkflowArtifacts(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
+    catalog_retrieval: JsonObject | None = None
     plan: JsonObject | None = None
     workflow_ir: JsonObject = Field(default_factory=dict)
     wdl: str = ""
@@ -147,6 +148,7 @@ class CompilationResultResponse(BaseModel):
         return cls(
             status=RunStatus.SUCCEEDED if result.succeeded else RunStatus.FAILED,
             artifacts=WorkflowArtifacts(
+                catalog_retrieval=result.catalog_retrieval,
                 plan=result.plan,
                 workflow_ir=result.workflow_ir,
                 wdl=result.wdl,

--- a/src/nl_planner.py
+++ b/src/nl_planner.py
@@ -74,6 +74,7 @@ def create_natural_language_plan(
     llm: PlannerLlm | None = None,
     tool_catalog: ToolCatalog | None = None,
     recipe_catalog: RecipeCatalog | None = None,
+    catalog_retrieval: dict[str, Any] | None = None,
 ) -> NaturalLanguagePlanResult:
     """Convert a natural-language request and retain planner observability details."""
     if not request.strip():
@@ -83,7 +84,8 @@ def create_natural_language_plan(
     recipe_catalog = recipe_catalog or load_recipe_catalog(tool_catalog=tool_catalog)
     planner_llm = llm if llm is not None else _make_planner_llm(model)
 
-    catalog_retrieval = retrieve_catalog_context(request, tool_catalog, recipe_catalog)
+    if catalog_retrieval is None:
+        catalog_retrieval = retrieve_catalog_context(request, tool_catalog, recipe_catalog)
     prompt = build_planner_prompt(
         request,
         tool_catalog,

--- a/src/orchestration/nodes/planner.py
+++ b/src/orchestration/nodes/planner.py
@@ -4,14 +4,15 @@ from __future__ import annotations
 
 from typing import Any, Callable, Mapping
 
-from src.catalog.loader import ToolCatalog
+from src.catalog.loader import ToolCatalog, load_tool_catalog
+from src.catalog.retriever import retrieve_catalog_context
 from src.nl_planner import (
     NaturalLanguagePlanningError,
     PlannerLlm,
     create_natural_language_plan,
 )
 from src.orchestration.state import OrchestrationState
-from src.recipes.loader import RecipeCatalog
+from src.recipes.loader import RecipeCatalog, load_recipe_catalog
 
 
 OrchestrationEventCallback = Callable[
@@ -36,29 +37,76 @@ def make_natural_language_planner_node(
     """Create a planner node, optionally injecting dependencies for tests."""
 
     def node(state: OrchestrationState) -> dict[str, Any]:
-        started_event = _planner_event(
-            "node.started",
-            "Natural-language planner started.",
-            {"model": state["planner_model"]},
-        )
-        _emit_planner_event(event_callback, started_event, state)
+        events: list[dict[str, Any]] = []
+        catalog_retrieval: dict[str, Any] | None = None
 
         try:
+            if not state["request"].strip():
+                raise NaturalLanguagePlanningError("natural language request is empty")
+
+            resolved_tool_catalog = tool_catalog or load_tool_catalog()
+            resolved_recipe_catalog = recipe_catalog or load_recipe_catalog(tool_catalog=resolved_tool_catalog)
+
+            catalog_started_event = _catalog_event(
+                "node.started",
+                "Catalog retriever started.",
+            )
+            events.append(catalog_started_event)
+            _emit_planner_event(event_callback, catalog_started_event, state)
+
+            catalog_retrieval = retrieve_catalog_context(
+                state["request"],
+                resolved_tool_catalog,
+                resolved_recipe_catalog,
+            )
+            catalog_completed_event = _catalog_event(
+                "node.completed",
+                "Catalog retriever completed.",
+                {
+                    "strategy": catalog_retrieval["strategy"],
+                    "recipe_count": len(catalog_retrieval["recipes"]),
+                    "tool_count": len(catalog_retrieval["tools"]),
+                    "fallback_used": catalog_retrieval["fallback_used"],
+                },
+            )
+            catalog_artifact_event = _catalog_event(
+                "artifact.updated",
+                "Catalog retrieval artifact updated.",
+                {"artifact": "catalog_retrieval"},
+            )
+            events.extend([catalog_completed_event, catalog_artifact_event])
+            catalog_state = {"catalog_retrieval": catalog_retrieval}
+            _emit_planner_events(
+                event_callback,
+                [catalog_completed_event, catalog_artifact_event],
+                catalog_state,
+            )
+
+            started_event = _planner_event(
+                "node.started",
+                "Natural-language planner started.",
+                {"model": state["planner_model"]},
+            )
+            events.append(started_event)
+            _emit_planner_event(event_callback, started_event, state)
+
             plan_result = create_natural_language_plan(
                 state["request"],
                 model=state["planner_model"],
                 llm=llm,
-                tool_catalog=tool_catalog,
-                recipe_catalog=recipe_catalog,
+                tool_catalog=resolved_tool_catalog,
+                recipe_catalog=resolved_recipe_catalog,
+                catalog_retrieval=catalog_retrieval,
             )
         except NaturalLanguagePlanningError as exc:
             update: dict[str, Any] = {
+                "catalog_retrieval": catalog_retrieval,
                 "plan": None,
                 "planner_prompt": None,
                 "planner_raw_response": None,
                 "errors": [str(exc)],
                 "events": [
-                    started_event,
+                    *events,
                     _planner_event(
                         "node.failed",
                         "Natural-language planner failed.",
@@ -69,16 +117,17 @@ def make_natural_language_planner_node(
                     ),
                 ],
             }
-            _emit_planner_events(event_callback, update["events"][1:], update)
+            _emit_planner_events(event_callback, update["events"][len(events) :], update)
             return update
         except Exception as exc:
             update = {
+                "catalog_retrieval": catalog_retrieval,
                 "plan": None,
                 "planner_prompt": None,
                 "planner_raw_response": None,
                 "errors": [str(exc)],
                 "events": [
-                    started_event,
+                    *events,
                     _planner_event(
                         "node.failed",
                         "Natural-language planner failed unexpectedly.",
@@ -89,16 +138,17 @@ def make_natural_language_planner_node(
                     ),
                 ],
             }
-            _emit_planner_events(event_callback, update["events"][1:], update)
+            _emit_planner_events(event_callback, update["events"][len(events) :], update)
             return update
 
         update = {
+            "catalog_retrieval": plan_result.catalog_retrieval,
             "plan": plan_result.plan,
             "planner_prompt": plan_result.planner_prompt,
             "planner_raw_response": plan_result.raw_response,
             "errors": [],
             "events": [
-                started_event,
+                *events,
                 _planner_event("node.completed", "Natural-language planner completed."),
                 _planner_event(
                     "artifact.updated",
@@ -107,7 +157,7 @@ def make_natural_language_planner_node(
                 ),
             ],
         }
-        _emit_planner_events(event_callback, update["events"][1:], update)
+        _emit_planner_events(event_callback, update["events"][len(events) :], update)
         return update
 
     return node
@@ -118,9 +168,26 @@ def _planner_event(
     summary: str,
     payload: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
+    return _node_event(event_type, "planner", summary, payload)
+
+
+def _catalog_event(
+    event_type: str,
+    summary: str,
+    payload: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    return _node_event(event_type, "catalog_retriever", summary, payload)
+
+
+def _node_event(
+    event_type: str,
+    node: str,
+    summary: str,
+    payload: dict[str, Any] | None = None,
+) -> dict[str, Any]:
     event: dict[str, Any] = {
         "type": event_type,
-        "node": "planner",
+        "node": node,
         "summary": summary,
     }
     if payload is not None:

--- a/src/orchestration/state.py
+++ b/src/orchestration/state.py
@@ -23,6 +23,7 @@ class OrchestrationState(TypedDict):
     request: str
     planner_model: str
     check: bool
+    catalog_retrieval: dict[str, Any] | None
     plan: dict[str, Any] | None
     planner_prompt: str | None
     planner_raw_response: str | None
@@ -42,6 +43,7 @@ def build_initial_orchestration_state(
         "request": request,
         "planner_model": planner_model,
         "check": check,
+        "catalog_retrieval": None,
         "plan": None,
         "planner_prompt": None,
         "planner_raw_response": None,

--- a/src/services/run_repository.py
+++ b/src/services/run_repository.py
@@ -268,11 +268,12 @@ class RunRepository:
             connection.execute(
                 """
                 INSERT INTO run_artifacts (
-                    run_id, plan_json, workflow_ir_json, wdl,
+                    run_id, catalog_retrieval_json, plan_json, workflow_ir_json, wdl,
                     planner_prompt, planner_raw_response
                 )
-                VALUES (?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
                 ON CONFLICT(run_id) DO UPDATE SET
+                    catalog_retrieval_json = excluded.catalog_retrieval_json,
                     plan_json = excluded.plan_json,
                     workflow_ir_json = excluded.workflow_ir_json,
                     wdl = excluded.wdl,
@@ -281,12 +282,32 @@ class RunRepository:
                 """,
                 (
                     run_id,
+                    _to_json(artifacts.catalog_retrieval),
                     _to_json(artifacts.plan),
                     _to_json(artifacts.workflow_ir),
                     artifacts.wdl,
                     planner_prompt,
                     planner_raw_response,
                 ),
+            )
+
+    def save_catalog_retrieval_artifact(
+        self,
+        run_id: str,
+        catalog_retrieval: dict[str, Any],
+    ) -> None:
+        with self._connect() as connection:
+            connection.execute(
+                """
+                INSERT INTO run_artifacts (
+                    run_id, catalog_retrieval_json, plan_json, workflow_ir_json, wdl,
+                    planner_prompt, planner_raw_response
+                )
+                VALUES (?, ?, NULL, '{}', '', NULL, NULL)
+                ON CONFLICT(run_id) DO UPDATE SET
+                    catalog_retrieval_json = excluded.catalog_retrieval_json
+                """,
+                (run_id, _to_json(catalog_retrieval)),
             )
 
     def save_plan_artifact(
@@ -432,6 +453,7 @@ class RunRepository:
 
                 CREATE TABLE IF NOT EXISTS run_artifacts (
                     run_id TEXT PRIMARY KEY,
+                    catalog_retrieval_json TEXT,
                     plan_json TEXT,
                     workflow_ir_json TEXT NOT NULL,
                     wdl TEXT NOT NULL,
@@ -453,6 +475,7 @@ class RunRepository:
                 );
                 """
             )
+            _ensure_column(connection, "run_artifacts", "catalog_retrieval_json", "TEXT")
 
     @contextmanager
     def _connect(self) -> Iterator[sqlite3.Connection]:
@@ -576,6 +599,7 @@ def _row_to_artifacts(row: sqlite3.Row | None) -> WorkflowArtifacts:
     if row is None:
         return WorkflowArtifacts()
     return WorkflowArtifacts(
+        catalog_retrieval=_from_json(row["catalog_retrieval_json"]),
         plan=_from_json(row["plan_json"]),
         workflow_ir=_from_json(row["workflow_ir_json"]) or {},
         wdl=row["wdl"] or "",
@@ -606,6 +630,20 @@ def _from_json(value: str | None) -> Any:
     if value is None:
         return None
     return json.loads(value)
+
+
+def _ensure_column(
+    connection: sqlite3.Connection,
+    table_name: str,
+    column_name: str,
+    column_type: str,
+) -> None:
+    columns = {
+        row["name"]
+        for row in connection.execute(f"PRAGMA table_info({table_name})").fetchall()
+    }
+    if column_name not in columns:
+        connection.execute(f"ALTER TABLE {table_name} ADD COLUMN {column_name} {column_type}")
 
 
 def _json_list_length(value: str | None) -> int:

--- a/src/services/run_service.py
+++ b/src/services/run_service.py
@@ -224,6 +224,7 @@ class RunService:
         self.repository.save_artifacts(
             run_id,
             WorkflowArtifacts(
+                catalog_retrieval=result.catalog_retrieval,
                 plan=result.plan,
                 workflow_ir=result.workflow_ir,
                 wdl=result.wdl,
@@ -315,7 +316,11 @@ class RunService:
             return
 
         artifact = payload.get("artifact")
-        if artifact == "plan":
+        if artifact == "catalog_retrieval":
+            catalog_retrieval = state.get("catalog_retrieval")
+            if isinstance(catalog_retrieval, dict):
+                self.repository.save_catalog_retrieval_artifact(run_id, catalog_retrieval)
+        elif artifact == "plan":
             plan = state.get("plan")
             if isinstance(plan, dict):
                 planner_prompt = state.get("planner_prompt")

--- a/src/services/workflow_service.py
+++ b/src/services/workflow_service.py
@@ -50,11 +50,13 @@ class WorkflowCompilationResult:
     succeeded: bool
     check_performed: bool
     state: WorkflowState
+    catalog_retrieval: dict[str, Any] | None = None
     planner_prompt: str | None = None
     planner_raw_response: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return {
+            "catalog_retrieval": self.catalog_retrieval,
             "plan": self.plan,
             "workflow_ir": self.workflow_ir,
             "wdl": self.wdl,
@@ -122,6 +124,7 @@ def plan_and_compile_workflow(
 
     return replace(
         cast(WorkflowCompilationResult, compiler_result),
+        catalog_retrieval=orchestration_state["catalog_retrieval"],
         planner_prompt=orchestration_state["planner_prompt"],
         planner_raw_response=orchestration_state["planner_raw_response"],
     )
@@ -244,6 +247,7 @@ def _result_from_state(
     *,
     plan: dict[str, Any] | None,
     check: bool,
+    catalog_retrieval: dict[str, Any] | None = None,
     planner_prompt: str | None = None,
     planner_raw_response: str | None = None,
 ) -> WorkflowCompilationResult:
@@ -259,6 +263,7 @@ def _result_from_state(
         succeeded=workflow_succeeded(state, check=check),
         check_performed=check,
         state=state,
+        catalog_retrieval=catalog_retrieval,
         planner_prompt=planner_prompt,
         planner_raw_response=planner_raw_response,
     )

--- a/tests/api/test_models.py
+++ b/tests/api/test_models.py
@@ -64,6 +64,7 @@ class WorkflowDtoTests(unittest.TestCase):
         self.assertTrue(response.diagnostics.succeeded)
         self.assertFalse(response.diagnostics.check_performed)
         self.assertEqual(response.diagnostics.analysis_errors, [])
+        self.assertIsNone(response.artifacts.catalog_retrieval)
         self.assertEqual(response.artifacts.workflow_ir["workflow"]["name"], "RNASeqDEG")
         self.assertIn("workflow RNASeqDEG", response.artifacts.wdl)
 
@@ -99,6 +100,7 @@ class WorkflowDtoTests(unittest.TestCase):
         )
 
         self.assertEqual(response.artifacts.workflow_ir, {})
+        self.assertIsNone(response.artifacts.catalog_retrieval)
         self.assertEqual(response.artifacts.wdl, "")
         self.assertFalse(response.diagnostics.succeeded)
         self.assertIsNone(response.kind)

--- a/tests/api/test_routes.py
+++ b/tests/api/test_routes.py
@@ -234,6 +234,7 @@ class ApiRouteTests(unittest.TestCase):
             request="Run RNA-seq DEG.",
             events_url="/api/runs/run_123/events",
             artifacts=WorkflowArtifacts(
+                catalog_retrieval={"strategy": "lexical_v1"},
                 plan=plan,
                 workflow_ir={"workflow": {"name": "RNASeqDEG"}},
                 wdl="version 1.0\nworkflow RNASeqDEG {}",
@@ -254,6 +255,7 @@ class ApiRouteTests(unittest.TestCase):
         body = response.json()
         self.assertEqual(body["run_id"], "run_123")
         self.assertEqual(body["kind"], "natural_language")
+        self.assertEqual(body["artifacts"]["catalog_retrieval"]["strategy"], "lexical_v1")
         self.assertEqual(body["artifacts"]["plan"]["workflow"]["recipe"], "rnaseq_differential_expression")
         self.assertEqual(body["artifacts"]["workflow_ir"]["workflow"]["name"], "RNASeqDEG")
         self.assertIn("workflow RNASeqDEG", body["artifacts"]["wdl"])

--- a/tests/test_orchestration_graph.py
+++ b/tests/test_orchestration_graph.py
@@ -21,6 +21,17 @@ def sample_plan() -> dict:
     }
 
 
+def sample_catalog_retrieval() -> dict:
+    return {
+        "query": "Run RNA-seq DEG.",
+        "strategy": "lexical_v1",
+        "recipes": [{"id": "rnaseq_differential_expression"}],
+        "tools": [{"id": "fastp", "trust_status": "catalog-approved"}],
+        "fallback_used": False,
+        "fallback_reason": None,
+    }
+
+
 def compilation_result(
     plan: dict,
     *,
@@ -54,11 +65,20 @@ def compilation_result(
 def planner_success_node(plan: dict):
     def node(state):
         return {
+            "catalog_retrieval": sample_catalog_retrieval(),
             "plan": plan,
             "planner_prompt": "planner prompt",
             "planner_raw_response": "{}",
             "errors": [],
             "events": [
+                {"type": "node.started", "node": "catalog_retriever", "summary": "Catalog retriever started."},
+                {"type": "node.completed", "node": "catalog_retriever", "summary": "Catalog retriever completed."},
+                {
+                    "type": "artifact.updated",
+                    "node": "catalog_retriever",
+                    "summary": "Catalog retrieval artifact updated.",
+                    "payload": {"artifact": "catalog_retrieval"},
+                },
                 {"type": "node.started", "node": "planner", "summary": "Planner started."},
                 {"type": "node.completed", "node": "planner", "summary": "Planner completed."},
                 {
@@ -99,6 +119,7 @@ class OrchestrationGraphTests(unittest.TestCase):
 
         self.assertEqual(compiler_calls, [{"parsed_json": plan, "check": False}])
         self.assertEqual(final_state["plan"], plan)
+        self.assertEqual(final_state["catalog_retrieval"]["strategy"], "lexical_v1")
         self.assertEqual(final_state["planner_prompt"], "planner prompt")
         self.assertIsNotNone(final_state["compiler_result"])
         self.assertTrue(final_state["compiler_result"].succeeded)
@@ -107,6 +128,9 @@ class OrchestrationGraphTests(unittest.TestCase):
         self.assertEqual(
             [event["type"] for event in final_state["events"]],
             [
+                "node.started",
+                "node.completed",
+                "artifact.updated",
                 "node.started",
                 "node.completed",
                 "artifact.updated",

--- a/tests/test_orchestration_planner_node.py
+++ b/tests/test_orchestration_planner_node.py
@@ -128,11 +128,22 @@ class OrchestrationPlannerNodeTests(unittest.TestCase):
         self.assertNotIn("compiler_result", update)
         self.assertNotIn("workflow_ir", update)
         self.assertNotIn("wdl", update)
+        self.assertEqual(update["catalog_retrieval"]["strategy"], "lexical_v1")
+        self.assertEqual(update["catalog_retrieval"]["recipes"][0]["id"], "rnaseq_differential_expression")
         self.assertEqual(
-            [event["type"] for event in update["events"]],
-            ["node.started", "node.completed", "artifact.updated"],
+            [(event["type"], event["node"]) for event in update["events"]],
+            [
+                ("node.started", "catalog_retriever"),
+                ("node.completed", "catalog_retriever"),
+                ("artifact.updated", "catalog_retriever"),
+                ("node.started", "planner"),
+                ("node.completed", "planner"),
+                ("artifact.updated", "planner"),
+            ],
         )
-        self.assertEqual(update["events"][0]["payload"], {"model": DEFAULT_PLANNER_MODEL})
+        self.assertEqual(update["events"][1]["payload"]["strategy"], "lexical_v1")
+        self.assertEqual(update["events"][2]["payload"], {"artifact": "catalog_retrieval"})
+        self.assertEqual(update["events"][3]["payload"], {"model": DEFAULT_PLANNER_MODEL})
         self.assertEqual(update["events"][-1]["payload"], {"artifact": "plan"})
         self.assertEqual(len(fake_llm.prompts), 1)
 
@@ -152,9 +163,16 @@ class OrchestrationPlannerNodeTests(unittest.TestCase):
         self.assertIsNone(update["plan"])
         self.assertIsNone(update["planner_prompt"])
         self.assertIsNone(update["planner_raw_response"])
+        self.assertEqual(update["catalog_retrieval"]["strategy"], "lexical_v1")
         self.assertEqual(
-            [event["type"] for event in update["events"]],
-            ["node.started", "node.failed"],
+            [(event["type"], event["node"]) for event in update["events"]],
+            [
+                ("node.started", "catalog_retriever"),
+                ("node.completed", "catalog_retriever"),
+                ("artifact.updated", "catalog_retriever"),
+                ("node.started", "planner"),
+                ("node.failed", "planner"),
+            ],
         )
         failure_payload = update["events"][-1]["payload"]
         self.assertEqual(failure_payload["error_type"], "PlannerJsonError")
@@ -173,9 +191,16 @@ class OrchestrationPlannerNodeTests(unittest.TestCase):
         self.assertIsNone(update["plan"])
         self.assertIsNone(update["planner_prompt"])
         self.assertIsNone(update["planner_raw_response"])
+        self.assertEqual(update["catalog_retrieval"]["strategy"], "lexical_v1")
         self.assertEqual(
-            [event["type"] for event in update["events"]],
-            ["node.started", "node.failed"],
+            [(event["type"], event["node"]) for event in update["events"]],
+            [
+                ("node.started", "catalog_retriever"),
+                ("node.completed", "catalog_retriever"),
+                ("artifact.updated", "catalog_retriever"),
+                ("node.started", "planner"),
+                ("node.failed", "planner"),
+            ],
         )
         failure_payload = update["events"][-1]["payload"]
         self.assertEqual(failure_payload["error_type"], "RuntimeError")

--- a/tests/test_orchestration_state.py
+++ b/tests/test_orchestration_state.py
@@ -21,6 +21,7 @@ class OrchestrationStateTests(unittest.TestCase):
         self.assertEqual(state["request"], "Run bulk RNA-seq differential expression.")
         self.assertEqual(state["planner_model"], DEFAULT_PLANNER_MODEL)
         self.assertFalse(state["check"])
+        self.assertIsNone(state["catalog_retrieval"])
         self.assertIsNone(state["plan"])
         self.assertIsNone(state["planner_prompt"])
         self.assertIsNone(state["planner_raw_response"])
@@ -45,6 +46,7 @@ class OrchestrationStateTests(unittest.TestCase):
             "request",
             "planner_model",
             "check",
+            "catalog_retrieval",
             "plan",
             "planner_prompt",
             "planner_raw_response",

--- a/tests/test_run_repository.py
+++ b/tests/test_run_repository.py
@@ -1,3 +1,4 @@
+import sqlite3
 import tempfile
 import unittest
 from pathlib import Path
@@ -38,6 +39,7 @@ class RunRepositoryTests(unittest.TestCase):
             repository.save_artifacts(
                 "run_001",
                 WorkflowArtifacts(
+                    catalog_retrieval={"strategy": "lexical_v1"},
                     plan={"workflow": {"recipe": "demo"}},
                     workflow_ir={"workflow": {"name": "Demo"}},
                     wdl="version 1.0\nworkflow Demo {}",
@@ -57,6 +59,7 @@ class RunRepositoryTests(unittest.TestCase):
             self.assertIsNotNone(snapshot)
             assert snapshot is not None
             self.assertEqual(snapshot.run.status, RunStatus.SUCCEEDED)
+            self.assertEqual(snapshot.artifacts.catalog_retrieval, {"strategy": "lexical_v1"})
             self.assertEqual(snapshot.artifacts.workflow_ir["workflow"]["name"], "Demo")
             self.assertTrue(snapshot.diagnostics.succeeded)
             self.assertFalse(snapshot.diagnostics.check_performed)
@@ -113,6 +116,7 @@ class RunRepositoryTests(unittest.TestCase):
             repository.save_artifacts(
                 "run_001",
                 WorkflowArtifacts(
+                    catalog_retrieval={"strategy": "lexical_v1"},
                     plan={"workflow": {"recipe": "demo"}},
                     workflow_ir={"workflow": {"name": "OldDemo"}},
                     wdl="version 1.0\nworkflow OldDemo {}",
@@ -125,9 +129,64 @@ class RunRepositoryTests(unittest.TestCase):
             snapshot = repository.get_snapshot("run_001")
             self.assertIsNotNone(snapshot)
             assert snapshot is not None
+            self.assertEqual(snapshot.artifacts.catalog_retrieval, {"strategy": "lexical_v1"})
             self.assertEqual(snapshot.artifacts.plan, {"workflow": {"recipe": "demo"}})
             self.assertEqual(snapshot.artifacts.workflow_ir["workflow"]["name"], "Demo")
             self.assertIn("workflow Demo", snapshot.artifacts.wdl)
+
+    def test_catalog_retrieval_artifact_update_preserves_later_fields(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repository = RunRepository(Path(temp_dir) / "runs.sqlite3")
+            repository.create_run(
+                run_id="run_001",
+                kind="natural_language",
+                request="Run demo.",
+                check_performed=False,
+                events_url="/api/runs/run_001/events",
+            )
+
+            repository.save_catalog_retrieval_artifact(
+                "run_001",
+                {"strategy": "lexical_v1", "recipes": [{"id": "demo"}]},
+            )
+            repository.save_plan_artifact("run_001", {"workflow": {"recipe": "demo"}})
+
+            snapshot = repository.get_snapshot("run_001")
+            self.assertIsNotNone(snapshot)
+            assert snapshot is not None
+            self.assertEqual(snapshot.artifacts.catalog_retrieval["strategy"], "lexical_v1")
+            self.assertEqual(snapshot.artifacts.plan, {"workflow": {"recipe": "demo"}})
+
+    def test_schema_migration_adds_catalog_retrieval_column(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            db_path = Path(temp_dir) / "runs.sqlite3"
+            connection = sqlite3.connect(db_path)
+            try:
+                connection.execute(
+                    """
+                    CREATE TABLE run_artifacts (
+                        run_id TEXT PRIMARY KEY,
+                        plan_json TEXT,
+                        workflow_ir_json TEXT NOT NULL,
+                        wdl TEXT NOT NULL,
+                        planner_prompt TEXT,
+                        planner_raw_response TEXT
+                    )
+                    """
+                )
+                connection.commit()
+            finally:
+                connection.close()
+
+            repository = RunRepository(db_path)
+
+            with repository._connect() as connection:
+                columns = {
+                    row["name"]
+                    for row in connection.execute("PRAGMA table_info(run_artifacts)").fetchall()
+                }
+
+            self.assertIn("catalog_retrieval_json", columns)
 
     def test_complete_run_persists_terminal_event_and_status_together(self):
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/tests/test_run_service.py
+++ b/tests/test_run_service.py
@@ -27,14 +27,27 @@ def load_example(name: str) -> dict:
     return json.loads((EXAMPLES_DIR / name).read_text(encoding="utf-8"))
 
 
+def sample_catalog_retrieval() -> dict:
+    return {
+        "query": "Run RNA-seq DEG.",
+        "strategy": "lexical_v1",
+        "recipes": [{"id": "rnaseq_differential_expression"}],
+        "tools": [{"id": "fastp", "trust_status": "catalog-approved"}],
+        "fallback_used": False,
+        "fallback_reason": None,
+    }
+
+
 def natural_language_result(
     plan: dict,
     *,
+    catalog_retrieval: dict | None = None,
     planner_prompt: str = "planner prompt",
     planner_raw_response: str | None = None,
 ):
     return replace(
         compile_structured_workflow(plan, check=False),
+        catalog_retrieval=catalog_retrieval if catalog_retrieval is not None else sample_catalog_retrieval(),
         planner_prompt=planner_prompt,
         planner_raw_response=planner_raw_response if planner_raw_response is not None else json.dumps(plan),
     )
@@ -66,6 +79,7 @@ class RunServiceTests(unittest.TestCase):
             self.assertIsNotNone(snapshot.created_at)
             self.assertIsNotNone(snapshot.updated_at)
             self.assertIsNotNone(snapshot.completed_at)
+            self.assertIsNone(snapshot.artifacts.catalog_retrieval)
             self.assertEqual(snapshot.artifacts.workflow_ir["workflow"]["name"], "RNASeqDEG")
             self.assertIn("workflow RNASeqDEG", snapshot.artifacts.wdl)
             self.assertTrue(snapshot.diagnostics.succeeded)
@@ -225,6 +239,7 @@ class RunServiceTests(unittest.TestCase):
             assert snapshot is not None
             self.assertEqual(snapshot.status, RunStatus.SUCCEEDED)
             self.assertEqual(snapshot.artifacts.plan, plan)
+            self.assertEqual(snapshot.artifacts.catalog_retrieval["strategy"], "lexical_v1")
             self.assertIn("workflow RNASeqDEG", snapshot.artifacts.wdl)
 
     def test_natural_language_run_replays_key_events_and_artifacts(self):
@@ -233,9 +248,36 @@ class RunServiceTests(unittest.TestCase):
             plan = load_example("rnaseq_deg_recipe_plan.json")
             request = NaturalLanguageRunRequest(request="Run RNA-seq DEG.", check=False)
             result = natural_language_result(plan)
+            catalog_retrieval = result.catalog_retrieval
 
             def service_success(*args, **kwargs):
                 event_callback = kwargs["event_callback"]
+                event_callback(
+                    RunEventType.NODE_STARTED.value,
+                    "catalog_retriever",
+                    "Catalog retriever started.",
+                    {"request": "Run RNA-seq DEG."},
+                    {},
+                )
+                event_callback(
+                    RunEventType.NODE_COMPLETED.value,
+                    "catalog_retriever",
+                    "Catalog retriever completed.",
+                    {"catalog_retrieval": catalog_retrieval},
+                    {
+                        "strategy": "lexical_v1",
+                        "recipe_count": 1,
+                        "tool_count": 1,
+                        "fallback_used": False,
+                    },
+                )
+                event_callback(
+                    RunEventType.ARTIFACT_UPDATED.value,
+                    "catalog_retriever",
+                    "Catalog retrieval artifact updated.",
+                    {"catalog_retrieval": catalog_retrieval},
+                    {"artifact": "catalog_retrieval"},
+                )
                 event_callback(
                     RunEventType.NODE_STARTED.value,
                     "planner",
@@ -350,6 +392,7 @@ class RunServiceTests(unittest.TestCase):
             snapshot = service.get_snapshot(accepted.run_id)
             self.assertIsNotNone(snapshot)
             assert snapshot is not None
+            self.assertEqual(snapshot.artifacts.catalog_retrieval, catalog_retrieval)
             self.assertEqual(snapshot.artifacts.plan, plan)
             self.assertEqual(snapshot.artifacts.workflow_ir["workflow"]["name"], "RNASeqDEG")
             self.assertIn("workflow RNASeqDEG", snapshot.artifacts.wdl)
@@ -360,9 +403,12 @@ class RunServiceTests(unittest.TestCase):
             assert events is not None
             event_keys = [(event.type.value, event.node) for event in events]
             self.assertEqual(
-                event_keys[:5],
+                event_keys[:8],
                 [
                     ("run.created", None),
+                    ("node.started", "catalog_retriever"),
+                    ("node.completed", "catalog_retriever"),
+                    ("artifact.updated", "catalog_retriever"),
                     ("node.started", "planner"),
                     ("node.completed", "planner"),
                     ("artifact.updated", "planner"),
@@ -382,6 +428,7 @@ class RunServiceTests(unittest.TestCase):
             self.assertEqual(
                 artifact_order,
                 [
+                    ("catalog_retrieval", "catalog_retriever"),
                     ("plan", "planner"),
                     ("workflow_ir", "ir_normalizer"),
                     ("wdl", "renderer"),
@@ -429,9 +476,17 @@ class RunServiceTests(unittest.TestCase):
             plan = load_example("rnaseq_deg_recipe_plan.json")
             workflow_ir = compile_structured_workflow(plan, check=False).workflow_ir
             request = NaturalLanguageRunRequest(request="Run RNA-seq DEG.", check=False)
+            catalog_retrieval = sample_catalog_retrieval()
 
             def service_failure(*args, **kwargs):
                 event_callback = kwargs["event_callback"]
+                event_callback(
+                    "artifact.updated",
+                    "catalog_retriever",
+                    "Catalog retrieval artifact updated.",
+                    {"catalog_retrieval": catalog_retrieval},
+                    {"artifact": "catalog_retrieval"},
+                )
                 event_callback(
                     "artifact.updated",
                     "planner",
@@ -463,6 +518,7 @@ class RunServiceTests(unittest.TestCase):
             self.assertIsNotNone(snapshot)
             assert snapshot is not None
             self.assertEqual(snapshot.status, RunStatus.FAILED)
+            self.assertEqual(snapshot.artifacts.catalog_retrieval, catalog_retrieval)
             self.assertEqual(snapshot.artifacts.plan, plan)
             self.assertEqual(snapshot.artifacts.workflow_ir["workflow"]["name"], "RNASeqDEG")
             self.assertEqual(snapshot.artifacts.wdl, "")
@@ -481,7 +537,7 @@ class RunServiceTests(unittest.TestCase):
                 for event in events
                 if event.type == RunEventType.ARTIFACT_UPDATED
             ]
-            self.assertEqual(artifact_order, ["plan", "workflow_ir", "diagnostics"])
+            self.assertEqual(artifact_order, ["catalog_retrieval", "plan", "workflow_ir", "diagnostics"])
             self.assertEqual(events[-1].type, RunEventType.RUN_COMPLETED)
 
     def test_natural_language_planner_error_is_persisted_as_failed_run(self):

--- a/tests/test_workflow_service.py
+++ b/tests/test_workflow_service.py
@@ -114,6 +114,7 @@ class WorkflowServiceTests(unittest.TestCase):
 
         self.assertTrue(result.succeeded, result.analysis_errors)
         self.assertIs(result.plan, plan)
+        self.assertIsNone(result.catalog_retrieval)
         self.assertEqual(result.workflow_ir["workflow"]["name"], "RNASeqDEG")
         self.assertIn("workflow RNASeqDEG", result.wdl)
         self.assertEqual(result.validation_message, "WDL syntax validation skipped (--no-check).")
@@ -126,6 +127,7 @@ class WorkflowServiceTests(unittest.TestCase):
 
         self.assertTrue(result.succeeded, result.analysis_errors)
         self.assertIsNone(result.plan)
+        self.assertIsNone(result.catalog_retrieval)
         self.assertEqual(result.workflow_ir["workflow"]["name"], "RNASeqPipeline")
         self.assertIn("workflow RNASeqPipeline", result.wdl)
 
@@ -326,6 +328,8 @@ class WorkflowServiceTests(unittest.TestCase):
 
         self.assertTrue(result.succeeded, result.analysis_errors)
         self.assertEqual(result.plan, plan)
+        self.assertEqual(result.catalog_retrieval["strategy"], "lexical_v1")
+        self.assertEqual(result.catalog_retrieval["recipes"][0]["id"], "rnaseq_differential_expression")
         self.assertIn("Catalog:", result.planner_prompt or "")
         self.assertIn("RNASeqDEG", result.planner_raw_response or "")
         self.assertIn("workflow RNASeqDEG", result.wdl)
@@ -357,8 +361,11 @@ class WorkflowServiceTests(unittest.TestCase):
         self.assertTrue(result.succeeded, result.analysis_errors)
         event_keys = [(event["type"], event["node"]) for event in events]
         self.assertEqual(
-            event_keys[:4],
+            event_keys[:7],
             [
+                ("node.started", "catalog_retriever"),
+                ("node.completed", "catalog_retriever"),
+                ("artifact.updated", "catalog_retriever"),
                 ("node.started", "planner"),
                 ("node.completed", "planner"),
                 ("artifact.updated", "planner"),
@@ -369,10 +376,15 @@ class WorkflowServiceTests(unittest.TestCase):
         artifact_events = [
             event for event in events if event["type"] == "artifact.updated"
         ]
+        self.assertIn({"artifact": "catalog_retrieval"}, [event["payload"] for event in artifact_events])
         self.assertIn({"artifact": "workflow_ir"}, [event["payload"] for event in artifact_events])
         self.assertIn({"artifact": "wdl"}, [event["payload"] for event in artifact_events])
         self.assertEqual(event_keys[-1], ("node.completed", "compiler_graph"))
 
+        catalog_event = next(
+            event for event in artifact_events if event["payload"] == {"artifact": "catalog_retrieval"}
+        )
+        self.assertEqual(catalog_event["state"]["catalog_retrieval"]["strategy"], "lexical_v1")
         plan_event = next(event for event in artifact_events if event["payload"] == {"artifact": "plan"})
         self.assertEqual(plan_event["state"]["plan"], plan)
 
@@ -410,6 +422,7 @@ class WorkflowServiceTests(unittest.TestCase):
         result = compile_structured_workflow(plan, check=False).to_dict()
 
         self.assertEqual(result["plan"], plan)
+        self.assertIsNone(result["catalog_retrieval"])
         self.assertIn("workflow", result["workflow_ir"])
         self.assertIn("workflow RNASeqDEG", result["wdl"])
         self.assertEqual(result["analysis_errors"], [])


### PR DESCRIPTION
## Summary

- Record catalog retriever events before planner execution in natural-language runs.
- Persist raw `catalog_retrieval` artifacts through workflow results, API DTOs, SQLite storage, run snapshots, and SSE replay.
- Keep structured compile runs independent of catalog retrieval and update tests/docs for the R3 behavior.

## Validation

- `./.venv/Scripts/python.exe -m unittest tests.test_orchestration_state tests.test_orchestration_planner_node tests.test_orchestration_graph tests.test_workflow_service tests.test_run_repository tests.test_run_service tests.api.test_models tests.api.test_routes tests.test_nl_planner tests.test_catalog_retriever -v` — 95 tests passed.
- `git diff --check` — passed.
- `./.venv/Scripts/python.exe -m unittest discover -v` — ran 180 tests; 3 existing validator-dependent graph tests failed because no local WDL validator is available, 4 skipped.