### PR TITLE
Polish W5 navigation and docs

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -384,7 +384,7 @@ W4/W5 Web 界面已接入真实 run 生命周期：`/workspace?example=rnaseq-de
 默认提交结构化 RNA-seq Recipe Tool Plan 到 `POST /api/compile`，也可切换到自然语言模式调用
 `POST /api/runs`。页面会订阅 `GET /api/runs/{run_id}/events` 的 SSE 事件流，轮询
 `GET /api/runs/{run_id}` snapshot，并展示同一次 run 的 Catalog Retrieval、Plan、Workflow IR、WDL 和 diagnostics。
-`/runs` 读取持久化 run 摘要，`/runs/{run_id}` 可回放事件、产物、诊断、失败摘要和基于 Workflow IR 派生的 DAG。DAG 节点状态表达结构审阅语义，不代表真实 workflow call 执行状态。
+`/runs` 读取持久化 run 摘要，`/runs/[runId]` 可回放事件、产物、诊断、失败摘要和基于 Workflow IR 派生的 DAG。DAG 节点状态表达结构审阅语义，不代表真实 workflow call 执行状态。
 
 当前 run API 接口：
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -81,17 +81,17 @@ Workflow IR 是本项目的核心编译契约。字段结构、表达式系统�
 
 后续新增 IR 数据结构、表达式形式、renderer backend 或 Nextflow 支持时，应先更新该规范，再实现代码与测试。
 
-## 项目展示定位与 Web 产品化目标（规划中）
+## 项目展示定位与 Web 产品化目标
 
 本项目同时承担求职作品集项目的职责：展示开发者能够将生物信息学领域知识转化为可解释、可测试、可交付的 AI Agent 工程系统。因此 Web 层不是简单的结果展示壳，而是用于呈现 Agent 决策过程、结构化中间产物、验证闭环和领域可信边界的产品入口。
 
 Web 产品化遵循以下目标：
 
-1. **突出 Agent 工程能力**：页面应能够展示从自然语言需求、规划过程、Workflow IR、静态分析/修复到 WDL 校验结果的完整链路，而不是只提供一个返回代码的聊天框。
+1. **突出 Agent 工程能力**：页面能够展示从自然语言需求、规划过程、Workflow IR、静态分析/修复到 WDL 校验结果的完整链路，而不是只提供一个返回代码的聊天框。
 2. **突出领域建模能力**：通过 recipe、tool catalog、工作流 DAG、运行输出和科学性告警展示生物信息学问题如何被结构化。
 3. **突出可解释与可审计性**：关键状态变化、修复动作、错误诊断、候选工具来源和镜像可信等级应能够被记录并在详情页回看。
 4. **保留核心编译器独立性**：Web API、CLI 与测试复用相同的 Python 服务层；UI 不侵入 Workflow IR 到 WDL 的确定性编译路径。
-5. **控制非核心投入**：第一版优先完成可演示的 Agent 工作台，不提前引入用户权限、计费、复杂微服务或大规模任务调度基础设施。
+5. **控制非核心投入**：W0-W5 已优先完成可演示的 Agent 工作台、run history、DAG 审阅和失败回放，不提前引入用户权限、计费、复杂微服务或大规模任务调度基础设施。
 
 ## 当前端到端调用链路与编译子图
 
@@ -302,7 +302,7 @@ FastAPI Application
 
 ### 目标仓库目录
 
-以下目录是在现有核心代码基础上的产品化目标结构，按迭代逐步创建：
+以下目录是在现有核心代码基础上的产品化结构；W0-W5 已覆盖 service、API、工作台、历史详情和 DAG 审阅主路径：
 
 ```text
 AI-bioworkflow/
@@ -319,12 +319,12 @@ AI-bioworkflow/
 │   ├── app/
 │   │   ├── page.tsx                # 项目介绍页
 │   │   ├── workspace/              # Workflow 生成工作台
-│   │   ├── workflows/[id]/graph/   # DAG 可视化页
-│   │   └── runs/[id]/              # Agent 执行历史详情页
+│   │   ├── runs/                   # Run 历史列表
+│   │   └── runs/[runId]/           # Run 详情、DAG、事件与产物回放
 │   ├── components/
 │   │   ├── workflow-graph/         # React Flow 图组件
