### PR TITLE
Add catalog retrieval UI

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -455,7 +455,7 @@ W2 当前接口：
   "updated_at": "2026-06-16T00:00:02Z",
   "completed_at": "2026-06-16T00:00:02Z",
   "artifacts": {
-    "catalog_retrieval": {},
+    "catalog_retrieval": null,
     "plan": {},
     "workflow_ir": {},
     "wdl": "version 1.0\n...",

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -345,6 +345,7 @@ AI-bioworkflow/
 
 ```text
 需求输入
+  -> Catalog Retrieval
   -> Planner / Recipe Tool Plan
   -> IR Normalizer
   -> Analyzer
@@ -382,7 +383,7 @@ FastAPI 默认允许本地 Next.js 开发来源 `http://127.0.0.1:3000` 和
 W4 工作台已接入真实 run 生命周期：`/workspace?example=rnaseq-deg`
 默认提交结构化 RNA-seq Recipe Tool Plan 到 `POST /api/compile`，也可切换到自然语言模式调用
 `POST /api/runs`。页面会订阅 `GET /api/runs/{run_id}/events` 的 SSE 事件流，轮询
-`GET /api/runs/{run_id}` snapshot，并展示同一次 run 的 Plan、Workflow IR、WDL 和 diagnostics。
+`GET /api/runs/{run_id}` snapshot，并展示同一次 run 的 Catalog Retrieval、Plan、Workflow IR、WDL 和 diagnostics。
 
 W2 当前接口：
 
@@ -391,7 +392,7 @@ W2 当前接口：
 | `POST /api/runs` | 从自然语言需求创建一次 Agent run | `run_id`、初始状态、事件流 URL |
 | `POST /api/compile` | 从 Recipe Tool Plan 或 Workflow IR 创建一次确定性编译 run | `run_id`、初始状态、事件流 URL |
 | `GET /api/runs` | 分页查询历史 run 摘要 | run 状态、请求摘要、时间戳、诊断计数 |
-| `GET /api/runs/{run_id}` | 查询详情页所需的 run 快照 | 请求、状态、Plan、IR、WDL、诊断、修复记录 |
+| `GET /api/runs/{run_id}` | 查询详情页所需的 run 快照 | 请求、状态、Catalog Retrieval、Plan、IR、WDL、诊断、修复记录 |
 | `GET /api/runs/{run_id}/events` | 订阅或回放当前 run 的 SSE 事件 | 节点开始/完成/失败、产物更新、最终结果 |
 | `GET /api/recipes` | 查询支持的分析配方列表 | recipe 元数据、required inputs 与步骤 |
 | `GET /api/recipes/{recipe_id}` | 查询单个分析配方 | recipe 元数据、required inputs 与步骤 |
@@ -454,6 +455,7 @@ W2 当前接口：
   "updated_at": "2026-06-16T00:00:02Z",
   "completed_at": "2026-06-16T00:00:02Z",
   "artifacts": {
+    "catalog_retrieval": {},
     "plan": {},
     "workflow_ir": {},
     "wdl": "version 1.0\n...",

--- a/docs/internal-catalog-rag-plan.md
+++ b/docs/internal-catalog-rag-plan.md
@@ -446,9 +446,9 @@ powershell -ExecutionPolicy Bypass -File scripts\check_p0.ps1
 - [x] 结构化入口不依赖 retriever。
 - [x] 自然语言 run 记录 retriever 事件。
 - [x] Run snapshot 暴露 retrieval artifact。
-- [ ] 前端能展示候选 recipe/tools 和 `trust_status`。
+- [x] 前端能展示候选 recipe/tools 和 `trust_status`。
 - [x] 单测覆盖成功、fallback 和错误边界。
-- [ ] 文档说明内部 RAG 与外部工具发现的边界。
+- [x] 文档说明内部 RAG 与外部工具发现的边界。
 
 ## 面试展示叙述
 

--- a/docs/test-cases.md
+++ b/docs/test-cases.md
@@ -3457,6 +3457,83 @@ npm run test:graph
 - graph metadata 中无法直接转成表达式文本的 object fallback 保持 deterministic。
 - 该行为只影响节点详情/审计字符串，不改变 Workflow IR，也不参与 Analyzer 或 Renderer。
 
+## `web/tests/catalog-retrieval.test.mjs`
+
+该文件验证前端 Catalog Retrieval 展示所依赖的纯数据 helper。测试通过
+`tsx --test` 调用 Node 内置 test runner，不启动 Next.js，也不访问后端 API。
+
+运行方式：
+
+```powershell
+cd web
+npm run test:catalog-retrieval
+```
+
+### `detects non-empty catalog retrieval artifacts`
+
+输入：
+
+- `null` retrieval。
+- 空 query、空 recipes、空 tools 且未 fallback 的 retrieval。
+- 包含 RNA-seq query、recipe 和 tool 候选的 retrieval。
+
+期望输出：
+
+- `null` 与空 retrieval 返回 `false`。
+- 包含候选或 query 的 retrieval 返回 `true`。
+
+覆盖点：
+
+- 前端不会为结构化入口或未产生检索产物的 run 伪造 Catalog Retrieval 展示。
+
+### `selects top catalog recipe and limited tools`
+
+输入：
+
+- RNA-seq retrieval artifact，包含 `rnaseq_differential_expression` recipe，以及 `deseq2`、`salmon` tools。
+
+期望输出：
+
+- top recipe 为 `rnaseq_differential_expression`。
+- 限制 tool 数量为 1 时只返回 `deseq2:1.42.1`。
+- limit 为 0 时返回空数组。
+
+覆盖点：
+
+- 工作台 run 卡片和详情页摘要使用稳定的 top recipe/tools 选择逻辑。
+
+### `summarizes matched terms with overflow count`
+
+输入：
+
+- matched terms：`["rna", "seq", "deg"]`，limit 为 2。
+- matched terms：`["rna", "seq"]`，limit 为 4。
+
+期望输出：
+
+- 第一组显示前两个 term，并记录 1 个隐藏 term。
+- 第二组全部显示，隐藏数为 0。
+
+覆盖点：
+
+- `matched_terms` 在紧凑卡片中保持可扫读，同时不丢失溢出计数。
+
+### `formats retrieval scores compactly`
+
+输入：
+
+- 整数 score、浮点 score 和 `NaN`。
+
+期望输出：
+
+- 整数不补小数。
+- 浮点保留 1 位小数。
+- 非法数字显示为 `0`。
+
+覆盖点：
+
+- 候选 recipe/tools 的 score 在前端展示中稳定、简洁。
+
 ## 当前测试覆盖边界
 
 已有测试重点覆盖：
@@ -3467,6 +3544,7 @@ npm run test:graph
 - Catalog 查询服务的 recipe/tool JSON-ready 输出。
 - Approved Catalog Retriever 的词法召回、CJK tokenization、fallback 原因和 JSON-ready 输出契约。
 - 自然语言 run 对 catalog retrieval artifact 的持久化、snapshot 暴露和 SSE 事件回放顺序。
+- 前端 Catalog Retrieval 摘要对 top recipe/tools、matched terms 和 score 格式的处理。
 - Analyzer 对引用、optional input、scatter output 类型提升的处理。
 - Renderer 对 call、scatter、array flatten、workflow output 和 task 的 WDL 渲染。
 - Deterministic repairer 对 call 顺序和 output 字面量的安全修复。
@@ -3488,4 +3566,4 @@ npm run test:graph
 - Reviewer LLM / Resource Agent / Bioinfo Reviewer 等规划中 Agent。
 - Nextflow 或其他 backend。
 - 真实自然语言模型调用的在线集成测试。
-- Next.js 工作台、DAG 可视化和 run history 前端回放。
+- Next.js 工作台、DAG 可视化和 run history 的浏览器级视觉回归测试。

--- a/docs/w4-workbench-plan.md
+++ b/docs/w4-workbench-plan.md
@@ -32,7 +32,7 @@
   - 自然语言模式调用 `POST /api/runs`，planner 失败时展示后端持久化的失败诊断。
   - 前端会轮询 `GET /api/runs/{run_id}`，展示 run 状态、WDL 摘要、校验信息和诊断计数。
   - 前端会订阅 `GET /api/runs/{run_id}/events` SSE 事件流，展示 run 时间线。
-  - Plan / Workflow IR / WDL / Diagnostics tabs 来自真实 run snapshot。
+  - Catalog Retrieval / Plan / Workflow IR / WDL / Diagnostics tabs 来自真实 run snapshot。
   - 默认本地 API base URL 为 `http://127.0.0.1:8010`，可通过 `NEXT_PUBLIC_API_BASE_URL` 覆盖。
 
 ## 产品行为
@@ -46,7 +46,7 @@
 
 - 输入面板展示请求文本、运行模式、`check` 开关和当前 run 状态。
 - 执行时间线展示每个阶段的 pending / running / completed / failed 状态。
-- 产物查看区展示 Plan、IR、WDL 和 Diagnostics。
+- 产物查看区展示 Catalog Retrieval、Plan、IR、WDL 和 Diagnostics。
 - 失败状态保留已产生的事件和 diagnostics，体现可审计失败，而不是只显示通用错误提示。
 
 ## 任务拆分
@@ -116,6 +116,7 @@ SSE 断开但 run 未终态时，页面应显示连接状态，并允许自动�
 
 产物区从当前静态卡片改成真实 tabs：
 
+- **Catalog**：展示自然语言 run 的 top recipe/tools、`score`、`matched_terms`、`matched_fields`、`trust_status` 和 fallback 原因；结构化入口为空状态。
 - **Plan**：展示 Recipe Tool Plan JSON；结构化编译 payload 是 Recipe Tool Plan 时应可见。
 - **IR**：展示 Workflow IR JSON，优先使用 pretty JSON。
 - **WDL**：展示生成的 WDL 1.0 文本。
@@ -177,7 +178,7 @@ W4 已把工作台顶部、运行模式、时间线、artifact tabs 和失败态
   - 页面能从 accepted run 轮询到 `created` / `running` / `succeeded` / `failed` snapshot。
   - 运行卡片展示 run id、状态、WDL 摘要、校验信息、analysis error 计数和 repair action 计数。
   - Timeline 能实时显示 Compiler Graph 节点进度。
-  - Plan、Workflow IR、WDL 和 Diagnostics 来自真实 run snapshot tabs。
+  - Catalog Retrieval、Plan、Workflow IR、WDL 和 Diagnostics 来自真实 run snapshot tabs。
   - 自然语言模式在 planner 环境可用时能走 `POST /api/runs`；环境不可用时显示明确失败诊断。
   - 失败 run 仍保留已产生事件、artifact 和 diagnostics。
 

--- a/web/app/runs/[runId]/page.tsx
+++ b/web/app/runs/[runId]/page.tsx
@@ -18,6 +18,7 @@ import { CatalogRetrievalSummary } from "@/components/run/catalog-retrieval-summ
 import { RunEventsTimeline } from "@/components/run/run-events-timeline";
 import { WorkflowGraphPanel } from "@/components/workflow-graph/workflow-graph";
 import { getRunSnapshot } from "@/lib/api";
+import { hasCatalogRetrieval } from "@/lib/catalog-retrieval";
 import type { JsonObject, RunStatus, WorkflowRunSnapshotResponse } from "@/lib/types";
 
 export const dynamic = "force-dynamic";
@@ -125,6 +126,7 @@ function DiagnosticsSummary({ snapshot }: { snapshot: WorkflowRunSnapshotRespons
 function RunDetail({ snapshot }: { snapshot: WorkflowRunSnapshotResponse }) {
   const kindLabel = snapshot.kind ? kindLabels[snapshot.kind] ?? snapshot.kind : "未记录";
   const requestText = formatRequest(snapshot.request);
+  const hasRetrieval = hasCatalogRetrieval(snapshot.artifacts.catalog_retrieval);
 
   return (
     <>
@@ -168,7 +170,7 @@ function RunDetail({ snapshot }: { snapshot: WorkflowRunSnapshotResponse }) {
         <StatItem label="运行类型" value={kindLabel} />
       </section>
 
-      {snapshot.kind === "natural_language" || snapshot.artifacts.catalog_retrieval ? (
+      {snapshot.kind === "natural_language" || hasRetrieval ? (
         <CatalogRetrievalSummary
           className="mt-6"
           emptyMessage="该自然语言 run 尚未保存 Catalog Retrieval artifact。"

--- a/web/app/runs/[runId]/page.tsx
+++ b/web/app/runs/[runId]/page.tsx
@@ -14,6 +14,7 @@ import Link from "next/link";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { RunArtifactsPanel } from "@/components/run/run-artifacts-panel";
+import { CatalogRetrievalSummary } from "@/components/run/catalog-retrieval-summary";
 import { RunEventsTimeline } from "@/components/run/run-events-timeline";
 import { WorkflowGraphPanel } from "@/components/workflow-graph/workflow-graph";
 import { getRunSnapshot } from "@/lib/api";
@@ -166,6 +167,15 @@ function RunDetail({ snapshot }: { snapshot: WorkflowRunSnapshotResponse }) {
         <StatItem label="完成时间" value={formatDateTime(snapshot.completed_at)} />
         <StatItem label="运行类型" value={kindLabel} />
       </section>
+
+      {snapshot.kind === "natural_language" || snapshot.artifacts.catalog_retrieval ? (
+        <CatalogRetrievalSummary
+          className="mt-6"
+          emptyMessage="该自然语言 run 尚未保存 Catalog Retrieval artifact。"
+          retrieval={snapshot.artifacts.catalog_retrieval}
+          title="Catalog Retrieval 回放"
+        />
+      ) : null}
 
       <section className="mt-6 rounded-md border bg-white p-5">
         <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">

--- a/web/app/workspace/workspace-workbench.tsx
+++ b/web/app/workspace/workspace-workbench.tsx
@@ -14,6 +14,7 @@ import {
 import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
 
+import { CatalogRetrievalSummary } from "@/components/run/catalog-retrieval-summary";
 import { RunArtifactsPanel } from "@/components/run/run-artifacts-panel";
 import { RunEventsTimeline } from "@/components/run/run-events-timeline";
 import { Badge } from "@/components/ui/badge";
@@ -38,6 +39,7 @@ type WorkspaceRunMode = "structured" | "natural_language";
 const POLL_INTERVAL_MS = 1200;
 
 const emptyArtifacts: WorkflowArtifacts = {
+  catalog_retrieval: null,
   plan: null,
   workflow_ir: {},
   wdl: "",
@@ -204,6 +206,10 @@ export function WorkspaceWorkbench({
   const currentStatus = snapshot?.status ?? acceptedRun?.status ?? "created";
   const artifacts = snapshot?.artifacts ?? emptyArtifacts;
   const diagnostics = snapshot?.diagnostics ?? emptyDiagnostics;
+  const shouldShowRetrievalSummary =
+    mode === "natural_language" ||
+    snapshot?.kind === "natural_language" ||
+    artifacts.catalog_retrieval !== null;
   const wdlLineCount = useMemo(() => {
     if (!artifacts.wdl) {
       return 0;
@@ -410,6 +416,16 @@ export function WorkspaceWorkbench({
                 {diagnostics.validation_message}
               </p>
             </div>
+          ) : null}
+
+          {shouldShowRetrievalSummary ? (
+            <CatalogRetrievalSummary
+              compact
+              className="mt-4"
+              emptyMessage="等待 Catalog Retriever 记录候选 recipe 和 tools。"
+              retrieval={artifacts.catalog_retrieval}
+              title="Retriever 候选"
+            />
           ) : null}
         </section>
       </div>

--- a/web/app/workspace/workspace-workbench.tsx
+++ b/web/app/workspace/workspace-workbench.tsx
@@ -24,6 +24,7 @@ import {
   createStructuredCompileRun,
   getRunSnapshot,
 } from "@/lib/api";
+import { hasCatalogRetrieval } from "@/lib/catalog-retrieval";
 import { rnaseqExamplePrompt, rnaseqRecipePlan, rnaseqRecipeSteps } from "@/lib/examples";
 import type {
   DiagnosticReport,
@@ -209,7 +210,7 @@ export function WorkspaceWorkbench({
   const shouldShowRetrievalSummary =
     mode === "natural_language" ||
     snapshot?.kind === "natural_language" ||
-    artifacts.catalog_retrieval !== null;
+    hasCatalogRetrieval(artifacts.catalog_retrieval);
   const wdlLineCount = useMemo(() => {
     if (!artifacts.wdl) {
       return 0;

--- a/web/components/run/catalog-retrieval-summary.tsx
+++ b/web/components/run/catalog-retrieval-summary.tsx
@@ -1,0 +1,202 @@
+"use client";
+
+import { AlertTriangle, Database, Search, ShieldCheck, Tags } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import {
+  formatRetrievalScore,
+  getTopCatalogRecipe,
+  getTopCatalogTools,
+  hasCatalogRetrieval,
+  summarizeMatchedTerms,
+} from "@/lib/catalog-retrieval";
+import type {
+  CatalogRetrievalArtifact,
+  CatalogRetrievalRecipe,
+  CatalogRetrievalTool,
+} from "@/lib/types";
+import { cn } from "@/lib/utils";
+
+type CatalogRetrievalSummaryProps = {
+  className?: string;
+  compact?: boolean;
+  emptyMessage?: string;
+  retrieval: CatalogRetrievalArtifact | null;
+  title?: string;
+};
+
+function MatchedTerms({ terms }: { terms: string[] }) {
+  const { hiddenCount, visibleTerms } = summarizeMatchedTerms(terms);
+
+  if (!visibleTerms.length) {
+    return <span className="text-xs text-muted-foreground">无命中词</span>;
+  }
+
+  return (
+    <div className="flex flex-wrap gap-1.5">
+      {visibleTerms.map((term) => (
+        <Badge key={term} variant="outline">
+          {term}
+        </Badge>
+      ))}
+      {hiddenCount ? <Badge variant="outline">+{hiddenCount}</Badge> : null}
+    </div>
+  );
+}
+
+function CandidateMeta({
+  candidate,
+}: {
+  candidate: CatalogRetrievalRecipe | CatalogRetrievalTool;
+}) {
+  const version = "version" in candidate ? candidate.version : null;
+  const trustStatus = "trust_status" in candidate ? candidate.trust_status : null;
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <span className="font-semibold">{candidate.id}</span>
+      {version ? <Badge variant="outline">v{version}</Badge> : null}
+      {trustStatus ? (
+        <Badge variant="secondary" className="gap-1.5">
+          <ShieldCheck className="h-3.5 w-3.5" />
+          {trustStatus}
+        </Badge>
+      ) : null}
+      <Badge variant="outline">score {formatRetrievalScore(candidate.score)}</Badge>
+    </div>
+  );
+}
+
+function CandidateRow({
+  candidate,
+  compact,
+  kind,
+}: {
+  candidate: CatalogRetrievalRecipe | CatalogRetrievalTool;
+  compact: boolean;
+  kind: "recipe" | "tool";
+}) {
+  return (
+    <div className="rounded-md border bg-background p-3">
+      <div className="flex items-start gap-3">
+        <div className="mt-0.5 rounded-md border bg-white p-2">
+          {kind === "recipe" ? (
+            <Database className="h-4 w-4 text-primary" />
+          ) : (
+            <ShieldCheck className="h-4 w-4 text-primary" />
+          )}
+        </div>
+        <div className="min-w-0 flex-1">
+          <CandidateMeta candidate={candidate} />
+          {!compact ? (
+            <p className="mt-2 break-words text-sm leading-6 text-muted-foreground">
+              {candidate.reason}
+            </p>
+          ) : null}
+          <div className="mt-3">
+            <MatchedTerms terms={candidate.matched_terms} />
+          </div>
+          {!compact && candidate.matched_fields.length ? (
+            <div className="mt-3 flex flex-wrap items-center gap-1.5 text-xs text-muted-foreground">
+              <Tags className="h-3.5 w-3.5" />
+              {candidate.matched_fields.map((field) => (
+                <span key={field}>{field}</span>
+              ))}
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function CatalogRetrievalSummary({
+  className,
+  compact = false,
+  emptyMessage = "当前 run 尚未记录 Catalog Retrieval；结构化编译入口不会触发该阶段。",
+  retrieval,
+  title = "Catalog Retrieval",
+}: CatalogRetrievalSummaryProps) {
+  if (!hasCatalogRetrieval(retrieval)) {
+    return (
+      <section className={cn("rounded-md border bg-background p-4", className)}>
+        <div className="flex items-center gap-2 font-semibold">
+          <Search className="h-4 w-4 text-primary" />
+          {title}
+        </div>
+        <p className="mt-2 text-sm leading-6 text-muted-foreground">{emptyMessage}</p>
+      </section>
+    );
+  }
+
+  const topRecipe = getTopCatalogRecipe(retrieval);
+  const topTools = getTopCatalogTools(retrieval, compact ? 4 : 8);
+
+  return (
+    <section className={cn("rounded-md border bg-white p-4", className)}>
+      <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+        <div>
+          <div className="flex flex-wrap items-center gap-2">
+            <Search className="h-5 w-5 text-primary" />
+            <h3 className="font-semibold">{title}</h3>
+            <Badge variant="outline">{retrieval.strategy}</Badge>
+            <Badge variant="secondary">approved catalog only</Badge>
+          </div>
+          <p className="mt-2 break-words text-sm leading-6 text-muted-foreground">
+            {retrieval.query}
+          </p>
+        </div>
+        {retrieval.fallback_used ? (
+          <Badge variant="outline" className="gap-1.5">
+            <AlertTriangle className="h-3.5 w-3.5" />
+            fallback
+          </Badge>
+        ) : (
+          <Badge variant="outline" className="gap-1.5">
+            <ShieldCheck className="h-3.5 w-3.5" />
+            direct match
+          </Badge>
+        )}
+      </div>
+
+      {retrieval.fallback_used && retrieval.fallback_reason ? (
+        <div className="mt-4 rounded-md border bg-background p-3 text-sm leading-6 text-muted-foreground">
+          {retrieval.fallback_reason}
+        </div>
+      ) : null}
+
+      <div className={cn("mt-4 grid gap-4", compact ? "lg:grid-cols-2" : "xl:grid-cols-[0.85fr_1.15fr]")}>
+        <div>
+          <div className="mb-2 text-sm font-semibold">Top recipe</div>
+          {topRecipe ? (
+            <CandidateRow candidate={topRecipe} compact={compact} kind="recipe" />
+          ) : (
+            <div className="rounded-md border bg-background p-3 text-sm text-muted-foreground">
+              暂无 recipe 候选。
+            </div>
+          )}
+        </div>
+
+        <div>
+          <div className="mb-2 text-sm font-semibold">Top tools</div>
+          {topTools.length ? (
+            <div className="grid gap-2">
+              {topTools.map((tool) => (
+                <CandidateRow
+                  key={`${tool.id}:${tool.version}`}
+                  candidate={tool}
+                  compact={compact}
+                  kind="tool"
+                />
+              ))}
+            </div>
+          ) : (
+            <div className="rounded-md border bg-background p-3 text-sm text-muted-foreground">
+              暂无 tool 候选。
+            </div>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/web/components/run/run-artifacts-panel.tsx
+++ b/web/components/run/run-artifacts-panel.tsx
@@ -2,7 +2,7 @@
 
 import { Activity, FileJson, Layers3, Search, SquareTerminal } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 import { CatalogRetrievalSummary } from "@/components/run/catalog-retrieval-summary";
 import { Badge } from "@/components/ui/badge";
@@ -130,6 +130,7 @@ export function RunArtifactsPanel({
   title?: string;
 }) {
   const [activeTab, setActiveTab] = useState<ArtifactTabId>("plan");
+  const didAutoSelectCatalogRef = useRef(false);
   const hasRetrieval = hasCatalogRetrieval(artifacts.catalog_retrieval);
   const content = useMemo(
     () => ({
@@ -141,7 +142,15 @@ export function RunArtifactsPanel({
   );
 
   useEffect(() => {
-    if (activeTab === "plan" && !content.plan && hasRetrieval) {
+    if (!hasRetrieval) {
+      didAutoSelectCatalogRef.current = false;
+      return;
+    }
+    if (didAutoSelectCatalogRef.current) {
+      return;
+    }
+    didAutoSelectCatalogRef.current = true;
+    if (activeTab === "plan" && !content.plan) {
       setActiveTab("catalog");
     }
   }, [activeTab, content.plan, hasRetrieval]);

--- a/web/components/run/run-artifacts-panel.tsx
+++ b/web/components/run/run-artifacts-panel.tsx
@@ -1,15 +1,17 @@
 "use client";
 
-import { Activity, FileJson, Layers3, SquareTerminal } from "lucide-react";
+import { Activity, FileJson, Layers3, Search, SquareTerminal } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
+import { CatalogRetrievalSummary } from "@/components/run/catalog-retrieval-summary";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { hasCatalogRetrieval } from "@/lib/catalog-retrieval";
 import type { DiagnosticReport, JsonObject, WorkflowArtifacts } from "@/lib/types";
 import { cn } from "@/lib/utils";
 
-type ArtifactTabId = "plan" | "ir" | "wdl" | "diagnostics";
+type ArtifactTabId = "catalog" | "plan" | "ir" | "wdl" | "diagnostics";
 
 type ArtifactTab = {
   id: ArtifactTabId;
@@ -19,6 +21,7 @@ type ArtifactTab = {
 };
 
 const artifactTabs: ArtifactTab[] = [
+  { id: "catalog", label: "Catalog", description: "Approved retriever", icon: Search },
   { id: "plan", label: "Plan", description: "Recipe Tool Plan", icon: FileJson },
   { id: "ir", label: "IR", description: "Workflow DAG 契约", icon: Layers3 },
   { id: "wdl", label: "WDL", description: "生成的 WDL 1.0", icon: SquareTerminal },
@@ -127,6 +130,7 @@ export function RunArtifactsPanel({
   title?: string;
 }) {
   const [activeTab, setActiveTab] = useState<ArtifactTabId>("plan");
+  const hasRetrieval = hasCatalogRetrieval(artifacts.catalog_retrieval);
   const content = useMemo(
     () => ({
       plan: formatJson(artifacts.plan),
@@ -135,6 +139,12 @@ export function RunArtifactsPanel({
     }),
     [artifacts.plan, artifacts.workflow_ir, artifacts.wdl],
   );
+
+  useEffect(() => {
+    if (activeTab === "plan" && !content.plan && hasRetrieval) {
+      setActiveTab("catalog");
+    }
+  }, [activeTab, content.plan, hasRetrieval]);
 
   const active = artifactTabs.find((tab) => tab.id === activeTab) ?? artifactTabs[0];
 
@@ -166,7 +176,12 @@ export function RunArtifactsPanel({
       </div>
 
       <div className="mt-5 rounded-md border bg-background p-4">
-        {activeTab === "diagnostics" ? (
+        {activeTab === "catalog" ? (
+          <CatalogRetrievalSummary
+            retrieval={artifacts.catalog_retrieval}
+            emptyMessage="当前 run 尚未记录 Catalog Retrieval；结构化编译入口不会触发该阶段。"
+          />
+        ) : activeTab === "diagnostics" ? (
           <DiagnosticsView diagnostics={diagnostics} />
         ) : content[activeTab] ? (
           <pre className="max-h-[42rem] overflow-auto whitespace-pre-wrap break-words font-mono text-xs leading-6 text-foreground">

--- a/web/components/run/run-events-timeline.tsx
+++ b/web/components/run/run-events-timeline.tsx
@@ -14,6 +14,8 @@ import { Badge } from "@/components/ui/badge";
 import { buildRunEventsUrl } from "@/lib/api";
 import {
   isTerminalRunStatus,
+  getArtifactLabel,
+  getRunNodeLabel,
   mergeRunEvent,
   parseRunEventMessage,
   runEventLabels,
@@ -147,27 +149,33 @@ export function RunEventsTimeline({
 
       {events.length ? (
         <div className="mt-5 grid gap-3">
-          {events.map((event) => (
-            <div
-              key={event.event_id}
-              className="grid gap-3 rounded-md border bg-background p-4 md:grid-cols-[auto_minmax(0,1fr)_auto] md:items-start"
-            >
-              <div className="mt-0.5">{getEventIcon(event)}</div>
-              <div className="min-w-0">
-                <div className="flex flex-wrap items-center gap-2">
-                  <Badge variant="outline">#{event.sequence}</Badge>
-                  <span className="font-medium">{runEventLabels[event.type]}</span>
-                  {event.node ? <Badge variant="secondary">{event.node}</Badge> : null}
+          {events.map((event) => {
+            const artifactLabel = getArtifactLabel(event.payload);
+            const nodeLabel = getRunNodeLabel(event.node);
+
+            return (
+              <div
+                key={event.event_id}
+                className="grid gap-3 rounded-md border bg-background p-4 md:grid-cols-[auto_minmax(0,1fr)_auto] md:items-start"
+              >
+                <div className="mt-0.5">{getEventIcon(event)}</div>
+                <div className="min-w-0">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <Badge variant="outline">#{event.sequence}</Badge>
+                    <span className="font-medium">{runEventLabels[event.type]}</span>
+                    {nodeLabel ? <Badge variant="secondary">{nodeLabel}</Badge> : null}
+                    {artifactLabel ? <Badge variant="outline">{artifactLabel}</Badge> : null}
+                  </div>
+                  <p className="mt-2 break-words text-sm leading-6 text-muted-foreground">
+                    {event.summary}
+                  </p>
                 </div>
-                <p className="mt-2 break-words text-sm leading-6 text-muted-foreground">
-                  {event.summary}
-                </p>
+                <div className="text-xs text-muted-foreground md:text-right">
+                  {formatDateTime(event.timestamp)}
+                </div>
               </div>
-              <div className="text-xs text-muted-foreground md:text-right">
-                {formatDateTime(event.timestamp)}
-              </div>
-            </div>
-          ))}
+            );
+          })}
         </div>
       ) : (
         <div className="mt-5 rounded-md border bg-background p-5 text-sm leading-6 text-muted-foreground">

--- a/web/lib/catalog-retrieval.ts
+++ b/web/lib/catalog-retrieval.ts
@@ -8,12 +8,14 @@ import type {
 export const DEFAULT_TOP_TOOL_COUNT = 5;
 export const DEFAULT_MATCHED_TERM_COUNT = 6;
 
-const TRUST_STATUSES = new Set<TrustStatus>([
+const TRUST_STATUS_VALUES = [
   "catalog-approved",
   "auto-validated",
   "experimental",
   "rejected",
-]);
+] satisfies TrustStatus[];
+
+const TRUST_STATUSES = new Set<TrustStatus>(TRUST_STATUS_VALUES);
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;

--- a/web/lib/catalog-retrieval.ts
+++ b/web/lib/catalog-retrieval.ts
@@ -2,15 +2,73 @@ import type {
   CatalogRetrievalArtifact,
   CatalogRetrievalRecipe,
   CatalogRetrievalTool,
+  TrustStatus,
 } from "@/lib/types";
 
 export const DEFAULT_TOP_TOOL_COUNT = 5;
 export const DEFAULT_MATCHED_TERM_COUNT = 6;
 
+const TRUST_STATUSES = new Set<TrustStatus>([
+  "catalog-approved",
+  "auto-validated",
+  "experimental",
+  "rejected",
+]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === "string");
+}
+
+function isTrustStatus(value: unknown): value is TrustStatus {
+  return typeof value === "string" && TRUST_STATUSES.has(value as TrustStatus);
+}
+
+function isCatalogRetrievalRecipe(value: unknown): value is CatalogRetrievalRecipe {
+  return (
+    isRecord(value) &&
+    typeof value.id === "string" &&
+    Number.isFinite(value.score) &&
+    isStringArray(value.matched_terms) &&
+    isStringArray(value.matched_fields) &&
+    typeof value.reason === "string"
+  );
+}
+
+function isCatalogRetrievalTool(value: unknown): value is CatalogRetrievalTool {
+  return (
+    isRecord(value) &&
+    typeof value.id === "string" &&
+    typeof value.version === "string" &&
+    Number.isFinite(value.score) &&
+    isStringArray(value.matched_terms) &&
+    isStringArray(value.matched_fields) &&
+    isTrustStatus(value.trust_status) &&
+    typeof value.reason === "string"
+  );
+}
+
+function isCatalogRetrievalArtifact(value: unknown): value is CatalogRetrievalArtifact {
+  return (
+    isRecord(value) &&
+    typeof value.query === "string" &&
+    typeof value.strategy === "string" &&
+    Array.isArray(value.recipes) &&
+    value.recipes.every(isCatalogRetrievalRecipe) &&
+    Array.isArray(value.tools) &&
+    value.tools.every(isCatalogRetrievalTool) &&
+    typeof value.fallback_used === "boolean" &&
+    (value.fallback_reason === null || typeof value.fallback_reason === "string")
+  );
+}
+
 export function hasCatalogRetrieval(
-  retrieval: CatalogRetrievalArtifact | null,
+  retrieval: unknown,
 ): retrieval is CatalogRetrievalArtifact {
-  if (retrieval === null) {
+  if (!isCatalogRetrievalArtifact(retrieval)) {
     return false;
   }
   return Boolean(

--- a/web/lib/catalog-retrieval.ts
+++ b/web/lib/catalog-retrieval.ts
@@ -1,0 +1,58 @@
+import type {
+  CatalogRetrievalArtifact,
+  CatalogRetrievalRecipe,
+  CatalogRetrievalTool,
+} from "@/lib/types";
+
+export const DEFAULT_TOP_TOOL_COUNT = 5;
+export const DEFAULT_MATCHED_TERM_COUNT = 6;
+
+export function hasCatalogRetrieval(
+  retrieval: CatalogRetrievalArtifact | null,
+): retrieval is CatalogRetrievalArtifact {
+  if (retrieval === null) {
+    return false;
+  }
+  return Boolean(
+    retrieval.query.trim() ||
+      retrieval.recipes.length ||
+      retrieval.tools.length ||
+      retrieval.fallback_used,
+  );
+}
+
+export function getTopCatalogRecipe(
+  retrieval: CatalogRetrievalArtifact | null,
+): CatalogRetrievalRecipe | null {
+  return hasCatalogRetrieval(retrieval) ? retrieval.recipes[0] ?? null : null;
+}
+
+export function getTopCatalogTools(
+  retrieval: CatalogRetrievalArtifact | null,
+  limit = DEFAULT_TOP_TOOL_COUNT,
+): CatalogRetrievalTool[] {
+  if (!hasCatalogRetrieval(retrieval) || limit < 1) {
+    return [];
+  }
+  return retrieval.tools.slice(0, limit);
+}
+
+export function summarizeMatchedTerms(
+  terms: string[],
+  limit = DEFAULT_MATCHED_TERM_COUNT,
+): { visibleTerms: string[]; hiddenCount: number } {
+  if (limit < 1) {
+    return { visibleTerms: [], hiddenCount: terms.length };
+  }
+  return {
+    visibleTerms: terms.slice(0, limit),
+    hiddenCount: Math.max(terms.length - limit, 0),
+  };
+}
+
+export function formatRetrievalScore(score: number): string {
+  if (!Number.isFinite(score)) {
+    return "0";
+  }
+  return Number.isInteger(score) ? String(score) : score.toFixed(1);
+}

--- a/web/lib/run-events.ts
+++ b/web/lib/run-events.ts
@@ -22,8 +22,44 @@ export const runEventLabels: Record<RunEventType, string> = {
   "run.completed": "Run 完成",
 };
 
+export const runNodeLabels: Record<string, string> = {
+  analyzer: "Analyzer",
+  catalog_retriever: "Catalog Retrieval",
+  checker: "Checker",
+  compiler: "Compiler",
+  compiler_graph: "Compiler Graph",
+  diagnostics: "Diagnostics",
+  ir_normalizer: "IR Normalizer",
+  planner: "Planner",
+  renderer: "Renderer",
+  repairer: "Repairer",
+};
+
+export const artifactLabels: Record<string, string> = {
+  catalog_retrieval: "Catalog Retrieval",
+  diagnostics: "Diagnostics",
+  plan: "Recipe Tool Plan",
+  wdl: "WDL",
+  workflow_ir: "Workflow IR",
+};
+
 export function isTerminalRunStatus(status: RunStatus): boolean {
   return status === "succeeded" || status === "failed";
+}
+
+export function getRunNodeLabel(node: string | null): string | null {
+  if (node === null) {
+    return null;
+  }
+  return runNodeLabels[node] ?? node;
+}
+
+export function getArtifactLabel(payload: JsonObject): string | null {
+  const artifact = readPayloadString(payload, "artifact");
+  if (artifact === null) {
+    return null;
+  }
+  return artifactLabels[artifact] ?? artifact;
 }
 
 export function mergeRunEvent(events: RunEvent[], nextEvent: RunEvent): RunEvent[] {

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -117,7 +117,35 @@ export type RunListResponse = {
   total: number;
 };
 
+export type CatalogRetrievalRecipe = {
+  id: string;
+  score: number;
+  matched_terms: string[];
+  matched_fields: string[];
+  reason: string;
+};
+
+export type CatalogRetrievalTool = {
+  id: string;
+  version: string;
+  score: number;
+  matched_terms: string[];
+  matched_fields: string[];
+  trust_status: TrustStatus;
+  reason: string;
+};
+
+export type CatalogRetrievalArtifact = {
+  query: string;
+  strategy: string;
+  recipes: CatalogRetrievalRecipe[];
+  tools: CatalogRetrievalTool[];
+  fallback_used: boolean;
+  fallback_reason: string | null;
+};
+
 export type WorkflowArtifacts = {
+  catalog_retrieval: CatalogRetrievalArtifact | null;
   plan: JsonObject | null;
   workflow_ir: JsonObject;
   wdl: string;

--- a/web/package.json
+++ b/web/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint app components lib --max-warnings=0",
+    "test:catalog-retrieval": "tsx --test tests/catalog-retrieval.test.mjs",
     "test:graph": "tsx --test tests/workflow-graph.test.mjs"
   },
   "dependencies": {

--- a/web/tests/catalog-retrieval.test.mjs
+++ b/web/tests/catalog-retrieval.test.mjs
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  formatRetrievalScore,
+  getTopCatalogRecipe,
+  getTopCatalogTools,
+  hasCatalogRetrieval,
+  summarizeMatchedTerms,
+} from "../lib/catalog-retrieval.ts";
+
+const retrieval = {
+  query: "Run bulk RNA-seq differential expression.",
+  strategy: "lexical_v1",
+  recipes: [
+    {
+      id: "rnaseq_differential_expression",
+      score: 22,
+      matched_terms: ["rna", "seq", "differential", "expression"],
+      matched_fields: ["id", "description", "steps.role"],
+      reason: "Matched approved catalog recipe fields.",
+    },
+  ],
+  tools: [
+    {
+      id: "deseq2",
+      version: "1.42.1",
+      score: 8.5,
+      matched_terms: ["differential", "expression"],
+      matched_fields: ["id", "description"],
+      trust_status: "catalog-approved",
+      reason: "Matched approved catalog tool fields.",
+    },
+    {
+      id: "salmon",
+      version: "1.9.0",
+      score: 5,
+      matched_terms: ["quantification"],
+      matched_fields: ["description"],
+      trust_status: "catalog-approved",
+      reason: "Matched approved catalog tool fields.",
+    },
+  ],
+  fallback_used: false,
+  fallback_reason: null,
+};
+
+test("detects non-empty catalog retrieval artifacts", () => {
+  assert.equal(hasCatalogRetrieval(null), false);
+  assert.equal(
+    hasCatalogRetrieval({
+      query: "",
+      strategy: "lexical_v1",
+      recipes: [],
+      tools: [],
+      fallback_used: false,
+      fallback_reason: null,
+    }),
+    false,
+  );
+  assert.equal(hasCatalogRetrieval(retrieval), true);
+});
+
+test("selects top catalog recipe and limited tools", () => {
+  assert.equal(getTopCatalogRecipe(retrieval)?.id, "rnaseq_differential_expression");
+  assert.deepEqual(
+    getTopCatalogTools(retrieval, 1).map((tool) => `${tool.id}:${tool.version}`),
+    ["deseq2:1.42.1"],
+  );
+  assert.deepEqual(getTopCatalogTools(retrieval, 0), []);
+});
+
+test("summarizes matched terms with overflow count", () => {
+  assert.deepEqual(summarizeMatchedTerms(["rna", "seq", "deg"], 2), {
+    visibleTerms: ["rna", "seq"],
+    hiddenCount: 1,
+  });
+  assert.deepEqual(summarizeMatchedTerms(["rna", "seq"], 4), {
+    visibleTerms: ["rna", "seq"],
+    hiddenCount: 0,
+  });
+});
+
+test("formats retrieval scores compactly", () => {
+  assert.equal(formatRetrievalScore(22), "22");
+  assert.equal(formatRetrievalScore(8.53), "8.5");
+  assert.equal(formatRetrievalScore(Number.NaN), "0");
+});

--- a/web/tests/catalog-retrieval.test.mjs
+++ b/web/tests/catalog-retrieval.test.mjs
@@ -46,7 +46,24 @@ const retrieval = {
 };
 
 test("detects non-empty catalog retrieval artifacts", () => {
+  assert.equal(hasCatalogRetrieval(undefined), false);
   assert.equal(hasCatalogRetrieval(null), false);
+  assert.equal(hasCatalogRetrieval({}), false);
+  assert.equal(
+    hasCatalogRetrieval({
+      query: "Run bulk RNA-seq differential expression.",
+      recipes: [],
+      tools: [],
+    }),
+    false,
+  );
+  assert.equal(
+    hasCatalogRetrieval({
+      ...retrieval,
+      tools: [{ id: "deseq2" }],
+    }),
+    false,
+  );
   assert.equal(
     hasCatalogRetrieval({
       query: "",


### PR DESCRIPTION
## Summary

- Add a Catalog Retrieval summary component for run artifacts, workspace cards, and run history replay.
- Surface top recipe/tool candidates, score, matched terms, matched fields, fallback status, and approved-catalog trust context.
- Update frontend retrieval helpers, type definitions, tests, and project documentation for the R4 display milestone.

## Validation

- `npm.cmd run lint`
- `npm.cmd run test:catalog-retrieval`
- `npm.cmd run test:graph`
- `npm.cmd run build`