### PR TITLE
Organize development roadmap documentation

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -551,6 +551,34 @@ Web 展示轨道与后续 Multi-Agent 能力路线并行推进，优先让已经
 
 W0-W5 是求职展示的最小可发布范围；W6 继续补齐在线部署、截图/录屏、架构图和更直接的作品集导航。W6 完成后，前端主线进入 feature freeze：除 bugfix、响应式 polish、文案微调和后续 Agent 能力带来的小型展示增量外，不再继续规划独立的前端功能阶段。
 
+### W0-W6 前端展示面与后续承接边界
+
+当前前端已形成完整的 run workbench 和 replay 体验：
+
+- 首页提供项目入口、核心能力说明和 demo 导航。
+- `/workspace` 支持结构化 RNA-seq 示例和自然语言 run 两种模式。
+- 工作台调用 FastAPI run API，轮询 run snapshot，并通过 SSE 订阅事件流。
+- Run timeline 展示 planner、compiler、artifact update、repair 和 checker 事件。
+- Artifact tabs 展示 Catalog Retrieval、Plan、Workflow IR、WDL 和 Diagnostics。
+- Catalog Retrieval summary 展示 top recipe、top tools、score、matched terms、matched fields、trust status 和 fallback 状态。
+- `/runs` 历史列表读取持久化 run 摘要，展示状态、请求摘要、诊断计数和时间戳。
+- `/runs/[runId]` 详情页支持刷新后回放 request、events、artifacts、diagnostics 和 Workflow IR DAG。
+- Workflow DAG 基于 Workflow IR 生成 React Flow 图，支持 workflow inputs、call nodes、scatter groups、outputs 和节点详情。
+- 失败 run 摘要能够展示失败状态、diagnostics 和已保存的部分 artifacts。
+
+前端职责边界：
+
+- 前端展示后端 API 和 persisted run artifacts，不生成或修复 Recipe Tool Plan、Workflow IR 或 WDL。
+- 页面展示的数据应来自 API snapshot、SSE event 或 persisted artifact，不依赖前端推理拼装状态。
+- 工作台和历史详情页应复用 timeline、artifact、diagnostics、DAG 和 failure summary 组件。
+- Planner、Catalog、Analyzer、Checker 或未来 Reviewer 的失败都应保留已产生 artifacts，并可在历史详情中回放。
+
+W6 之后，前端不再规划新的独立 W7/W8 产品阶段。后续只作为 backend / Agent 能力的展示承接面，候选增量包括：
+
+- **Real Catalog Browser**：Catalog 页面读取 `/api/recipes` 和 `/api/tools`，展示 recipe required inputs、steps、scatter、allowed tools，以及 tool inputs、params、outputs、runtime docker 和 trust status。
+- **Retrieval Evaluation Summary**：当 retrieval evaluation 建立后，前端可展示 lexical、vector、hybrid retriever 的指标摘要；指标应来自 eval artifact 或版本化结果，不在前端重新计算。
+- **Agent Artifact Display**：Bioinfo Reviewer warnings、Resource Agent suggestions、Reviewer Repair request / patch / rejection / applied summary 等能力落地后，以结构化 artifact 形式进入 UI；前端不展示未脱敏 raw model output，也不改变 Plan、IR 或 WDL。
+
 ## Agent 修复闭环与职责边界（规划中）
 
 ### 有界反思与自愈
@@ -719,15 +747,33 @@ Candidate ToolSpec
 
 本路线描述智能编排、检索和运行环境能力的演进；可演示 Web 产品的建设顺序见上文 `W0` 至 `W6`，两条轨道可以并行推进。
 
+后端 Agent 路线继续遵循当前稳定边界：
+
+- LLM 不直接生成最终 WDL；自然语言 Planner 只输出 Recipe Tool Plan。
+- Recipe 和 tool 选择必须通过完整 approved Catalog validation。
+- Approved Catalog Retriever 只缩小 planner context，不作为准入边界。
+- Workflow IR 是 compiler 内部 canonical model；WDL 由确定性 renderer 生成。
+- Analyzer、Repairer、Renderer、Checker 不应被前端、prompt 或 Agent 节点绕过。
+- 结构化编译路径不依赖 `DEEPSEEK_API_KEY`。
+
+当前已落地的后端 Agent 基线包括：
+
+- `plan_and_compile_workflow` 通过 Orchestration Graph 串联 planner 和 compiler delegate。
+- `compile_structured_workflow` 支持 Recipe Tool Plan、Workflow IR 和 legacy JSON。
+- Run service 保存 run、events、artifacts、diagnostics，并支持 SSE replay。
+- Planner failure、schema failure、catalog failure、compiler failure 会进入 failed run。
+- Deterministic repairer 可处理安全的 IR 修复，例如拓扑顺序和有限 literal 问题。
+- Execution backend 抽象和 Cromwell backend contract tests 已存在，但不混入默认前端 demo 路径。
+
 | 阶段 | 建设内容 | 主要交付 |
 | --- | --- | --- |
-| P0 | 稳定现有 Recipe / Catalog / 执行测试 | 可靠的编译与执行评测基线 |
+| P0 | 稳定现有 Recipe / Catalog / 执行测试 | 可靠的编译、验证、run 记录和执行评测基线 |
 | P1 | Compiler Graph 明确化与 Orchestration Graph 外壳 | 自然语言和结构化入口分层，Planner 可在上层图运行 |