-│   │   ├── run-timeline/           # Agent 阶段与事件组件
-│   │   └── code-viewer/            # Plan / IR / WDL 查看组件
+│   │   ├── run/                    # timeline、artifact tabs、failed summary
+│   │   └── ui/                     # 共享界面组件
 │   └── lib/                        # API client、SSE client 与 TypeScript types
 ├── tests/
 │   ├── ...                         # 现有核心测试
@@ -336,10 +336,10 @@ AI-bioworkflow/
 
 | 页面 | 核心内容 | 招聘展示价值 | 第一版完成标准 |
 | --- | --- | --- | --- |
-| 项目介绍页 | 问题背景、Agent/Compiler 架构、RNA-seq DEG 示例、技术栈与项目边界 | 快速说明生信经验如何转化为 Agent 产品能力 | 可以从介绍跳转到预填充示例的工作台 |
-| Workflow 生成工作台 | 自然语言输入、执行阶段流、Plan / IR / WDL 标签页、校验和修复信息 | 展示端到端 Agent 工程链路与可解释输出 | 提交一个示例请求后可实时看到状态与最终校验结果 |
-| 工作流 DAG 可视化页 | calls、scatter、依赖边、输入输出以及节点状态 | 展示结构化建模、领域工作流理解和可视化能力 | 能从生成的 IR 渲染 RNA-seq 示例 DAG 并选中节点查看详情 |
-| Agent 执行历史详情页 | 原始请求、事件时间线、模型/编译步骤、修复动作、产物与诊断 | 展示可观测性、审计能力和失败处理意识 | 刷新页面后仍可重看一次成功或失败 run 的关键产物 |
+| 项目介绍页 | 问题背景、Agent/Compiler 架构、RNA-seq DEG 示例、技术栈与项目边界 | 快速说明生信经验如何转化为 Agent 产品能力 | 可跳转到预填充示例工作台、run 历史和 API 文档 |
+| Workflow 生成工作台 | 自然语言输入、执行阶段流、Plan / IR / WDL 标签页、校验、修复信息和失败摘要 | 展示端到端 Agent 工程链路与可解释输出 | 提交一个示例请求后可实时看到状态、最终校验结果，并进入历史详情 |
+| Workflow DAG 审阅 | calls、scatter、依赖边、输入输出、runtime docker 和结构状态 | 展示结构化建模、领域工作流理解和可视化能力 | 能在 run 详情中从 Workflow IR 渲染 RNA-seq 示例 DAG 并选中节点查看详情 |
+| Run 历史详情 | 原始请求、事件时间线、模型/编译步骤、修复动作、产物、诊断与失败回放 | 展示可观测性、审计能力和失败处理意识 | 刷新页面后仍可重看一次成功或失败 run 的关键产物 |
 
 第一版工作台重点呈现的阶段为：
 
@@ -359,7 +359,7 @@ AI-bioworkflow/
 
 API 第一版围绕“生成并查看一次可解释 workflow run”设计，不直接引入登录、多租户或正式执行集群。
 
-当前 W2 已落地的是持久化 run API：API 层接收请求、创建展示级 run 记录，并通过后台任务调用 application service / Compiler Graph。FastAPI 只负责 HTTP 入口、状态查询和 SSE 输出，不实现 planner、catalog resolver、Analyzer、Renderer 或 Checker 逻辑。
+当前持久化 run API 已覆盖 W2-W5 展示需求：API 层接收请求、创建展示级 run 记录，并通过后台任务调用 application service / Compiler Graph。FastAPI 只负责 HTTP 入口、状态查询和 SSE 输出，不实现 planner、catalog resolver、Analyzer、Renderer 或 Checker 逻辑。
 
 本地开发端口约定：
 
@@ -380,12 +380,13 @@ FastAPI 默认允许本地 Next.js 开发来源 `http://127.0.0.1:3000` 和
 `http://localhost:3000` 访问 API。当前端开发服务改用其他端口时，可通过
 `AI_BIOWORKFLOW_CORS_ORIGINS` 配置逗号分隔的 allowed origins；配置值会去除首尾空白和末尾 `/`，避免常见本地 URL 写法导致 CORS 不匹配。
 
