### PR TITLE
Refine W5 DAG and failed run replay

### DIFF
--- a/docs/w5-dag-history-plan.md
+++ b/docs/w5-dag-history-plan.md
@@ -6,7 +6,7 @@
 
 `W5` 的目标是把 `W4` 工作台产生的一次 workflow run，从“可实时生成”推进到“可结构化理解、可回放、可审计”。
 
-完成后，访问者应能从工作台创建 RNA-seq 示例 run，在历史列表中再次找到它，进入详情页回放事件、产物和诊断信息，并通过 DAG 图理解 Workflow IR 中的 calls、scatter、依赖边、输入输出和节点状态。
+完成后，访问者应能从工作台创建 RNA-seq 示例 run，在历史列表中再次找到它，进入详情页回放事件、产物和诊断信息，并通过 DAG 图理解 Workflow IR 中的 calls、scatter、依赖边、输入输出和结构状态。
 
 `W5` 是 run 历史与 Workflow IR 可视化阶段，不改变 Compiler Graph 的职责，不让前端生成或修复 Plan、IR、WDL，也不引入新的 Agent 节点或真实 WDL 执行后端。
 
@@ -44,6 +44,28 @@
 3. **DAG 视图**：从详情页中的 Workflow IR 派生图结构，展示 workflow inputs、call nodes、scatter group、workflow outputs 和依赖边。
 
 历史详情页和工作台应复用同一批展示组件，例如 timeline、artifact tabs、diagnostics summary 和 code viewer。工作台关注“当前运行中”，历史详情页关注“刷新后仍可审计”。
+
+### DAG 状态语义
+
+W5 的 DAG 是 Workflow IR 结构审计图，不是 workflow call 执行监控图。当前后端 SSE 事件记录的是 planner、Compiler Graph、Analyzer、Renderer 和 Checker 等编译阶段事件，并不代表 `fastp`、`salmon`、`tximport`、`deseq2` 或 `multiqc` 等 workflow call 的真实运行状态。
+
+因此第一版 DAG 节点只使用结构状态：
+
+- `available`：节点存在于当前 Workflow IR 中，结构和元数据可审阅。
+- `unresolved`：节点包含无法解析的表达式引用，需要结合 diagnostics 审阅。
+- `unavailable`：当前 run 尚未产生可展示的 Workflow IR 节点。
+
+Analyzer、Checker 或 Planner 失败应主要通过 timeline、diagnostics 和 run summary 呈现。除非后端未来提供带 `step_id` / `call_id` 的 workflow call 级事件，否则前端不得把 compiler 阶段事件映射成 DAG 节点的 `running`、`completed` 或 `failed` 执行状态。
+
+### 失败 run 展示口径
+
+失败 run 的详情页和工作台应额外展示失败摘要，但不改变 DAG 的结构语义。第一版摘要包含：
+
+- 首要失败线索，优先级为 `diagnostics.analysis_errors[0]`、`diagnostics.validation_message`、`diagnostics.analysis_warnings[0]`，都为空时引导查看 timeline。
+- 已保留产物状态，包括 Plan、Workflow IR、WDL 和 Diagnostics。
+- DAG 展示口径：如果失败前已保存 Workflow IR，则 DAG 继续展示结构；如果没有 Workflow IR，则 DAG 使用空状态。失败阶段仍以 timeline 和 diagnostics 为准。
+
+这样可以同时覆盖 planner 失败、Analyzer / Checker 失败和结构化编译中途失败，而不会把编译阶段事件误读成 workflow call 级执行结果。
 
 ## 任务拆分
 
@@ -166,11 +188,11 @@ web/components/workflow-graph/
 
 第一版图交互：
 
-- 节点状态映射 pending / running / completed / failed / unavailable。
-- 点击节点展示 task、inputs、outputs、runtime docker 和相关事件摘要。
+- 节点结构状态映射 `available` / `unresolved` / `unavailable`。
+- 点击节点展示 task、inputs、outputs、runtime docker 和 unresolved reference 摘要。
 - scatter group 能体现 per-sample 并行语义。
 - DAG 空状态说明当前 run 尚未产生 Workflow IR。
-- 失败 run 中已产生 IR 时仍展示 DAG，并标出失败节点。
+- 失败 run 中已产生 IR 时仍展示 DAG；失败阶段由 timeline / diagnostics 呈现，DAG 仅标出 unresolved 结构问题。
 
 ### 7. 导航、文案与文档更新
 
@@ -209,7 +231,7 @@ web/components/workflow-graph/
 - `/runs/[runId]` 能回放 events、artifacts 和 diagnostics。
 - DAG 能正确展示 RNA-seq 示例中的 per-sample Salmon scatter、tximport、DESeq2 和 MultiQC 依赖关系。
 - 点击 DAG 节点能看到对应 task、inputs、outputs 和 runtime docker。