-| P2 | 有界 Reviewer LLM 与 IR 修复闭环 | 结构化修复、诊断记录、失败报告 |
-| P3 | Architect 与 Bioinfo Reviewer 分层 | 分析方案和科学性告警职责分离 |
-| P4 | Approved Catalog Tool Retriever | 高召回候选工具筛选和 prompt 缩减 |
-| P5 | Resource Agent | 可追踪的 CPU / memory / disk 建议与 override |
-| P6 | External Retrieval 与 Candidate ToolSpec | 未知工具发现和候选定义 |
+| P2 | 有界 Reviewer LLM 与 IR 修复闭环 | 结构化 IR patch、policy validation、diagnostics 和 run artifacts |
+| P3 | Architect 与 Bioinfo Reviewer 分层 | 分析方案和科学性告警职责分离，Bioinfo Reviewer 只读输出 warnings |
+| P4 | Approved Catalog Tool Retriever 与 RAG 子序列 | approved catalog 内候选工具筛选、prompt 缩减、retrieval trace、查询测试集和检索策略演进 |
+| P5 | Resource Agent | 可追踪的 CPU / memory / disk 建议与 override，资源建议不选择工具或镜像 |
+| P6 | External Retrieval 与 Candidate ToolSpec | 未知工具发现和候选定义，不自动写入 approved Catalog |
 | P7 | On-demand Experimental Container Build | 临时镜像支持当前探索任务 |
 | P8 | Validated Container Promotion | GHCR 正式发布及 Catalog digest 准入 |
 | P9 | 文献驱动 Workflow Blueprint | 从文献方法提取候选流程 |
@@ -749,14 +795,60 @@ P2 的目标是将 Reviewer LLM 作为受控 IR 修复分支接入 Compiler Grap
 
 👉 **[P2 Reviewer IR 修复闭环实施计划](./docs/p2-reviewer-repair-plan.md)**
 
+### P3 Architect 与 Bioinfo Reviewer
+
+P3 的目标是把分析方案职责和方法学审查职责分开。Architect Agent 负责形成候选分析方案、步骤和预期输出；Bioinfo Reviewer 负责只读审查并输出 warnings，例如缺少 QC、缺少样本分组或 contrast、未说明 transcriptome index / reference resource、MultiQC 汇总输入不足等。
+
+Bioinfo Reviewer 的边界：
+
+- 不直接修改 Recipe Tool Plan 或 Workflow IR。
+- 不选择工具、不改 runtime、不生成 WDL。
+- warnings 进入 run artifacts，并可被前端展示。
+- warnings 默认不阻断确定性编译，除非后续显式引入 policy。
+
+### P4 Approved Catalog Tool Retriever 与 RAG 子序列
+
+P4 的目标是在自然语言 Planner 之前加入 approved catalog 内部检索层。这个检索层只缩小候选 recipe / tool context，并记录召回依据；完整 recipe/catalog validation 仍然使用全量 approved catalog，结构化编译入口也不依赖 retriever。
+
+RAG 开发序列放在 P4 之下维护：
+
+| 子阶段 | 文档 | 目标 |
+| --- | --- | --- |
+| R1 | [Internal Catalog RAG / Tool Retriever](./docs/r1-internal-catalog-rag-plan.md) | Approved Catalog Retriever MVP、Planner prompt 集成、run artifact 和前端展示 |
+| R2 | [Retrieval Evaluation Roadmap](./docs/r2-retrieval-evaluation-roadmap.md) | 查询测试集、Recall@K、MRR、Role Coverage、vector / hybrid retriever 优先级 |
+| R3 | 规划中 | 在 R2 baseline 后选择 vector 或 hybrid backend，并保持现有 artifact contract |
+| R4 | 规划中 | 当 catalog 和标注数据足够后，再评估 reranker 或 embedding fine-tuning |
+
+R1/R2 仍属于受控 Catalog 内检索，不进入 P6 的未知工具发现边界。外部网页、论文、未知工具和 Candidate ToolSpec 的发现应继续归入 P6。
+
+### P5 Resource Agent
+
+P5 的目标是对 task runtime 资源字段提供可追踪建议。Resource Agent 只处理 CPU、memory、disk 等资源字段，并记录建议依据，例如 tool metadata、sample count、file size hint 或默认 policy。
+
+Resource Agent 的边界：
+
+- 不选择工具。
+- 不替换 Docker image。
+- 不改变 command template。
+- 不改变分析方法。
+- Resource suggestion 与 Workflow IR 修改分开记录；如资源字段被覆盖，run artifacts 必须包含理由。
+
+### P6 External Retrieval 与 Candidate ToolSpec
+
+P6 的目标是在 approved Catalog 不覆盖用户请求时，形成候选工具定义，而不是直接引入未知工具。
+
+External Retrieval 的输出应是 Candidate ToolSpec 草案，至少记录工具名称、版本、用途、输入输出、参数、命令依据、来源 URL、未确认字段和验证状态。该草案不自动写入 approved Catalog，不自动替换 container image，也不能绕过 Catalog validation。
+
 ## 评测重点（规划中）
 
 | 能力 | 首要指标 |
 | --- | --- |
-| Reviewer LLM | IR 修复成功率、错误修改率、平均修复轮数、诊断可读性 |
+| Planner | valid plan rate、catalog validation pass rate、planner error class distribution |
+| Deterministic Repairer | safe repair success rate、false repair rate |
+| Reviewer LLM | IR patch accepted rate、post-patch validation pass rate、policy rejection rate、诊断可读性 |
 | Bioinfo Reviewer | 高风险缺失步骤召回率、误告警率 |
 | Tool Retriever | `Recall@K`、步骤覆盖率、Planner 成功率、prompt token 降幅、回退比例 |