-W4 工作台已接入真实 run 生命周期：`/workspace?example=rnaseq-deg`
+W4/W5 Web 界面已接入真实 run 生命周期：`/workspace?example=rnaseq-deg`
 默认提交结构化 RNA-seq Recipe Tool Plan 到 `POST /api/compile`，也可切换到自然语言模式调用
 `POST /api/runs`。页面会订阅 `GET /api/runs/{run_id}/events` 的 SSE 事件流，轮询
 `GET /api/runs/{run_id}` snapshot，并展示同一次 run 的 Catalog Retrieval、Plan、Workflow IR、WDL 和 diagnostics。
+`/runs` 读取持久化 run 摘要，`/runs/{run_id}` 可回放事件、产物、诊断、失败摘要和基于 Workflow IR 派生的 DAG。DAG 节点状态表达结构审阅语义，不代表真实 workflow call 执行状态。
 
-W2 当前接口：
+当前 run API 接口：
 
 | Endpoint | 用途 | 主要返回 |
 | --- | --- | --- |
@@ -514,7 +515,7 @@ W2 当前接口：
 }
 ```
 
-第一版事件类型包含：`run.created`、`node.started`、`node.completed`、`node.failed`、`artifact.updated`、`repair.applied`、`validation.completed` 和 `run.completed`。Run service 会为事件 payload 补充稳定的 observability 字段，例如 `stage`、`status`、`node`、`artifact_name`、`artifact_content_type` 和 `error_type`。这些字段用于前端时间线、DAG 状态映射和历史回放；事件中不保存 API key、原始模型鉴权信息或其他秘密环境变量。
+第一版事件类型包含：`run.created`、`node.started`、`node.completed`、`node.failed`、`artifact.updated`、`repair.applied`、`validation.completed` 和 `run.completed`。Run service 会为事件 payload 补充稳定的 observability 字段，例如 `stage`、`status`、`node`、`artifact_name`、`artifact_content_type` 和 `error_type`。这些字段用于前端时间线、失败摘要和历史回放；DAG 状态由 Workflow IR 结构与 unresolved references 派生。事件中不保存 API key、原始模型鉴权信息或其他秘密环境变量。
 
 ### 持久化与部署边界
 
@@ -537,13 +538,15 @@ Web 展示轨道与后续 Multi-Agent 能力路线并行推进，优先让已经
 | W5 | DAG 与历史详情 | React Flow 工作流图、run 历史详情和失败/修复回放 | W4 |
 | W6 | 部署与作品集打磨 | 在线 demo、示例数据、架构图、截图/录屏、API 文档与 README 导航 | W5 |
 
+截至 W5，最小作品集演示链路已经落地：访问者能够使用预置 RNA-seq 示例触发 run，看到 Agent/Compiler 阶段过程、Workflow IR、DAG、校验后的 WDL、历史回放和失败 run 摘要。W6 负责将这些能力包装成可在简历和项目主页直接访问、快速理解的在线作品。
+
 `W4` 的具体实施范围、任务拆分和验收口径记录在
 [W4 Workflow 生成工作台工作拆解](./docs/w4-workbench-plan.md)。
 
 `W5` 的具体实施范围、任务拆分和验收口径记录在
 [W5 DAG 与历史详情工作拆解](./docs/w5-dag-history-plan.md)。
 
-求职展示的最小可发布范围为 `W0` 至 `W5`：访问者能够使用一个预置 RNA-seq 示例触发 run，看到 Agent/Compiler 的阶段过程、Workflow IR、DAG、校验后的 WDL 与历史回放。`W6` 负责将能力包装成可在简历和项目主页直接访问、快速理解的作品。
+W0-W5 是求职展示的最小可发布范围；W6 继续补齐在线部署、截图/录屏、架构图和更直接的作品集导航。
 
 ## Agent 修复闭环与职责边界（规划中）
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ LLM 在这个架构中更适合承担规划、补全、修复与解释任务；�
 - **Agentic 架构**：基于 LangGraph 串联 IR Normalizer、Analyzer、Repairer、Renderer 与 Checker 节点，支持继续扩展 LLM planner / repairer。
 - **可复用服务与 API**：CLI 与 FastAPI 复用同一套 workflow/catalog service，避免界面层复制编译逻辑。
 - **执行后端边界**：提供可配置的 Execution Backend 抽象和 Cromwell REST client，用 contract tests 覆盖提交、轮询、outputs/metadata 与失败语义。
+- **Run history 与 DAG 审阅**：Next.js 工作台接入真实 run snapshot、SSE 时间线、历史详情、Workflow IR DAG 和失败 run 回放。
 - **模块化设计**：高度解耦的 State、Prompts、Nodes 与 Tools 设计，极佳的代码可维护性。
 
 ## 🛠️ 快速开始
@@ -179,10 +180,12 @@ $env:AI_BIOWORKFLOW_API_PORT = "8020"
 .\.venv\Scripts\python.exe -m src.api.server
 ```
 
