### PR TITLE
Prefer named artifact records in snapshots

### DIFF
--- a/docs/test-cases.md
+++ b/docs/test-cases.md
@@ -771,6 +771,31 @@ OK (skipped=2)
 - 后续 Catalog Retriever、planner trace 摘要和 execution result 可以作为命名 artifact 保存，不需要为每类产物新增 SQLite 固定列。
 - Artifact 名称有稳定约束，避免 UI 和 API 消费方收到不可预测的 key。
 
+### `test_named_records_override_legacy_fixed_columns_in_snapshot`
+
+输入：
+
+- 一个 natural-language run。
+- 旧固定 artifact 列中已有 `catalog_retrieval`、`plan`、`workflow_ir` 和 `wdl`。
+- 同名 named artifact records 中写入更新后的内容，其中 `workflow_ir == {}` 且 `wdl == ""`。
+
+执行：
+
+- 先调用 `repository.save_artifacts(...)` 写入 legacy fixed columns 和初始 records。
+- 再通过 `save_json_artifact(...)` / `save_text_artifact(...)` 只更新同名 named artifact records。
+- 读取 run snapshot。
+
+期望输出：
+
+- snapshot 顶层 `catalog_retrieval`、`plan`、`workflow_ir` 和 `wdl` 均来自 named artifact records。
+- `extras.catalog_retrieval` 与顶层 `catalog_retrieval` 保持一致。
+- 空 dict 和空字符串 record 不会被当作缺失值而回退到旧固定列。
+
+覆盖点：
+
+- `run_artifact_records` 是 snapshot 的优先读取来源。
+- `run_artifacts` 固定列只作为兼容旧数据库或缺失 records 时的 fallback。
+
 ### `test_snapshot_reads_artifact_records_without_public_list_helper`
 
 输入：

--- a/src/services/run_repository.py
+++ b/src/services/run_repository.py
@@ -974,16 +974,27 @@ def _row_to_artifacts(
     artifact_records: list[RunArtifactRecord],
 ) -> WorkflowArtifacts:
     record_by_name = {record.name: record for record in artifact_records}
-    catalog_retrieval = _artifact_record_content(record_by_name, "catalog_retrieval")
-    plan = _artifact_record_content(record_by_name, "plan")
-    workflow_ir = _artifact_record_content(record_by_name, "workflow_ir") or {}
-    wdl = _artifact_record_content(record_by_name, "wdl") or ""
+    legacy_catalog_retrieval = (
+        _from_json(row["catalog_retrieval_json"]) if row is not None else None
+    )
+    legacy_plan = _from_json(row["plan_json"]) if row is not None else None
+    legacy_workflow_ir = (
+        _from_json(row["workflow_ir_json"]) if row is not None else None
+    )
+    legacy_wdl = row["wdl"] if row is not None else None
 
-    if row is not None:
-        catalog_retrieval = _from_json(row["catalog_retrieval_json"])
-        plan = _from_json(row["plan_json"])
-        workflow_ir = _from_json(row["workflow_ir_json"]) or {}
-        wdl = row["wdl"] or ""
+    catalog_retrieval = _artifact_record_content_or_legacy(
+        record_by_name,
+        "catalog_retrieval",
+        legacy_catalog_retrieval,
+    )
+    plan = _artifact_record_content_or_legacy(record_by_name, "plan", legacy_plan)
+    workflow_ir = _artifact_record_content_or_legacy(
+        record_by_name,
+        "workflow_ir",
+        legacy_workflow_ir,
+    )
+    wdl = _artifact_record_content_or_legacy(record_by_name, "wdl", legacy_wdl)
 
     return WorkflowArtifacts(
         catalog_retrieval=catalog_retrieval if isinstance(catalog_retrieval, dict) else None,
@@ -1006,12 +1017,14 @@ def _row_to_artifacts(
     )
 
 
-def _artifact_record_content(
+def _artifact_record_content_or_legacy(
     record_by_name: dict[str, RunArtifactRecord],
     name: str,
+    legacy_content: Any,
 ) -> Any:
-    record = record_by_name.get(name)
-    return record.content if record is not None else None
+    if name in record_by_name:
+        return record_by_name[name].content
+    return legacy_content
 
 
 def _row_to_diagnostics(row: sqlite3.Row | None, *, check_performed: bool) -> DiagnosticReport:

--- a/tests/test_run_repository.py
+++ b/tests/test_run_repository.py
@@ -176,6 +176,40 @@ class RunRepositoryTests(unittest.TestCase):
             self.assertIn("workflow_ir", {artifact.name for artifact in snapshot.artifacts.manifest})
             self.assertIn("wdl", {artifact.name for artifact in snapshot.artifacts.manifest})
 
+    def test_named_records_override_legacy_fixed_columns_in_snapshot(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repository = RunRepository(Path(temp_dir) / "runs.sqlite3")
+            repository.create_run(
+                run_id="run_001",
+                kind="natural_language",
+                request="Run demo.",
+                check_performed=False,
+                events_url="/api/runs/run_001/events",
+            )
+            repository.save_artifacts(
+                "run_001",
+                WorkflowArtifacts(
+                    catalog_retrieval={"strategy": "legacy"},
+                    plan={"workflow": {"recipe": "legacy"}},
+                    workflow_ir={"workflow": {"name": "LegacyDemo"}},
+                    wdl="version 1.0\nworkflow LegacyDemo {}",
+                ),
+            )
+
+            repository.save_json_artifact("run_001", "catalog_retrieval", {"strategy": "record"})
+            repository.save_json_artifact("run_001", "plan", {"workflow": {"recipe": "record"}})
+            repository.save_json_artifact("run_001", "workflow_ir", {})
+            repository.save_text_artifact("run_001", "wdl", "")
+
+            snapshot = repository.get_snapshot("run_001")
+            self.assertIsNotNone(snapshot)
+            assert snapshot is not None
+            self.assertEqual(snapshot.artifacts.catalog_retrieval, {"strategy": "record"})
+            self.assertEqual(snapshot.artifacts.extras["catalog_retrieval"], {"strategy": "record"})
+            self.assertEqual(snapshot.artifacts.plan, {"workflow": {"recipe": "record"}})
+            self.assertEqual(snapshot.artifacts.workflow_ir, {})
+            self.assertEqual(snapshot.artifacts.wdl, "")
+
     def test_named_extra_artifacts_are_exposed_in_snapshot(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             repository = RunRepository(Path(temp_dir) / "runs.sqlite3")


### PR DESCRIPTION
## Summary

- Prefer `run_artifact_records` over legacy fixed artifact columns when building run snapshots.
- Fall back to legacy `run_artifacts` columns only when the corresponding named record is missing.
- Add regression coverage for same-name record-only updates, including empty JSON/text artifact values.
- Document the new repository test coverage.

## Validation

- `.\.venv\Scripts\python.exe -m unittest tests.test_run_repository -v`
- `.\.venv\Scripts\python.exe -m unittest tests.test_run_service -v`
- `git diff --check`