-| Resource Agent | 执行成功率、OOM 率、资源浪费比例、override 可追踪率 |
+| Resource Agent | OOM reduction、resource over-allocation rate、suggestion traceability |
 | Candidate ToolSpec | 字段完整率、来源可追溯率、准入接受率 |
 | 临时镜像构建 | 构建成功率、smoke test 通过率、任务首跑等待时间 |
 | 文献方法提取 | 显式步骤提取准确率、推断标注准确率、缺失信息识别率 |

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -733,6 +733,14 @@ P1 的目标是明确 Compiler Graph，并建立第一版 Orchestration Graph �
 
 👉 **[P1 Orchestration Graph 实施计划](./docs/p1-orchestration-graph-plan.md)**
 
+### P2 实施计划
+
+P2 的目标是将 Reviewer LLM 作为受控 IR 修复分支接入 Compiler Graph。Reviewer 只能在确定性 repairer 没有安全修复动作时提出结构化 Workflow IR patch；patch 必须经过 schema、policy、Analyzer、Renderer 和 Checker 验证，不能直接生成 WDL 或绕过 Catalog 与容器准入边界。
+
+详细工作拆解、关键契约、验收清单和建议 PR 切分维护在：
+
+👉 **[P2 Reviewer IR Repair Plan](./docs/p2-reviewer-repair-plan.md)**
+
 ## 评测重点（规划中）
 
 | 能力 | 首要指标 |

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -560,7 +560,7 @@ W0-W5 是求职展示的最小可发布范围；W6 继续补齐在线部署、�
 - 工作台调用 FastAPI run API，轮询 run snapshot，并通过 SSE 订阅事件流。
 - Run timeline 展示 planner、compiler、artifact update、repair 和 checker 事件。
 - Artifact tabs 展示 Catalog Retrieval、Plan、Workflow IR、WDL 和 Diagnostics。
-- Catalog Retrieval summary 展示 top recipe、top tools、score、matched terms、matched fields、trust status 和 fallback 状态。
+- Catalog Retrieval summary 展示 top recipe、top tools、`score`、`matched_terms`、`matched_fields`、`trust_status` 和 fallback 状态。
 - `/runs` 历史列表读取持久化 run 摘要，展示状态、请求摘要、诊断计数和时间戳。
 - `/runs/[runId]` 详情页支持刷新后回放 request、events、artifacts、diagnostics 和 Workflow IR DAG。
 - Workflow DAG 基于 Workflow IR 生成 React Flow 图，支持 workflow inputs、call nodes、scatter groups、outputs 和节点详情。

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -739,7 +739,7 @@ P2 的目标是将 Reviewer LLM 作为受控 IR 修复分支接入 Compiler Grap
 
 详细工作拆解、关键契约、验收清单和建议 PR 切分维护在：
 
-👉 **[P2 Reviewer IR Repair Plan](./docs/p2-reviewer-repair-plan.md)**
+👉 **[P2 Reviewer IR 修复闭环实施计划](./docs/p2-reviewer-repair-plan.md)**
 
 ## 评测重点（规划中）
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -575,7 +575,7 @@ W0-W5 是求职展示的最小可发布范围；W6 继续补齐在线部署、�
 
 W6 之后，前端不再规划新的独立 W7/W8 产品阶段。后续只作为 backend / Agent 能力的展示承接面，候选增量包括：
 
-- **Real Catalog Browser**：Catalog 页面读取 `/api/recipes` 和 `/api/tools`，展示 recipe required inputs、steps、scatter、allowed tools，以及 tool inputs、params、outputs、runtime docker 和 trust status。
+- **Real Catalog Browser**：Catalog 页面读取 `/api/recipes` 和 `/api/tools`，展示 recipe required inputs、steps、scatter、allowed tools，以及 tool inputs、params、outputs、`runtime.docker` 和 `trust_status`。
 - **Retrieval Evaluation Summary**：当 retrieval evaluation 建立后，前端可展示 lexical、vector、hybrid retriever 的指标摘要；指标应来自 eval artifact 或版本化结果，不在前端重新计算。
 - **Agent Artifact Display**：Bioinfo Reviewer warnings、Resource Agent suggestions、Reviewer Repair request / patch / rejection / applied summary 等能力落地后，以结构化 artifact 形式进入 UI；前端不展示未脱敏 raw model output，也不改变 Plan、IR 或 WDL。
 

--- a/docs/p2-reviewer-repair-plan.md
+++ b/docs/p2-reviewer-repair-plan.md
@@ -270,6 +270,12 @@ artifacts，避免前端和 API 消费方解析文本 summary。
 
 验证：
 
+```bash
+.venv/bin/python -m unittest discover -v
+```
+
+Windows PowerShell：
+
 ```powershell
 .\.venv\Scripts\python.exe -m unittest discover -v
 ```