-### 7. 启动 Web 工作台
+### 7. 启动 Web 工作台与历史回放
 
 前端位于 `web/`，作为独立的 Next.js 应用运行。`/workspace?example=rnaseq-deg`
-的“运行示例”会调用 FastAPI `POST /api/compile`，并轮询 run snapshot 显示状态摘要。
+的“运行示例”会调用 FastAPI `POST /api/compile`，订阅 SSE 事件流，并轮询 run snapshot
+显示 Plan、Workflow IR、WDL、Diagnostics 和失败摘要。`/runs` 会读取持久化 run history，
+`/runs/[runId]` 可以刷新回放同一次 run 的 timeline、artifacts、diagnostics 和 Workflow IR DAG。
 本地演示时需要分别启动 FastAPI 和 Next.js。前端默认读取本地 FastAPI：
 
 ```text
@@ -201,6 +204,12 @@ npm install
 ```powershell
 npm run dev
 ```
+
+常用演示入口：
+
+- `http://127.0.0.1:3000/workspace?example=rnaseq-deg`
+- `http://127.0.0.1:3000/runs`
+- `http://127.0.0.1:3000/catalog`
 
 如果后端 API 地址不同，复制 `web/.env.example` 为 `web/.env.local` 并调整：
 
@@ -270,6 +279,10 @@ Workflow IR 的结构、表达式规则、scatter 语义和 WDL 后端映射详�
 
 👉 **[Workflow IR 规范与后端映射](./docs/workflow-ir.md)**
 
+Web 产品化拆解与当前 W5 验收口径详见：
+
+👉 **[W5 DAG 与历史详情工作拆解](./docs/w5-dag-history-plan.md)**
+
 ## 📅 未来路线图 (Roadmap)
 
 - [x] 搭建基础 LangGraph 状态机。
@@ -289,7 +302,8 @@ Workflow IR 的结构、表达式规则、scatter 语义和 WDL 后端映射详�
 - [x] 记录一份可复现的 [Cromwell e2e 验证摘要](./docs/p0-e2e-verification.md)，包括 workflow id、最终状态和 output keys。
 - [x] 实现 W2 run 事件、SQLite 展示级持久化和 SSE 事件流。
 - [x] 完成 W4 工作台：结构化示例 / 自然语言 run 创建、snapshot 轮询、SSE 时间线、Plan / IR / WDL / Diagnostics tabs 和失败态展示。
-- [ ] 建设 [W5 DAG 可视化和历史详情页](./docs/w5-dag-history-plan.md)。
+- [x] 完成 [W5 DAG 可视化和历史详情页](./docs/w5-dag-history-plan.md)：真实 run 列表、详情回放、Workflow IR DAG、结构状态和失败 run 摘要。
+- [ ] W6 部署与作品集打磨：在线 demo、示例数据、架构图、截图/录屏、API 文档与 README 导航。
 - [ ] 扩展更多常用生信 recipe 与 tool catalog。
 
 ## 📄 许可证

--- a/docs/w5-dag-history-plan.md
+++ b/docs/w5-dag-history-plan.md
@@ -200,7 +200,7 @@ web/components/workflow-graph/
 ### 7. 导航、文案与文档更新
 
 - 工作台运行后提供“查看详情”入口。