-- 失败 run 已有 Workflow IR 时仍能展示 DAG，并突出失败阶段或失败节点。
+- 失败 run 已有 Workflow IR 时仍能展示 DAG；失败阶段通过 timeline / diagnostics 回放，DAG 不伪造 call-level 执行状态。
 
 工程验收：
 

--- a/web/app/runs/[runId]/page.tsx
+++ b/web/app/runs/[runId]/page.tsx
@@ -15,6 +15,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { RunArtifactsPanel } from "@/components/run/run-artifacts-panel";
 import { RunEventsTimeline } from "@/components/run/run-events-timeline";
+import { RunFailureSummary } from "@/components/run/run-failure-summary";
 import { WorkflowGraphPanel } from "@/components/workflow-graph/workflow-graph";
 import { getRunSnapshot } from "@/lib/api";
 import type { JsonObject, RunStatus, WorkflowRunSnapshotResponse } from "@/lib/types";
@@ -198,11 +199,15 @@ function RunDetail({ snapshot }: { snapshot: WorkflowRunSnapshotResponse }) {
         <DiagnosticsSummary snapshot={snapshot} />
       </section>
 
-      <WorkflowGraphPanel
-        workflowIr={snapshot.artifacts.workflow_ir}
-        eventsUrl={snapshot.events_url}
-        status={snapshot.status}
-      />
+      {snapshot.status === "failed" ? (
+        <RunFailureSummary
+          artifacts={snapshot.artifacts}
+          className="mt-6"
+          diagnostics={snapshot.diagnostics}
+        />
+      ) : null}
+
+      <WorkflowGraphPanel workflowIr={snapshot.artifacts.workflow_ir} />
       <RunEventsTimeline eventsUrl={snapshot.events_url} status={snapshot.status} />
       <RunArtifactsPanel artifacts={snapshot.artifacts} diagnostics={snapshot.diagnostics} />
     </>

--- a/web/app/workspace/workspace-workbench.tsx
+++ b/web/app/workspace/workspace-workbench.tsx
@@ -16,6 +16,7 @@ import { useEffect, useMemo, useState } from "react";
 
 import { RunArtifactsPanel } from "@/components/run/run-artifacts-panel";
 import { RunEventsTimeline } from "@/components/run/run-events-timeline";
+import { RunFailureSummary } from "@/components/run/run-failure-summary";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -413,6 +414,14 @@ export function WorkspaceWorkbench({
           ) : null}
         </section>
       </div>
+
+      {currentStatus === "failed" ? (
+        <RunFailureSummary
+          artifacts={artifacts}
+          className="mt-6"
+          diagnostics={diagnostics}
+        />
+      ) : null}
 
       <RunEventsTimeline
         eventsUrl={acceptedRun?.events_url ?? null}

--- a/web/components/run/run-failure-summary.tsx
+++ b/web/components/run/run-failure-summary.tsx
@@ -38,7 +38,9 @@ function hasDiagnosticSignals(diagnostics: DiagnosticReport): boolean {
 }
 
 function getPrimaryFailureReason(diagnostics: DiagnosticReport): string {
-  const analysisError = diagnostics.analysis_errors.find((error) => error.trim().length > 0);
+  const analysisError = diagnostics.analysis_errors
+    .map((error) => error.trim())
+    .find((error) => error.length > 0);
   if (analysisError) {
     return analysisError;
   }
@@ -48,9 +50,9 @@ function getPrimaryFailureReason(diagnostics: DiagnosticReport): string {
     return validationMessage;
   }
 
-  const analysisWarning = diagnostics.analysis_warnings.find(
-    (warning) => warning.trim().length > 0,
-  );
+  const analysisWarning = diagnostics.analysis_warnings
+    .map((warning) => warning.trim())
+    .find((warning) => warning.length > 0);
   if (analysisWarning) {
     return analysisWarning;
   }

--- a/web/components/run/run-failure-summary.tsx
+++ b/web/components/run/run-failure-summary.tsx
@@ -1,0 +1,175 @@
+import {
+  Activity,
+  AlertCircle,
+  FileJson,
+  GitBranch,
+  SquareTerminal,
+} from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import type { DiagnosticReport, JsonObject, WorkflowArtifacts } from "@/lib/types";
+import { cn } from "@/lib/utils";
+
+type ArtifactState = {
+  badge: string;
+  badgeVariant: "outline" | "secondary";
+  description: string;
+  icon: LucideIcon;
+  label: string;
+};
+
+function hasJsonContent(value: JsonObject | null): boolean {
+  return value !== null && Object.keys(value).length > 0;
+}
+
+function hasWdlContent(value: string): boolean {
+  return value.trim().length > 0;
+}
+
+function hasDiagnosticSignals(diagnostics: DiagnosticReport): boolean {
+  return (
+    diagnostics.analysis_errors.length > 0 ||
+    diagnostics.analysis_warnings.length > 0 ||
+    diagnostics.repair_actions.length > 0 ||
+    diagnostics.validation_message.trim().length > 0 ||
+    diagnostics.check_performed
+  );
+}
+
+function getPrimaryFailureReason(diagnostics: DiagnosticReport): string {
+  const analysisError = diagnostics.analysis_errors.find((error) => error.trim().length > 0);
+  if (analysisError) {
+    return analysisError;
+  }
+
+  const validationMessage = diagnostics.validation_message.trim();
+  if (validationMessage) {
+    return validationMessage;
+  }
+
+  const analysisWarning = diagnostics.analysis_warnings.find(
+    (warning) => warning.trim().length > 0,
+  );
+  if (analysisWarning) {
+    return analysisWarning;
+  }
+
+  return "Run 未成功完成，但 diagnostics 中没有记录具体错误；请查看事件时间线中的失败事件。";
+}
+
+function getDagDisplayMessage(artifacts: WorkflowArtifacts): string {
+  if (hasJsonContent(artifacts.workflow_ir)) {
+    return "DAG 展示失败前已经保存的 Workflow IR 结构；失败阶段以事件时间线和 diagnostics 为准，不映射成 workflow call 执行状态。";
+  }
+
+  if (hasJsonContent(artifacts.plan)) {
+    return "Plan 已保存，但 run 在产生 Workflow IR 前失败；DAG 暂不可用，优先查看事件时间线和 diagnostics。";
+  }
+
+  return "Run 在保存 Workflow IR 前失败；DAG 暂不可用，优先查看事件时间线和 diagnostics。";
+}
+
+function getArtifactStates(
+  artifacts: WorkflowArtifacts,
+  diagnostics: DiagnosticReport,
+): ArtifactState[] {
+  const hasPlan = hasJsonContent(artifacts.plan);
+  const hasWorkflowIr = hasJsonContent(artifacts.workflow_ir);
+  const hasWdl = hasWdlContent(artifacts.wdl);
+  const hasDiagnostics = hasDiagnosticSignals(diagnostics);
+
+  return [
+    {
+      badge: hasPlan ? "已保留" : "未产生",
+      badgeVariant: hasPlan ? "secondary" : "outline",
+      description: "Recipe Tool Plan",
+      icon: FileJson,
+      label: "Plan",
+    },
+    {
+      badge: hasWorkflowIr ? "已保留" : "未产生",
+      badgeVariant: hasWorkflowIr ? "secondary" : "outline",
+      description: "DAG 可视化输入",
+      icon: GitBranch,
+      label: "Workflow IR",
+    },
+    {
+      badge: hasWdl ? "已保留" : "未产生",
+      badgeVariant: hasWdl ? "secondary" : "outline",
+      description: "Renderer 输出",
+      icon: SquareTerminal,
+      label: "WDL",
+    },
+    {
+      badge: hasDiagnostics ? "有线索" : "空报告",
+      badgeVariant: hasDiagnostics ? "secondary" : "outline",
+      description: "Analyzer 与 checker 记录",
+      icon: Activity,
+      label: "Diagnostics",
+    },
+  ];
+}
+
+export function RunFailureSummary({
+  artifacts,
+  className,
+  diagnostics,
+}: {
+  artifacts: WorkflowArtifacts;
+  className?: string;
+  diagnostics: DiagnosticReport;
+}) {
+  const primaryFailureReason = getPrimaryFailureReason(diagnostics);
+  const dagDisplayMessage = getDagDisplayMessage(artifacts);
+  const artifactStates = getArtifactStates(artifacts, diagnostics);
+
+  return (
+    <section className={cn("rounded-md border border-destructive/40 bg-white p-5", className)}>
+      <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+        <div>
+          <div className="flex items-center gap-2">
+            <AlertCircle className="h-5 w-5 text-destructive" />
+            <h2 className="font-semibold">失败回放</h2>
+          </div>
+          <p className="mt-2 text-sm leading-6 text-muted-foreground">
+            Run 未成功完成；这里汇总持久化 snapshot 中保留下来的失败线索和结构化产物。
+          </p>
+        </div>
+        <Badge variant="destructive">运行失败</Badge>
+      </div>
+
+      <div className="mt-5 grid gap-4 lg:grid-cols-2">
+        <div className="rounded-md border bg-background p-4">
+          <div className="text-sm font-semibold">首要失败线索</div>
+          <p className="mt-2 break-words text-sm leading-6 text-muted-foreground">
+            {primaryFailureReason}
+          </p>
+        </div>
+        <div className="rounded-md border bg-background p-4">
+          <div className="text-sm font-semibold">DAG 展示口径</div>
+          <p className="mt-2 break-words text-sm leading-6 text-muted-foreground">
+            {dagDisplayMessage}
+          </p>
+        </div>
+      </div>
+
+      <div className="mt-4 grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+        {artifactStates.map((artifact) => (
+          <div key={artifact.label} className="rounded-md border bg-background p-4">
+            <div className="flex items-start justify-between gap-3">
+              <div className="flex min-w-0 items-center gap-2">
+                <artifact.icon className="h-4 w-4 flex-none text-primary" />
+                <div className="truncate text-sm font-semibold">{artifact.label}</div>
+              </div>
+              <Badge variant={artifact.badgeVariant}>{artifact.badge}</Badge>
+            </div>
+            <p className="mt-2 text-sm leading-6 text-muted-foreground">
+              {artifact.description}
+            </p>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/web/components/workflow-graph/node-detail-panel.tsx
+++ b/web/components/workflow-graph/node-detail-panel.tsx
@@ -1,10 +1,9 @@
 "use client";
 
-import { Activity, AlertCircle, Box, FileOutput, GitBranch, Info } from "lucide-react";
+import { AlertCircle, Box, FileOutput, GitBranch, Info } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
-import { runEventLabels } from "@/lib/run-events";
-import type { JsonValue, RunEvent } from "@/lib/types";
+import type { JsonValue } from "@/lib/types";
 import type {
   WorkflowGraphExpression,
   WorkflowGraphNode,
@@ -13,11 +12,21 @@ import type {
 import type { WorkflowGraphNodeStatus } from "./workflow-node";
 
 const statusLabels: Record<WorkflowGraphNodeStatus, string> = {
-  pending: "Pending",
-  running: "Running",
-  completed: "Completed",
-  failed: "Failed",
-  unavailable: "Unavailable",
+  available: "结构可用",
+  unresolved: "引用待审阅",
+  unavailable: "DAG 不可用",
+};
+
+const statusDescriptions: Record<WorkflowGraphNodeStatus, string> = {
+  available: "该节点来自当前 Workflow IR，可用于审阅结构和元数据。",
+  unresolved: "该节点包含无法解析的表达式引用，需要结合 diagnostics 审阅。",
+  unavailable: "当前 run 尚未产生可展示的 Workflow IR 节点。",
+};
+
+const statusClassNames: Record<WorkflowGraphNodeStatus, string> = {
+  available: "border-primary/40 bg-secondary text-primary",
+  unresolved: "border-destructive/40 bg-destructive text-destructive-foreground",
+  unavailable: "border-muted-foreground/20 text-muted-foreground",
 };
 
 function formatExpression(value: WorkflowGraphExpression): string {
@@ -57,13 +66,18 @@ function runtimeValues(runtime: Record<string, JsonValue>): Record<string, strin
   );
 }
 
+function statusSummary(status: WorkflowGraphNodeStatus, unresolvedCount: number): string {
+  if (status !== "unresolved") {
+    return statusDescriptions[status];
+  }
+  return `${statusDescriptions[status]} 当前节点有 ${unresolvedCount} 条未解析引用。`;
+}
+
 export function NodeDetailPanel({
   node,
-  relatedEvents,
   status,
 }: {
   node: WorkflowGraphNode | null;
-  relatedEvents: RunEvent[];
   status: WorkflowGraphNodeStatus;
 }) {
   if (!node) {
@@ -90,9 +104,14 @@ export function NodeDetailPanel({
       <div className="flex flex-wrap items-center gap-2">
         <h3 className="font-semibold">{node.label}</h3>
         <Badge variant="outline">{node.kind}</Badge>
-        <Badge variant="secondary">{statusLabels[status]}</Badge>
+        <Badge variant="outline" className={statusClassNames[status]}>
+          {statusLabels[status]}
+        </Badge>
       </div>
       <p className="mt-2 break-all font-mono text-xs text-muted-foreground">{node.sourceStepId}</p>
+      <div className="mt-4 rounded-md border bg-background p-3 text-sm leading-6 text-muted-foreground">
+        {statusSummary(status, unresolvedReferences.length)}
+      </div>
 
       {metadata.workflowInput ? (
         <section className="mt-5">
@@ -188,32 +207,6 @@ export function NodeDetailPanel({
           </ul>
         </section>
       ) : null}
-
-      <section className="mt-5">
-        <div className="mb-2 flex items-center gap-2 text-sm font-semibold">
-          <Activity className="h-4 w-4 text-primary" />
-          Related events
-        </div>
-        {relatedEvents.length ? (
-          <div className="grid gap-2">
-            {relatedEvents.slice(-4).map((event) => (
-              <div key={event.event_id} className="rounded-md border bg-background p-3">
-                <div className="flex flex-wrap items-center gap-2 text-xs">
-                  <Badge variant="outline">#{event.sequence}</Badge>
-                  <span className="font-medium">{runEventLabels[event.type]}</span>
-                </div>
-                <p className="mt-2 break-words text-xs leading-5 text-muted-foreground">
-                  {event.summary}
-                </p>
-              </div>
-            ))}
-          </div>
-        ) : (
-          <div className="rounded-md border bg-background p-3 text-sm text-muted-foreground">
-            暂无关联事件。
-          </div>
-        )}
-      </section>
     </aside>
   );
 }

--- a/web/components/workflow-graph/workflow-graph.tsx
+++ b/web/components/workflow-graph/workflow-graph.tsx
@@ -99,11 +99,21 @@ export function WorkflowGraphPanel({
 
   const selectedNode = selectedNodeId ? graphNodesById.get(selectedNodeId) ?? null : null;
   const selectedView = selectedNodeId ? nodeViews.get(selectedNodeId) : null;
+  const hasGraph = graph.nodes.length > 0;
   const unresolvedCount = graph.unresolvedReferences.length;
   const handleNodeClick: NodeMouseHandler = (_, node) => {
     setSelectedNodeId(node.id);
   };
-  const graphStatusLabel = unresolvedCount ? "引用待审阅" : "结构可用";
+  const graphStatusLabel = !hasGraph
+    ? "DAG 不可用"
+    : unresolvedCount
+      ? "引用待审阅"
+      : "结构可用";
+  const graphStatusVariant = !hasGraph
+    ? "outline"
+    : unresolvedCount
+      ? "destructive"
+      : "secondary";
 
   return (
     <section className="mt-6 rounded-md border bg-white p-5">
@@ -114,7 +124,7 @@ export function WorkflowGraphPanel({
             <h2 className="font-semibold">Workflow DAG</h2>
             <Badge variant="outline">{graph.nodes.length} nodes</Badge>
             <Badge variant="outline">{graph.edges.length} edges</Badge>
-            {unresolvedCount ? (
+            {hasGraph && unresolvedCount ? (
               <Badge variant="destructive" className="gap-1.5">
                 <AlertCircle className="h-3.5 w-3.5" />
                 {unresolvedCount} unresolved
@@ -125,13 +135,13 @@ export function WorkflowGraphPanel({
             基于 Workflow IR 的 inputs、steps、scatter 和 outputs 构建依赖图；该图展示编译时结构，不代表真实任务执行状态。
           </p>
         </div>
-        <Badge variant={unresolvedCount ? "destructive" : "secondary"} className="gap-1.5">
-          {unresolvedCount ? <AlertCircle className="h-3.5 w-3.5" /> : null}
+        <Badge variant={graphStatusVariant} className="gap-1.5">
+          {hasGraph && unresolvedCount ? <AlertCircle className="h-3.5 w-3.5" /> : null}
           {graphStatusLabel}
         </Badge>
       </div>
 
-      {graph.nodes.length ? (
+      {hasGraph ? (
         <div className="mt-5 grid gap-4 lg:grid-cols-[minmax(0,1fr)_22rem]">
           <div className="h-[38rem] overflow-hidden rounded-md border bg-background xl:h-[42rem]">
             <ReactFlowProvider>

--- a/web/components/workflow-graph/workflow-graph.tsx
+++ b/web/components/workflow-graph/workflow-graph.tsx
@@ -10,24 +10,17 @@ import {
   type Edge,
   type NodeMouseHandler,
 } from "@xyflow/react";
-import { GitBranch, Loader2 } from "lucide-react";
+import { AlertCircle, GitBranch } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 
 import { Badge } from "@/components/ui/badge";
-import { buildRunEventsUrl } from "@/lib/api";
-import {
-  isTerminalRunStatus,
-  mergeRunEvent,
-  parseRunEventMessage,
-  readPayloadString,
-  runEventTypes,
-} from "@/lib/run-events";
-import type { JsonObject, RunEvent, RunStatus } from "@/lib/types";
+import type { JsonObject } from "@/lib/types";
 import {
   buildWorkflowGraph,
   type WorkflowGraph,
   type WorkflowGraphEdge,
   type WorkflowGraphNode,
+  type WorkflowGraphUnresolvedReference,
 } from "@/lib/workflow-graph";
 import { cn } from "@/lib/utils";
 import { GraphEmptyState } from "./graph-empty-state";
@@ -42,14 +35,6 @@ const nodeTypes = {
   workflowGraphNode: WorkflowNode,
 };
 
-const streamLabels: Record<WorkflowGraphStreamState, string> = {
-  disabled: "无事件流",
-  connecting: "连接中",
-  connected: "读取事件",
-  closed: "事件结束",
-  error: "事件流中断",
-};
-
 const TOP_LEVEL_NODE_HEIGHT = 106;
 const TOP_LEVEL_NODE_WIDTH = 252;
 const SCATTER_HEADER_HEIGHT = 104;
@@ -61,8 +46,6 @@ const CHILD_NODE_X = 52;
 const CHILD_NODE_Y = 94;
 const COLUMN_GAP = 380;
 const ROW_GAP = 32;
-
-type WorkflowGraphStreamState = "disabled" | "connecting" | "connected" | "closed" | "error";
 
 type PositionedNode = WorkflowGraphReactNode & {
   parentId?: string;
@@ -78,28 +61,23 @@ type NodeLayout = {
 
 type GraphNodeView = {
   node: WorkflowGraphNode;
-  relatedEvents: RunEvent[];
   status: WorkflowGraphNodeStatus;
+  unresolvedCount: number;
 };
 
 export function WorkflowGraphPanel({
-  eventsUrl,
-  status,
   workflowIr,
 }: {
-  eventsUrl: string | null;
-  status: RunStatus;
   workflowIr: JsonObject;
 }) {
   const graph = useMemo(() => buildWorkflowGraph(workflowIr), [workflowIr]);
-  const { events, streamState } = useWorkflowGraphEvents(eventsUrl, status);
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
 
   const graphNodesById = useMemo(
     () => new Map(graph.nodes.map((node) => [node.id, node])),
     [graph.nodes],
   );
-  const nodeViews = useMemo(() => buildNodeViews(graph, events, status), [events, graph, status]);
+  const nodeViews = useMemo(() => buildNodeViews(graph), [graph]);
   const { edges, nodes } = useMemo(
     () => toReactFlowElements(graph, nodeViews, selectedNodeId),
     [graph, nodeViews, selectedNodeId],
@@ -121,9 +99,11 @@ export function WorkflowGraphPanel({
 
   const selectedNode = selectedNodeId ? graphNodesById.get(selectedNodeId) ?? null : null;
   const selectedView = selectedNodeId ? nodeViews.get(selectedNodeId) : null;
+  const unresolvedCount = graph.unresolvedReferences.length;
   const handleNodeClick: NodeMouseHandler = (_, node) => {
     setSelectedNodeId(node.id);
   };
+  const graphStatusLabel = unresolvedCount ? "引用待审阅" : "结构可用";
 
   return (
     <section className="mt-6 rounded-md border bg-white p-5">
@@ -134,19 +114,20 @@ export function WorkflowGraphPanel({
             <h2 className="font-semibold">Workflow DAG</h2>
             <Badge variant="outline">{graph.nodes.length} nodes</Badge>
             <Badge variant="outline">{graph.edges.length} edges</Badge>
+            {unresolvedCount ? (
+              <Badge variant="destructive" className="gap-1.5">
+                <AlertCircle className="h-3.5 w-3.5" />
+                {unresolvedCount} unresolved
+              </Badge>
+            ) : null}
           </div>
           <p className="mt-2 text-sm leading-6 text-muted-foreground">
-            基于 Workflow IR 的 inputs、steps、scatter 和 outputs 构建依赖图。
+            基于 Workflow IR 的 inputs、steps、scatter 和 outputs 构建依赖图；该图展示编译时结构，不代表真实任务执行状态。
           </p>
         </div>
-        <Badge
-          variant={streamState === "connected" ? "secondary" : "outline"}
-          className="gap-1.5"
-        >
-          {streamState === "connected" || streamState === "connecting" ? (
-            <Loader2 className="h-3.5 w-3.5 animate-spin" />
-          ) : null}
-          {streamLabels[streamState]}
+        <Badge variant={unresolvedCount ? "destructive" : "secondary"} className="gap-1.5">
+          {unresolvedCount ? <AlertCircle className="h-3.5 w-3.5" /> : null}
+          {graphStatusLabel}
         </Badge>
       </div>
 
@@ -181,7 +162,6 @@ export function WorkflowGraphPanel({
           </div>
           <NodeDetailPanel
             node={selectedNode}
-            relatedEvents={selectedView?.relatedEvents ?? []}
             status={selectedView?.status ?? "unavailable"}
           />
         </div>
@@ -192,83 +172,16 @@ export function WorkflowGraphPanel({
   );
 }
 
-function useWorkflowGraphEvents(
-  eventsUrl: string | null,
-  status: RunStatus,
-): { events: RunEvent[]; streamState: WorkflowGraphStreamState } {
-  const [events, setEvents] = useState<RunEvent[]>([]);
-  const [streamState, setStreamState] = useState<WorkflowGraphStreamState>(
-    eventsUrl ? "connecting" : "disabled",
-  );
-
-  useEffect(() => {
-    if (!eventsUrl) {
-      setStreamState("disabled");
-      return undefined;
-    }
-
-    let isClosed = false;
-    const eventSource = new EventSource(buildRunEventsUrl(eventsUrl));
-    setStreamState("connecting");
-
-    eventSource.onopen = () => {
-      if (!isClosed) {
-        setStreamState("connected");
-      }
-    };
-
-    eventSource.onerror = () => {
-      if (!isClosed) {
-        setStreamState(isTerminalRunStatus(status) ? "closed" : "error");
-      }
-      if (isTerminalRunStatus(status)) {
-        eventSource.close();
-      }
-    };
-
-    const handlers = runEventTypes.map((eventType) => {
-      const handler = (message: MessageEvent<string>) => {
-        const parsed = parseRunEventMessage(message);
-        if (!parsed) {
-          return;
-        }
-
-        setEvents((currentEvents) => mergeRunEvent(currentEvents, parsed));
-        if (parsed.type === "run.completed") {
-          setStreamState("closed");
-          eventSource.close();
-        }
-      };
-      eventSource.addEventListener(eventType, handler);
-      return { eventType, handler };
-    });
-
-    return () => {
-      isClosed = true;
-      handlers.forEach(({ eventType, handler }) => {
-        eventSource.removeEventListener(eventType, handler);
-      });
-      eventSource.close();
-    };
-  }, [eventsUrl, status]);
-
-  return { events, streamState };
-}
-
-function buildNodeViews(
-  graph: WorkflowGraph,
-  events: RunEvent[],
-  runStatus: RunStatus,
-): Map<string, GraphNodeView> {
+function buildNodeViews(graph: WorkflowGraph): Map<string, GraphNodeView> {
   return new Map(
     graph.nodes.map((node) => {
-      const relatedEvents = events.filter((event) => eventBelongsToNode(event, node));
+      const unresolvedCount = countNodeUnresolvedReferences(node);
       return [
         node.id,
         {
           node,
-          relatedEvents,
-          status: getNodeStatus(relatedEvents, runStatus),
+          status: unresolvedCount ? "unresolved" : "available",
+          unresolvedCount,
         },
       ];
     }),
@@ -295,7 +208,7 @@ function toReactFlowElements(
       type: "workflowGraphNode",
       data: {
         graphNode,
-        eventCount: nodeView?.relatedEvents.length ?? 0,
+        unresolvedCount: nodeView?.unresolvedCount ?? 0,
         status: nodeView?.status ?? "unavailable",
       },
       position: {
@@ -352,6 +265,15 @@ function toReactFlowEdge(edge: WorkflowGraphEdge): Edge {
     type: "smoothstep",
     zIndex: edge.kind === "output" ? 3 : edge.kind === "dependency" ? 2 : 1,
   };
+}
+
+function countNodeUnresolvedReferences(node: WorkflowGraphNode): number {
+  const references: WorkflowGraphUnresolvedReference[] = [
+    ...(node.metadata.call?.unresolvedReferences ?? []),
+    ...(node.metadata.scatter?.unresolvedReferences ?? []),
+    ...(node.metadata.workflowOutput?.unresolvedReferences ?? []),
+  ];
+  return references.length;
 }
 
 function calculateNodeLayouts(graph: WorkflowGraph): Map<string, NodeLayout> {
@@ -558,51 +480,6 @@ function average(values: number[]): number | null {
   return values.reduce((total, value) => total + value, 0) / values.length;
 }
 
-function getNodeStatus(
-  relatedEvents: RunEvent[],
-  runStatus: RunStatus,
-): WorkflowGraphNodeStatus {
-  if (!relatedEvents.length) {
-    return runStatus === "running" ? "pending" : "unavailable";
-  }
-
-  const latestEvent = relatedEvents[relatedEvents.length - 1];
-  const payloadStatus = readPayloadString(latestEvent.payload, "status");
-
-  if (latestEvent.type === "node.failed" || payloadStatus === "failed") {
-    return "failed";
-  }
-  if (latestEvent.type === "node.started") {
-    return "running";
-  }
-  if (latestEvent.type === "node.completed" || payloadStatus === "succeeded") {
-    return "completed";
-  }
-
-  return "pending";
-}
-
-function eventBelongsToNode(event: RunEvent, node: WorkflowGraphNode): boolean {
-  const identifiers = new Set([node.id, node.label, node.sourceStepId]);
-
-  if (event.node && identifiers.has(event.node)) {
-    return true;
-  }
-
-  return [
-    "call_id",
-    "input_id",
-    "node_id",
-    "output_id",
-    "source_step_id",
-    "step_id",
-    "workflow_node_id",
-  ].some((key) => {
-    const value = readPayloadString(event.payload, key);
-    return value !== null && identifiers.has(value);
-  });
-}
-
 function getEdgeColor(kind: WorkflowGraphEdge["kind"]): string {
   if (kind === "input") {
     return "#0f766e";
@@ -618,13 +495,10 @@ function shouldShowEdgeLabel(edge: WorkflowGraphEdge): boolean {
 }
 
 function getMiniMapColor(node: WorkflowGraphReactNode): string {
-  if (node.data.status === "failed") {
+  if (node.data.status === "unresolved") {
     return "#ef4444";
   }
-  if (node.data.status === "running") {
-    return "#2563eb";
-  }
-  if (node.data.status === "completed") {
+  if (node.data.status === "available") {
     return "#0f766e";
   }
   return "#94a3b8";

--- a/web/components/workflow-graph/workflow-node.tsx
+++ b/web/components/workflow-graph/workflow-node.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Handle, Position, type Node, type NodeProps } from "@xyflow/react";
-import { Box, Database, FileOutput, GitBranch, Layers3 } from "lucide-react";
+import { AlertCircle, Box, Database, FileOutput, GitBranch, Layers3 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
@@ -9,16 +9,14 @@ import { cn } from "@/lib/utils";
 import type { WorkflowGraphNode, WorkflowGraphNodeKind } from "@/lib/workflow-graph";
 
 export type WorkflowGraphNodeStatus =
-  | "pending"
-  | "running"
-  | "completed"
-  | "failed"
+  | "available"
+  | "unresolved"
   | "unavailable";
 
 export type WorkflowGraphNodeData = {
   graphNode: WorkflowGraphNode;
   status: WorkflowGraphNodeStatus;
-  eventCount: number;
+  unresolvedCount: number;
 };
 
 export type WorkflowGraphReactNode = Node<WorkflowGraphNodeData, "workflowGraphNode">;
@@ -31,11 +29,9 @@ const kindLabels: Record<WorkflowGraphNodeKind, string> = {
 };
 
 const statusLabels: Record<WorkflowGraphNodeStatus, string> = {
-  pending: "Pending",
-  running: "Running",
-  completed: "Completed",
-  failed: "Failed",
-  unavailable: "Unavailable",
+  available: "结构可用",
+  unresolved: "引用待审阅",
+  unavailable: "DAG 不可用",
 };
 
 const kindIcons: Record<WorkflowGraphNodeKind, LucideIcon> = {
@@ -46,25 +42,23 @@ const kindIcons: Record<WorkflowGraphNodeKind, LucideIcon> = {
 };
 
 const statusClassNames: Record<WorkflowGraphNodeStatus, string> = {
-  pending: "border-muted-foreground/30 text-muted-foreground",
-  running: "border-primary/40 bg-secondary text-primary",
-  completed: "border-primary/40 bg-secondary text-primary",
-  failed: "border-destructive/40 bg-destructive text-destructive-foreground",
+  available: "border-primary/40 bg-secondary text-primary",
+  unresolved: "border-destructive/40 bg-destructive text-destructive-foreground",
   unavailable: "border-muted-foreground/20 text-muted-foreground",
 };
 
-function formatEventCount(eventCount: number): string {
-  if (eventCount === 0) {
-    return "No events";
+function formatUnresolvedCount(unresolvedCount: number): string {
+  if (unresolvedCount === 0) {
+    return "Workflow IR 节点";
   }
-  if (eventCount === 1) {
-    return "1 event";
+  if (unresolvedCount === 1) {
+    return "1 条未解析引用";
   }
-  return `${eventCount} events`;
+  return `${unresolvedCount} 条未解析引用`;
 }
 
 export function WorkflowNode({ data, selected }: NodeProps<WorkflowGraphReactNode>) {
-  const { graphNode, status, eventCount } = data;
+  const { graphNode, status, unresolvedCount } = data;
   const Icon = kindIcons[graphNode.kind];
   const isScatter = graphNode.kind === "scatter";
 
@@ -101,11 +95,22 @@ export function WorkflowNode({ data, selected }: NodeProps<WorkflowGraphReactNod
 
       {!isScatter ? (
         <div className="mt-3 flex items-center gap-1.5 text-xs text-muted-foreground">
-          <Layers3 className="h-3.5 w-3.5" />
-          {formatEventCount(eventCount)}
+          {unresolvedCount ? (
+            <AlertCircle className="h-3.5 w-3.5 text-destructive" />
+          ) : (
+            <Layers3 className="h-3.5 w-3.5" />
+          )}
+          {formatUnresolvedCount(unresolvedCount)}
         </div>
       ) : (
-        <div className="mt-3 text-xs leading-5 text-muted-foreground">per-sample group</div>
+        <div className="mt-3 flex items-center gap-1.5 text-xs leading-5 text-muted-foreground">
+          {unresolvedCount ? (
+            <AlertCircle className="h-3.5 w-3.5 text-destructive" />
+          ) : (
+            <Layers3 className="h-3.5 w-3.5" />
+          )}
+          {unresolvedCount ? formatUnresolvedCount(unresolvedCount) : "scatter group"}
+        </div>
       )}
 
       {graphNode.kind !== "workflow-output" ? (


### PR DESCRIPTION
Summary
- Clarify W5 DAG node states as structural review states rather than workflow execution states.
- Add failed run replay summary for preserved artifacts, diagnostics, and DAG display scope.
- Document failed run display policy in the W5 DAG/history plan.

Verification
- npm.cmd run lint
- npm.cmd run test:graph
- npm.cmd run build