--- a/docs/p2-reviewer-repair-plan.md
+++ b/docs/p2-reviewer-repair-plan.md
@@ -1,0 +1,316 @@
+# P2 Reviewer IR 修复闭环实施计划
+
+本文档细化 P2 阶段的工程工作：把 Reviewer LLM 作为受控 IR 修复分支接入
+Compiler Graph。它补充 `DEVELOPMENT.md` 中的路线图摘要，并承接 P1
+Orchestration Graph 的分层边界。
+
+## 背景与现状
+
+P1 已建立双层图边界：
+
+```text
+自然语言请求
+  -> Orchestration Graph
+  -> Recipe Tool Plan
+  -> Compiler Graph
+  -> Workflow IR / WDL / Diagnostic Report
+
+结构化输入
+  -> Compiler Graph
+  -> Workflow IR / WDL / Diagnostic Report
+```
+
+当前 Compiler Graph 负责确定性的结构化编译：
+
+```text
+Recipe Tool Plan / Workflow IR / Legacy JSON
+  -> IR Normalizer
+  -> Analyzer
+  -> deterministic Repairer when a safe fix exists
+  -> Renderer
+  -> Checker
+```
+
+现有 deterministic repairer 仍然是第一层修复机制。P2 只在编译链路已经产生
+diagnostics，且 deterministic repairer 没有安全修复动作时，引入 Reviewer LLM
+提出受约束的 Workflow IR patch。
+
+## P2 目标
+
+P2 的目标是增加一个有界 IR 修复闭环，使 Analyzer 或 Checker 失败后，可以由
+Reviewer 提出结构化 Workflow IR 修复建议。
+
+完成后应满足：
+
+- Analyzer 和 Checker 失败可以路由到 Reviewer repair 分支，但必须发生在
+  deterministic repairer 已失败或明确放弃修复之后。
+- Reviewer 输入是结构化请求，包含当前 Workflow IR、diagnostics、validation
+  output、修复历史和 approved Catalog 上下文。
+- Reviewer 输出只能是 schema 可校验的 IR patch 或显式 no-op 结果。
+- patch 应用范围限制在 Workflow IR 内，并且应用后必须重新经过 Analyzer、
+  Renderer 和 Checker。
+- 修复轮数有硬上限，最终失败时返回可读的 diagnostic report。
+- run events 和 artifacts 能暴露 Reviewer 尝试、已接受 patch、已拒绝 patch 和最终
+  diagnostics。
+
+## 非目标
+
+P2 不承担以下工作：
+
+- 不允许任何 LLM 直接生成或修改最终 WDL。
+- 不绕过 Analyzer、Renderer、Checker 或 Catalog validation。
+- 不引入未知工具、外部工具发现、Candidate ToolSpec 或容器构建行为。
+- 不修改 Tool Catalog 条目、command template、runtime image 来源或容器可信策略。
+- 不实现 Architect Agent、Bioinfo Reviewer、Resource Agent 或完整 Multi-Agent
+  planning。
+- 不改变自然语言入口路由，除非是为了把已有 approved Catalog 上下文传给
+  Reviewer 请求。
+- 不要求结构化确定性编译路径依赖 `DEEPSEEK_API_KEY`。
+
+## 目标 Compiler Flow
+
+```text
+Analyzer / Checker failure
+  -> deterministic Repairer
+       -> safe deterministic fix
+            -> Analyzer / Renderer / Checker
+       -> no safe deterministic fix
+            -> Reviewer Repair Node
+                 -> structured IR patch
+                 -> patch schema validation
+                 -> patch policy validation
+                 -> apply patch
+                 -> Analyzer / Renderer / Checker
+            -> rejected / no-op / exhausted attempts
+                 -> Diagnostic Report
+```
+
+Reviewer node 是 Compiler Graph 的失败恢复分支，不属于 Orchestration Graph 的
+planner sequence。
+
+## 契约草案
+
+P2 应引入明确的 request、patch 和 result model，而不是在 compiler nodes 之间传递
+自由 prompt 文本。
+
+### ReviewerRepairRequest
+
+建议字段：
+
+| 字段 | 说明 |
+| --- | --- |
+| `workflow_ir` | 当前 Workflow IR candidate。 |
+| `failure_stage` | `analyzer` 或 `checker`。 |
+| `analysis_errors` | Analyzer diagnostics。 |
+| `analysis_warnings` | Analyzer warnings。 |
+| `validation_message` | Checker 或 WDL validator 输出。 |
+| `repair_history` | 已尝试的 deterministic 和 Reviewer repair actions。 |
+| `catalog_context` | 避免未知工具和越权工具选择所需的 approved recipe/tool context。 |
+| `attempt_index` | 当前 Reviewer 尝试次数。 |
+| `constraints` | allowed changes 的机器可读 policy 限制。 |
+
+### ReviewerIRPatch
+
+初始 patch model 应保持保守。建议结构：
+
+| 字段 | 说明 |
+| --- | --- |
+| `summary` | 人类可读的修复意图。 |
+| `actions` | 有序 patch action 列表。 |
+| `diagnostic_references` | 触发 patch 的错误信息或 validator 行。 |
+| `catalog_references` | 支撑 patch 的 approved tools 或 recipes。 |
+| `confidence` | 粗粒度置信度，仅用于 diagnostics，不可用于绕过验证。 |
+
+每个 patch action 应包含 operation、target path、可选 value 和 reason。path 语言必须
+限制在 patch policy 明确允许的 Workflow IR 字段内。
+
+### ReviewerRepairResult
+
+建议状态：
+
+- `patch_proposed`
+- `no_action`
+- `invalid_request`
+- `policy_rejected`
+- `model_error`
+
+只有在经过脱敏且不包含 secrets 时，才可以把 raw Reviewer output 作为诊断材料保存。
+
+## Patch Policy
+
+P2 初版应采用窄 allowlist。Reviewer patch 只能更新 compiler repair 所需的
+Workflow IR 字段，不能修改：
+
+- final WDL text；
+- Tool Catalog entries；
+- task command templates；
+- runtime Docker images；
+- container trust fields；
+- approved context 之外的 tool IDs 或 recipe IDs；
+- 未来 Resource Agent 负责的 resource sizing fields。
+
+初始允许的 patch 区域建议聚焦：
+
+- deterministic rules 无法安全处理的 workflow step ordering；
+- 使用已有 workflow inputs 或已有 call outputs 的 call input wiring；
+- 引用已有作用域值的 workflow output expressions；
+- Workflow IR expression rules 覆盖范围内的有限 expression literal 修复。
+
+任何超出 allowlist 的 patch 都必须在修改 compiler state 之前被拒绝。
+
+## Observability
+
+P2 应复用现有 run artifact contract，避免继续增加固定 artifact 列。
+
+建议事件：
+
+- `node.started` / `node.completed`：`reviewer_repair`；
+- `node.failed`：Reviewer provider 或 patch validation 失败；
+- `repair.proposed`：产出结构化 patch；
+- `repair.rejected`：schema 或 policy validation 拒绝 patch；
+- `repair.applied`：patch 被接受并应用。
+
+建议 artifacts：
+
+- `reviewer_repair_request`：脱敏后的结构化 request。
+- `reviewer_ir_patch`：已接受或已拒绝的结构化 patch。
+- `workflow_ir`：patch 应用后、`repair.applied` 事件前更新。
+- `diagnostics`：包含 Reviewer attempt count 的最终诊断报告。
+
+现有 `repair_actions` list 可以继续作为兼容摘要，但结构化 patch 应进入 named
+artifacts，避免前端和 API 消费方解析文本 summary。
+
+## 实现拆分
+
+### P2.1 Plan 与契约模型
+
+交付：
+
+- 本计划文档。
+- Reviewer request、patch action、patch result 和 patch diagnostics 的 Pydantic
+  models。
+- 在执行 policy 的模块中用简短注释或 docstring 固定 patch policy。
+
+测试：
+
+- 合法 patch model 可解析。
+- 非法 patch model 会失败。
+- 尝试编辑 WDL、Catalog、runtime image 或 resource sizing 的 patch 会被拒绝。
+
+### P2.2 Patch Application Layer
+
+交付：
+
+- 一个小型 patch application 模块，接收 Workflow IR 和已校验 patch，返回新的
+  Workflow IR candidate。
+- 对 forbidden paths 和 unsupported operations 给出清晰 policy error。
+- patch 通过 schema 与 policy validation 前，不修改原始 IR object。
+
+测试：
+
+- 允许的 workflow wiring patch 可应用。
+- 禁止的 runtime 或 command patch 被拒绝。
+- patch 失败时原始 IR 保持不变。
+- 应用后的 patch 在 graph re-entry 前仍通过 Workflow IR schema validation。
+
+### P2.3 Reviewer Node 与 Provider Boundary
+
+交付：
+
+- `reviewer_repair` compiler node。
+- 可在测试中 fake 的 provider interface。
+- prompt construction 只包含结构化 request data 和 approved context。
+- structured path 未显式启用 Reviewer 或没有 API key 时，不触发 model call。
+
+测试：
+
+- Reviewer 不可用时 node 返回 no-op，并记录 diagnostics。
+- fake provider patch 可被 node 接受并返回 validated patch data。
+- provider 输出非法时 node 拒绝 patch，且不应用。
+
+### P2.4 Compiler Graph Routing
+
+交付：
+
+- Analyzer 和 Checker failure routing 先尝试 deterministic repair。
+- 只有 deterministic repair 没有安全动作且 repair budget 仍可用时，才进入 Reviewer
+  branch。
+- 修复次数有硬上限，可共享现有 `repair_count`，也可显式拆分
+  deterministic/reviewer counters。
+
+测试：
+
+- deterministic repair 路径行为不变。
+- deterministic repair 成功时不调用 Reviewer。
+- deterministic repair 放弃且 policy 允许时调用 Reviewer。
+- 修复次数耗尽时返回 failed diagnostic report。
+
+### P2.5 Run Service 与 API Observability
+
+交付：
+
+- Reviewer start、completion、rejection、application 和 failure 的 run events。
+- 脱敏 request 与结构化 patch 的 named artifacts。
+- diagnostic summary 或 artifact content 能展示 Reviewer attempt count 和最终状态。
+
+测试：
+
+- Reviewer 尝试后 run snapshot 包含 Reviewer artifacts。
+- SSE/history replay 中 `workflow_ir` update 早于 `repair.applied`。
+- Reviewer 失败时，run completion 前仍写入 diagnostics。
+
+### P2.6 文档与验收
+
+交付：
+
+- P2 实现落地时更新 `DEVELOPMENT.md` 状态。
+- 增加测试时同步更新 `docs/test-cases.md`。
+- 只有 Workflow IR schema 或 expression rules 发生变化时，才更新
+  `docs/workflow-ir.md`。
+
+验证：
+
+```powershell
+.\.venv\Scripts\python.exe -m unittest discover -v
+```
+
+如果实现改动影响生成 WDL，还应生成代表性 WDL，并运行配置的 WDL validator。
+
+## 建议 PR 拆分
+
+1. **Reviewer repair contract models**
+   - models、patch policy skeleton、unit tests。
+2. **Patch application and validation**
+   - policy-enforced patch application、schema revalidation、tests。
+3. **Reviewer node and graph routing**
+   - fakeable provider boundary、Compiler Graph routing、attempt limits。
+4. **Run observability**
+   - events、named artifacts、diagnostics、API/run snapshot tests。
+5. **Documentation closeout**
+   - 行为稳定后更新 roadmap status 和 test coverage docs。
+
+实现 PR 应与前端展示工作分开，除非只需要很小的 UI 改动来确认 artifact contract。
+
+## 验收清单
+
+- [ ] Deterministic repairer 仍然是第一层修复机制。
+- [ ] Reviewer 只在 Analyzer 或 Checker 失败，且没有安全 deterministic repair 时触发。
+- [ ] Reviewer 输出先经过 schema validation，再经过 patch policy validation。
+- [ ] Patch policy 会拒绝 WDL、Catalog、runtime image、command 和 resource sizing
+  修改。
+- [ ] 已接受 patch 只应用到 Workflow IR，并重新进入 Analyzer、Renderer 和 Checker。
+- [ ] 修复次数有硬上限，不能无限循环。
+- [ ] 未配置 Reviewer 时，结构化编译路径仍可在没有 API key 的情况下运行。
+- [ ] Run history 通过 named artifacts 和 events 暴露 Reviewer 尝试。
+- [ ] 最终 diagnostics 能说明成功、拒绝、次数耗尽或 model error。
+- [ ] 测试覆盖成功、拒绝、no-op、次数耗尽和 Reviewer 不可用路径。
+
+## 待确认问题
+
+- Reviewer 尝试次数应复用现有 `repair_count`，还是拆成
+  `deterministic_repair_count` 和 `reviewer_repair_count`？
+- P2 初版是否只支持 Analyzer failures，第二个 PR 再支持 Checker failures；还是从
+  一开始就用同一套 policy 支持两者？
+- 是否需要保存 raw Reviewer output，还是只持久化脱敏后的 parsed patch data？
+- 哪些最小 Catalog context 足够支撑 P2，同时又不会重复当前 Catalog Retriever
+  payload？