-- `/runs` 列表提供返回工作台 / 运行示例入口。
+- `/runs` 列表提供运行 RNA-seq 示例入口，`/runs/[runId]` 详情页提供返回历史和运行示例入口。
 - 项目介绍页中 DAG 和 Timeline 的系统视图文案已从预览状态更新为真实能力。
 - README roadmap 已链接到本文件，并将 W5 标记为完成。
 - `DEVELOPMENT.md` 保留 W5 里程碑摘要，并链接本拆解文档。

--- a/docs/w5-dag-history-plan.md
+++ b/docs/w5-dag-history-plan.md
@@ -1,12 +1,12 @@
 # W5 DAG 与历史详情工作拆解
 
-本文档记录 Web 产品化路线中 `W5` 阶段的实施范围、任务拆分和验收口径，便于后续开发按同一边界推进。
+本文档记录 Web 产品化路线中 `W5` 阶段的实施范围、已落地能力和验收口径，便于后续开发按同一边界维护。
 
 ## 阶段定位
 
 `W5` 的目标是把 `W4` 工作台产生的一次 workflow run，从“可实时生成”推进到“可结构化理解、可回放、可审计”。
 
-完成后，访问者应能从工作台创建 RNA-seq 示例 run，在历史列表中再次找到它，进入详情页回放事件、产物和诊断信息，并通过 DAG 图理解 Workflow IR 中的 calls、scatter、依赖边、输入输出和结构状态。
+当前访问者已经能从工作台创建 RNA-seq 示例 run，在历史列表中再次找到它，进入详情页回放事件、产物和诊断信息，并通过 DAG 图理解 Workflow IR 中的 calls、scatter、依赖边、输入输出和结构状态。
 
 `W5` 是 run 历史与 Workflow IR 可视化阶段，不改变 Compiler Graph 的职责，不让前端生成或修复 Plan、IR、WDL，也不引入新的 Agent 节点或真实 WDL 执行后端。
 
@@ -17,11 +17,12 @@
 - `/workspace?example=rnaseq-deg` 可以稳定创建结构化 RNA-seq 示例 run。
 - 失败 run 保留已产生的 events、artifacts 和 diagnostics，供历史详情页回放。
 
-如果进入 `W5` 时上述能力尚未全部完成，应先收尾 `W4`，避免历史详情页和工作台重复实现同一套事件、产物和失败态展示逻辑。
+这些进入条件保留为阶段边界记录：如果后续重构发现工作台、历史详情页或失败态展示出现重复实现，应优先复用 W4/W5 已沉淀的事件、产物和诊断组件。
 
-## 当前基础
+## 已落地能力
 
-- 后端已有单个 run 查询接口：
+- 后端已有 run 历史与详情查询接口：
+  - `GET /api/runs`：分页返回 run 摘要、状态、时间戳和诊断计数。
   - `GET /api/runs/{run_id}`：返回 run snapshot、artifacts 和 diagnostics。
   - `GET /api/runs/{run_id}/events`：通过 SSE 推送或回放 run events。
 - SQLite repository 已保存：
@@ -30,14 +31,16 @@
   - `run_artifacts`
   - `run_diagnostics`
 - 前端已有：
-  - `/workspace` 示例 run launcher。
-  - `/runs` 静态历史列表预览。
+  - `/workspace` 真实 run 工作台。
+  - `/runs` 真实历史列表。
+  - `/runs/[runId]` 历史详情、事件回放、artifact tabs、失败摘要和 Workflow IR DAG。
+  - `workflow-graph` 纯数据模型、React Flow 展示组件和 graph 测试。
   - `RunEvent`、`WorkflowArtifacts`、`DiagnosticReport` 和 `WorkflowRunSnapshotResponse` 类型。
 - Workflow IR 已以 `workflow.steps` 作为 canonical DAG 表示，`workflow.calls` 仅用于兼容旧输入和调试输出。
 
 ## 产品行为
 
-第一版 `W5` 建议围绕同一个 `run_id` 组织三层视图：
+第一版 `W5` 已围绕同一个 `run_id` 组织三层视图：
 
 1. **历史列表**：展示最近 run 的状态、请求摘要、创建/更新时间、诊断摘要和详情入口。
 2. **历史详情**：回放同一次 run 的 request、timeline、Plan、IR、WDL 和 Diagnostics。
@@ -71,15 +74,15 @@ Analyzer、Checker 或 Planner 失败应主要通过 timeline、diagnostics 和 
 
 ### 1. 后端 run 历史列表契约
 
-新增 `GET /api/runs`，用于分页读取持久化 run 摘要。
+已新增 `GET /api/runs`，用于分页读取持久化 run 摘要。
 
-建议第一版 query 参数：
+第一版 query 参数：
 
 - `limit`：默认 20，设置合理上限。
 - `offset`：默认 0。
 - `status`：可选，过滤 `created` / `running` / `succeeded` / `failed`。
 
-建议响应 DTO：
+响应 DTO：
 
 ```json
 {
@@ -108,23 +111,23 @@ Analyzer、Checker 或 Planner 失败应主要通过 timeline、diagnostics 和 
 }
 ```
 
-Repository 层应按 `created_at DESC` 或 `updated_at DESC` 稳定排序，并补充 service 与 API route 测试。列表响应不返回完整 WDL 或大块 JSON artifact，避免历史页首屏过重。
+Repository 层按稳定时间顺序返回结果，并通过 service 与 API route 测试覆盖。列表响应不返回完整 WDL 或大块 JSON artifact，避免历史页首屏过重。
 
 ### 2. 前端 API client 与类型
 
-在 `web/lib/types.ts` 和 `web/lib/api.ts` 中补齐：
+已在 `web/lib/types.ts` 和 `web/lib/api.ts` 中补齐：
 
 - `RunSummary`
 - `RunDiagnosticSummary`
 - `RunListResponse`
 - `listRuns(params?)`
-- `getRunEvents(runId, afterSequence?)` 或继续复用 SSE URL helper，由详情页选择是否一次性回放事件。
+- SSE URL helper，用于详情页和工作台复用持久化事件回放。
 
 类型应与 Pydantic DTO 显式同步，页面组件不直接拼装松散的 `any`。
 
 ### 3. `/runs` 真实历史列表页
 
-替换当前静态预览：
+`/runs` 已替换静态预览：
 
 - 首屏展示最近 run。
 - 状态 badge 使用 created / running / succeeded / failed。
@@ -136,9 +139,9 @@ Repository 层应按 `created_at DESC` 或 `updated_at DESC` 稳定排序，并�
 
 ### 4. `/runs/[runId]` 历史详情页
 
-新增 run 详情页，读取 `GET /api/runs/{run_id}` 和事件回放数据。
+run 详情页已读取 `GET /api/runs/{run_id}` 和事件回放数据。
 
-详情页需要展示：
+详情页展示：
 
 - run id、状态、运行类型、创建/完成时间。
 - 原始 request 或结构化 payload 摘要。
@@ -150,9 +153,9 @@ Repository 层应按 `created_at DESC` 或 `updated_at DESC` 稳定排序，并�
 
 ### 5. Workflow graph 数据模型
 
-在前端新增纯函数，把 `WorkflowArtifacts.workflow_ir` 转成图模型。
+前端已新增纯函数，把 `WorkflowArtifacts.workflow_ir` 转成图模型。
 
-建议图模型包含：
+图模型包含：
 
 - workflow input nodes。
 - call nodes。
@@ -174,9 +177,9 @@ Repository 层应按 `created_at DESC` 或 `updated_at DESC` 稳定排序，并�
 
 ### 6. React Flow DAG 可视化
 
-引入 React Flow 作为 W5 的前端展示依赖，用于交互式 DAG 布局、节点选择和边关系展示。新增依赖时需要在 PR 描述中说明用途。
+已引入 React Flow 作为 W5 的前端展示依赖，用于交互式 DAG 布局、节点选择和边关系展示。
 