--- a/docs/p2-reviewer-repair-plan.md
+++ b/docs/p2-reviewer-repair-plan.md
@@ -44,8 +44,8 @@ Reviewer 提出结构化 Workflow IR 修复建议。
 
 - Analyzer 和 Checker 失败可以路由到 Reviewer repair 分支，但必须发生在
   deterministic repairer 已失败或明确放弃修复之后。
-- Reviewer 输入是结构化请求，包含当前 Workflow IR、diagnostics、validation
-  output、修复历史和 approved Catalog 上下文。
+- Reviewer 输入是结构化请求，包含当前 Workflow IR、diagnostics、
+  `validation_message`、修复历史和 approved Catalog 上下文。
 - Reviewer 输出只能是 schema 可校验的 IR patch 或显式 no-op 结果。
 - patch 应用范围限制在 Workflow IR 内，并且应用后必须重新经过 Analyzer、
   Renderer 和 Checker。

--- a/docs/r1-internal-catalog-rag-plan.md
+++ b/docs/r1-internal-catalog-rag-plan.md
@@ -1,8 +1,10 @@
-# Internal Catalog RAG / Tool Retriever 开发计划
+# R1 Internal Catalog RAG / Tool Retriever 开发计划
 
 本文档描述项目内第一版 RAG 能力的范围、边界和实施步骤。这里的
 RAG 不指外部网页、论文或未知工具检索，而是指在项目已批准的
 Recipe / Tool Catalog 内做可解释召回，为自然语言 Planner 提供受控上下文。