-建议组件目录：
+当前组件目录：
 
 ```text
 web/components/workflow-graph/
@@ -196,10 +199,10 @@ web/components/workflow-graph/
 
 ### 7. 导航、文案与文档更新
 
-- 工作台成功后提供“查看历史详情”入口。
-- `/runs` 列表提供“返回工作台”入口。
-- 项目介绍页中 DAG 和 Timeline 的系统视图文案从预览状态更新为真实能力。
-- README roadmap 链接到本文件。
+- 工作台运行后提供“查看详情”入口。
+- `/runs` 列表提供返回工作台 / 运行示例入口。
+- 项目介绍页中 DAG 和 Timeline 的系统视图文案已从预览状态更新为真实能力。
+- README roadmap 已链接到本文件，并将 W5 标记为完成。
 - `DEVELOPMENT.md` 保留 W5 里程碑摘要，并链接本拆解文档。
 
 公共文案保持项目维护者视角，强调工程、编译器、生信工作流建模和产品可观测性，不加入工具签名、自动生成说明或外部助手品牌化措辞。
@@ -213,14 +216,14 @@ web/components/workflow-graph/
 - 不把历史列表做成多用户、权限或长期审计系统；第一版只服务本地和作品集 demo。
 - 不新增生信 tool catalog 或 recipe，除非 DAG 展示发现现有示例缺少必要元数据。
 
-## 建议 PR 顺序
+## 收口记录
 
-1. **W5 run history API**：新增 run summary DTO、repository 分页查询、service 方法、`GET /api/runs` 与 API 测试。
-2. **W5 real runs list page**：替换 `/runs` 静态样例，接入真实列表和错误/空状态。
-3. **W5 run detail replay**：新增 `/runs/[runId]`，复用 timeline、artifact tabs 和 diagnostics 展示。
-4. **W5 workflow graph model**：实现 Workflow IR 到 graph nodes/edges 的纯函数和覆盖 scatter 的测试。
-5. **W5 React Flow DAG view**：接入 React Flow、节点详情面板和状态映射。
-6. **W5 navigation and docs polish**：更新工作台入口、README、DEVELOPMENT 和作品集文案。
+1. **W5 run history API**：已新增 run summary DTO、repository 分页查询、service 方法、`GET /api/runs` 与 API 测试。
+2. **W5 real runs list page**：已替换 `/runs` 静态样例，接入真实列表和错误/空状态。
+3. **W5 run detail replay**：已新增 `/runs/[runId]`，复用 timeline、artifact tabs、diagnostics 和失败摘要。
+4. **W5 workflow graph model**：已实现 Workflow IR 到 graph nodes/edges 的纯函数和覆盖 scatter 的测试。
+5. **W5 React Flow DAG view**：已接入 React Flow、节点详情面板和结构状态映射。
+6. **W5 navigation and docs polish**：已更新工作台入口、README、DEVELOPMENT 和作品集文案。
 
 ## 验收标准
 
@@ -253,6 +256,7 @@ web/components/workflow-graph/
 ```powershell
 cd web
 npm run lint
+npm run test:graph
 npm run build
 ```
 

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -7,6 +7,7 @@ import {
   FileJson,
   FlaskConical,
   GitBranch,
+  History,
   Layers3,
   Network,
   ShieldCheck,
@@ -96,20 +97,20 @@ const systemSurfaces: Array<{
   },
   {
     title: "Timeline",
-    description: "展示 run 从 created 到终态的生命周期事件。",
+    description: "基于持久化 SSE envelope 回放 run 生命周期事件。",
     icon: GitBranch,
   },
   {
     title: "DAG",
-    description: "查看 calls、scatter 分组、依赖边和节点详情。",
+    description: "查看 Workflow IR 的 calls、scatter、依赖边和结构状态。",
     icon: Network,
   },
 ];
 
 const stackRows = [
   ["编译器核心", "Python 3.13、LangGraph、Pydantic、Jinja2"],
-  ["API 层", "FastAPI、SQLite 持久化、SSE 事件回放"],
-  ["Web 外壳", "Next.js、TypeScript、Tailwind、shadcn-style 组件"],
+  ["API 层", "FastAPI、SQLite run history、SSE 事件回放"],
+  ["Web 外壳", "Next.js、TypeScript、Tailwind、React Flow"],
   ["工作流目标", "Workflow IR、WDL 1.0、WOMtool / miniwdl 校验"],
 ];
 
@@ -123,20 +124,26 @@ export default function Home() {
           <div className="w-full max-w-[calc(100vw-3rem)] sm:max-w-2xl">
             <div className="flex flex-wrap items-center gap-3">
               <Badge variant="secondary">可解释的生信 Workflow 生成与编译系统</Badge>
-              <Badge variant="outline">W3 产品外壳</Badge>
+              <Badge variant="outline">W5 Run history + DAG</Badge>
             </div>
             <h1 className="mt-6 text-4xl font-semibold tracking-normal text-foreground sm:text-5xl lg:text-6xl">
               AI-bioworkflow
             </h1>
             <p className="mt-6 max-w-xl break-words text-base leading-7 text-muted-foreground sm:text-lg sm:leading-8">
               从自然语言需求到结构化计划、Workflow IR 与可验证 WDL，
-              展示工具目录、静态分析、确定性渲染和诊断回放。
+              展示工具目录、静态分析、确定性渲染、DAG 审阅和历史回放。
             </p>
             <div className="mt-8 flex flex-wrap gap-3">
               <Button asChild>
                 <Link href={workspaceHref}>
                   打开 RNA-seq 示例
                   <ArrowRight className="h-4 w-4" />
+                </Link>
+              </Button>
+              <Button asChild variant="outline">
+                <Link href="/runs">
+                  <History className="h-4 w-4" />
+                  查看 Run 历史
                 </Link>
               </Button>
               <Button asChild variant="outline">
@@ -148,7 +155,7 @@ export default function Home() {
               {[
                 ["边界", "LLM 负责规划"],
                 ["契约", "Recipe Tool Plan -> Workflow IR"],
-                ["验证", "Analyzer + WDL checker"],
+                ["回放", "Timeline + DAG + Diagnostics"],
               ].map(([label, body]) => (
                 <div key={label} className="rounded-md border bg-white/88 p-4 shadow-sm backdrop-blur">
                   <div className="font-semibold text-primary">{label}</div>
@@ -239,11 +246,11 @@ export default function Home() {
           <div className="max-w-2xl">
             <h2 className="text-2xl font-semibold tracking-normal">系统视图</h2>
             <p className="mt-3 text-muted-foreground">
-              产品外壳围绕 workflow review 最重要的产物和可观测记录组织。
+              工作台与历史详情围绕 workflow review 最重要的产物和可观测记录组织。
             </p>
           </div>
           <Button asChild variant="outline">
-            <Link href={workspaceHref}>预览工作台</Link>
+            <Link href={workspaceHref}>打开工作台</Link>
           </Button>
         </div>
         <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">

--- a/web/app/runs/page.tsx
+++ b/web/app/runs/page.tsx
@@ -275,7 +275,7 @@ export default async function RunsPage({
         <Button asChild variant="outline">
           <Link href="/workspace?example=rnaseq-deg">
             <RotateCcw className="h-4 w-4" />
-            返回工作台
+            运行 RNA-seq 示例
           </Link>
         </Button>
       </div>

--- a/web/app/runs/page.tsx
+++ b/web/app/runs/page.tsx
@@ -275,7 +275,7 @@ export default async function RunsPage({
         <Button asChild variant="outline">
           <Link href="/workspace?example=rnaseq-deg">
             <RotateCcw className="h-4 w-4" />
-            运行 RNA-seq 示例
+            返回工作台
           </Link>
         </Button>
       </div>

--- a/web/app/workspace/page.tsx
+++ b/web/app/workspace/page.tsx
@@ -27,7 +27,7 @@ export default async function WorkspacePage({
           </Button>
           <div className="flex flex-wrap items-center gap-3">
             <h1 className="text-3xl font-semibold tracking-normal">Workflow 工作台</h1>
-            <Badge variant="secondary">W4 Workbench</Badge>
+            <Badge variant="secondary">W5 Workbench</Badge>
             <Badge variant="outline">真实 run 接入</Badge>
           </div>
           <p className="mt-3 max-w-2xl text-muted-foreground">
@@ -39,7 +39,7 @@ export default async function WorkspacePage({
           <Button asChild variant="outline">
             <Link href="/runs">
               <History className="h-4 w-4" />
-              Run 历史
+              Run 历史回放
             </Link>
           </Button>
           <Button asChild variant="outline">


### PR DESCRIPTION
Summary
- Update README and DEVELOPMENT to reflect W5 run history, DAG review, and failed-run replay as completed capabilities.
- Refresh the home page, workspace, and runs navigation copy for the W5 product surface.
- Convert the W5 DAG/history plan from implementation plan wording to landed capability and acceptance-record wording.

Verification
- npm.cmd run lint
- npm.cmd run test:graph
- npm.cmd run build