+
+本文档是 RAG 开发序列的 R1，聚焦已落地的 approved catalog 内部检索能力。后续评估集、retrieval metrics、vector / hybrid backend 和 embedding fine-tuning 优先级由 [R2 Retrieval Evaluation Roadmap](./r2-retrieval-evaluation-roadmap.md) 维护。
 
 ## 背景
 
@@ -360,9 +362,9 @@ docs/test-cases.md
 
 其中 `src/catalog/retriever.py` 应尽量保持纯函数和无副作用，便于测试。
 
-## 建议实现步骤
+## R1 MVP 实现步骤
 
-### R1. Catalog Retriever 核心
+### M1. Catalog Retriever 核心
 
 交付：
 
@@ -378,7 +380,7 @@ docs/test-cases.md
 - 输出包含 `matched_terms`、`matched_fields` 和 `strategy`。
 - 空 query 返回清晰错误或 fallback 结果。
 
-### R2. Planner Prompt 集成
+### M2. Planner Prompt 集成
 
 交付：
 
@@ -393,7 +395,7 @@ docs/test-cases.md
 - Planner schema/catalog 错误分类不变。
 - `--input` 结构化路径不触发 retriever。
 
-### R3. Run Artifact 与事件
+### M3. Run Artifact 与事件
 
 交付：
 
@@ -407,7 +409,7 @@ docs/test-cases.md
 - snapshot artifacts 包含 retrieval result。
 - 失败路径不泄露 API key 或本地 credential path。
 
-### R4. 前端展示
+### M4. 前端展示
 
 交付：
 
@@ -420,7 +422,7 @@ docs/test-cases.md
 - TypeScript 类型更新。
 - 前端 build/lint 在依赖安装后通过。
 
-### R5. 文档与验收
+### M5. 文档与验收
 
 交付：
 
@@ -450,18 +452,15 @@ powershell -ExecutionPolicy Bypass -File scripts\check_p0.ps1
 - [x] 单测覆盖成功、fallback 和错误边界。
 - [x] 文档说明内部 RAG 与外部工具发现的边界。
 
-## 面试展示叙述
+## 后续序列
 
-推荐讲法：
+R1 的职责是建立受控、可解释、可展示的 approved catalog retrieval 层。它不评价向量检索是否优于词法检索，也不决定是否需要 embedding fine-tuning。
 
-> I added a retrieval layer over the approved bioinformatics catalog. It narrows
-> planner context and records why tools were retrieved, but it does not admit
-> new tools or bypass validation. The final Recipe Tool Plan still goes through
-> full Catalog validation, Workflow IR analysis, deterministic WDL rendering,
-> and syntax checking.
+后续 RAG 序列建议如下：
 
-中文版本：
-
-> 我把 RAG 做在正式工具目录内部。它帮助 Planner 缩小候选上下文，并记录为什么召回这些工具，但它不负责准入未知工具，也不能绕过完整 Catalog 校验。最终仍然走 Recipe Tool Plan、Workflow IR、Analyzer、确定性 WDL Renderer 和 Checker。
-
-这个定位能同时展示 RAG 能力、领域工具建模能力和工程边界意识。
+| 阶段 | 文档 | 目标 |
+| --- | --- | --- |
+| R1 | 本文档 | Approved Catalog Retriever MVP、Planner prompt 集成、run artifact 和前端展示 |
+| R2 | [Retrieval Evaluation Roadmap](./r2-retrieval-evaluation-roadmap.md) | 查询测试集、Recall@K、MRR、Role Coverage、vector / hybrid retriever 优先级 |
+| R3 | 规划中 | 基于 R2 baseline 选择 vector 或 hybrid backend，并保持 artifact contract 不变 |
+| R4 | 规划中 | 在 catalog 和标注数据足够后再评估 reranker 或 embedding fine-tuning |

--- a/docs/r2-retrieval-evaluation-roadmap.md
+++ b/docs/r2-retrieval-evaluation-roadmap.md
@@ -23,7 +23,7 @@ natural language request
 - 使用确定性 lexical scoring。
 - 输出 `score`、`matched_terms`、`matched_fields`、`reason`。
 - Tool 结果包含 `trust_status`。
-- 低置信度时记录 fallback。
+- recipe 或 tool 召回无匹配时触发 fallback，并在 artifact 中记录 `fallback_used` / `fallback_reason`。
 - Retrieval artifact 会保存到 run snapshot，并可在前端展示。
 - 完整 Catalog validation 仍使用全量 approved catalog。
 
@@ -224,6 +224,14 @@ Retrieval eval 的结果可以被前端轻量展示，但前端不应重新计�
 只修改评估文档时无需跑完整测试。
 
 修改 retriever 或 eval 代码时运行：
+
+Linux / macOS：
+
+```bash
+.venv/bin/python -m unittest discover -v
+```
+
+Windows PowerShell：
 
 ```powershell
 .\.venv\Scripts\python.exe -m unittest discover -v

--- a/docs/r2-retrieval-evaluation-roadmap.md
+++ b/docs/r2-retrieval-evaluation-roadmap.md
@@ -136,7 +136,7 @@ tests/test_retrieval_evaluation.py
 
 - 将 recipe/tool metadata 构造成本地 catalog documents。
 - 对 description、aliases、inputs、outputs、params、steps role 建立 embedding。
-- 保留 metadata filtering，例如 tool id、version、trust status、recipe id。
+- 保留 metadata filtering，例如 tool id、version、`trust_status`、recipe id。
 
 边界：
 
@@ -150,7 +150,7 @@ tests/test_retrieval_evaluation.py
 职责：
 
 - 融合 lexical score 和 vector similarity。
-- 保留 matched_terms / matched_fields，用于解释。
+- 保留 `matched_terms` / `matched_fields`，用于解释。
 - 输出与 lexical retriever 相同的 artifact contract。
 
 验收：

--- a/docs/r2-retrieval-evaluation-roadmap.md
+++ b/docs/r2-retrieval-evaluation-roadmap.md
@@ -1,0 +1,239 @@
+# R2 Retrieval Evaluation Roadmap
+
+本文档记录 Approved Catalog Retriever 的评估与检索策略演进路线。它聚焦查询测试集、retrieval metrics、vector / hybrid retrieval 和 embedding fine-tuning 的优先级。
+
+本文档是 RAG 开发序列的 R2。第一版内部 Catalog RAG 的实现边界、输入输出契约和已完成清单由 [R1 Internal Catalog RAG / Tool Retriever](./r1-internal-catalog-rag-plan.md) 维护。本文档不重复 MVP 实现细节，只规划评估和后续 retriever backend 演进。
+
+## Current Retriever
+
+当前 retriever 是 `Approved Catalog Retriever`：
+
+```text
+natural language request
+  -> lexical retrieval over approved Recipe / Tool Catalog
+  -> retrieved recipes and tools
+  -> planner prompt context
+  -> Recipe Tool Plan
+  -> full Catalog validation
+```
+
+已具备能力：
+
+- 只读取本地 approved Recipe / Tool Catalog。
+- 使用确定性 lexical scoring。
+- 输出 `score`、`matched_terms`、`matched_fields`、`reason`。
+- Tool 结果包含 `trust_status`。
+- 低置信度时记录 fallback。
+- Retrieval artifact 会保存到 run snapshot，并可在前端展示。
+- 完整 Catalog validation 仍使用全量 approved catalog。
+
+## Why Evaluation Comes Before Vector Search
+
+向量数据库和 embedding 检索适合进入后续路线，但应建立在评估集之后。否则无法判断检索策略是否真正改善了 planner context。
+
+推荐顺序：
+
+```text
+retrieval query set
+  -> lexical baseline
+  -> vector retrieval
+  -> hybrid retrieval
+  -> reranker
+  -> embedding fine-tuning
+```
+
+## Retrieval Query Set
+
+查询测试集是一组人工标注的自然语言请求和期望召回结果。它不是生信原始数据，也不是 LLM 训练数据。
+
+第一版样本结构：
+
+```json
+{
+  "id": "rnaseq_deg_basic_en",
+  "query": "Run bulk RNA-seq differential expression from paired-end FASTQ files.",
+  "expected_recipe": "rnaseq_differential_expression",
+  "expected_tools": ["fastp", "salmon", "tximport", "deseq2", "multiqc"],
+  "expected_roles": {
+    "read_quality_control": ["fastp"],
+    "transcript_quantification": ["salmon"],
+    "gene_count_summary": ["tximport"],
+    "differential_expression": ["deseq2"],
+    "quality_report": ["multiqc"]
+  },
+  "notes": "Basic RNA-seq DEG request without explicit tool names."
+}
+```
+
+建议第一批 20 条，覆盖：
+
+- 英文 RNA-seq DEG 请求。
+- 中文 RNA-seq DEG 请求。
+- 缩写表达，例如 DEG、RNAseq、bulk RNA。
+- 明确工具名请求，例如 use Salmon and DESeq2。
+- 只描述分析目标但不说工具名。
+- Catalog 暂不支持的负例，例如 ChIP-seq、scRNA-seq、variant calling。
+- 模糊需求，例如 quality report、quantification、gene-level counts。
+- 参数相关请求，例如 paired-end reads、contrast、threads。
+
+建议文件：
+
+```text
+tests/fixtures/retrieval_queries.json
+```
+
+## Metrics
+
+第一版 eval 应保持轻量、可解释、可在本地稳定运行。
+
+| Metric | Definition | Purpose |
+| --- | --- | --- |
+| `Recipe Recall@K` | expected recipe 是否出现在 top-K recipes | 判断分析类型召回是否可靠 |
+| `Tool Recall@K` | expected tools 中有多少出现在 top-K tools | 判断候选工具是否完整 |
+| `MRR` | 第一个正确 recipe 或 tool 的 reciprocal rank | 判断排序质量 |
+| `Role Coverage` | expected_roles 中每个 role 是否至少有一个正确 tool | 判断 workflow step 覆盖 |
+| `Fallback Rate` | 触发 fallback 的 query 占比 | 判断 catalog 覆盖和检索置信度 |
+
+初始目标不是追求高分，而是建立可重复 baseline：
+
+```text
+lexical_v1 Recipe Recall@3
+lexical_v1 Tool Recall@8
+lexical_v1 Role Coverage
+lexical_v1 Fallback Rate
+```
+
+## Eval Script
+
+建议新增一个独立脚本或 unittest：
+
+```text
+scripts/evaluate_retrieval.py
+```
+
+或：
+
+```text
+tests/test_retrieval_evaluation.py
+```
+
+输出应包括：
+
+- 每条 query 的 retrieved recipes/tools。
+- missed expected recipe/tool。
+- aggregate metrics。
+- fallback queries。
+
+输出格式建议同时支持人类可读 summary 和 JSON artifact，便于后续前端或文档展示。
+
+## Vector / Hybrid Retriever
+
+在 baseline 建立后，再引入可替换 retriever backend。
+
+### Vector Retriever
+
+职责：
+
+- 将 recipe/tool metadata 构造成本地 catalog documents。
+- 对 description、aliases、inputs、outputs、params、steps role 建立 embedding。
+- 保留 metadata filtering，例如 tool id、version、trust status、recipe id。
+
+边界：
+
+- 只检索 approved catalog。
+- 不发现外部工具。
+- 不改变 Catalog validation。
+- 不替换 runtime image。
+
+### Hybrid Retriever
+
+职责：
+
+- 融合 lexical score 和 vector similarity。
+- 保留 matched_terms / matched_fields，用于解释。
+- 输出与 lexical retriever 相同的 artifact contract。
+
+验收：
+
+- Hybrid retriever 在 query set 上优于或不低于 lexical baseline。
+- 如果某些 query 变差，应在 eval output 中可见。
+- Planner validation pass rate 不下降。
+
+## Embedding Fine-Tuning Priority
+
+Embedding model fine-tuning 暂不作为近期优先项。
+
+原因：
+
+- 当前 catalog 规模较小。
+- 人工标注 query 和 validated plan 数据不足。
+- 过早微调很难证明收益。
+- Fine-tuning 应以 eval 指标提升为目标，而不是单独作为模型实验。
+
+较合理的触发条件：
+
+- Approved Catalog 扩展到几十到上百个工具。
+- Query set 覆盖多个 workflow family。
+- 已积累 validated plans、missed retrieval cases 和人工修正记录。
+- Lexical / vector / hybrid baseline 已稳定。
+
+届时可评估：
+
+- local bi-encoder retriever。
+- reranker for top-K candidates。
+- domain-specific embedding fine-tuning。
+
+## Relationship To Frontend And Agent Workflow
+
+Retrieval eval 的结果可以被前端轻量展示，但前端不应重新计算指标。
+
+后端 Agent workflow 使用 retriever 的规则保持不变：
+
+- Retriever 提供 planner candidate context。
+- Full Catalog validation 仍是准入边界。
+- 结构化 compile path 不依赖 retriever。
+- Retrieval miss 不应导致系统绕过 approved catalog。
+
+## Deliverables
+
+建议 PR 顺序：
+
+1. **Retrieval query set**
+   - 添加 `tests/fixtures/retrieval_queries.json`。
+   - 覆盖中英文、缩写、工具名显式、工具名隐式、负例。
+
+2. **Retrieval eval baseline**
+   - 添加 eval 脚本或测试。
+   - 输出 Recall@K、MRR、Role Coverage、Fallback Rate。
+   - 文档记录 lexical baseline。
+
+3. **Retriever interface**
+   - 抽象 lexical backend。
+   - 保持现有 artifact contract。
+
+4. **Vector backend prototype**
+   - 加入本地 vector index 或轻量 embedding backend。
+   - 不影响结构化入口。
+
+5. **Hybrid scoring**
+   - 融合 lexical 和 vector。
+   - 用 eval 证明效果。
+
+## Verification
+
+只修改评估文档时无需跑完整测试。
+
+修改 retriever 或 eval 代码时运行：
+
+```powershell
+.\.venv\Scripts\python.exe -m unittest discover -v
+```
+
+如果新增前端展示 retrieval metrics，还应运行：
+
+```powershell
+cd web
+npm run lint
+npm run test:catalog-retrieval
+npm run build
+```


### PR DESCRIPTION
## Summary

- Consolidate frontend product surface notes into the W0-W6 development sequence.
- Expand the P0-P10 backend Agent roadmap with current boundaries, baseline capabilities, and planned P3-P6 responsibilities.
- Rename the internal catalog RAG plan as R1 and add an R2 retrieval evaluation roadmap for query sets, metrics, vector/hybrid retrieval, and embedding fine-tuning priority.

## Validation

- Checked that stale Markdown links to the old RAG document names were removed with `rg`.
- Did not run unit tests because this is a documentation-only change.