### PR TITLE
Add Reviewer repair contracts and policy

### DIFF
--- a/docs/p2-reviewer-repair-plan.md
+++ b/docs/p2-reviewer-repair-plan.md
@@ -134,7 +134,8 @@ P2 应引入明确的 request、patch 和 result model，而不是在 compiler n
 - `policy_rejected`
 - `model_error`
 
-只有在经过脱敏且不包含 secrets 时，才可以把 raw Reviewer output 作为诊断材料保存。
+P2 初版不保存 raw Reviewer output；只持久化脱敏后的 parsed patch data、
+`rejection_reason` 和必要 diagnostics。
 
 ## Patch Policy
 
@@ -311,12 +312,13 @@ Windows PowerShell：
 - [ ] 最终 diagnostics 能说明成功、拒绝、次数耗尽或 model error。
 - [ ] 测试覆盖成功、拒绝、no-op、次数耗尽和 Reviewer 不可用路径。
 
-## 待确认问题
+## 已确认的 P2.1 决策
 
-- Reviewer 尝试次数应复用现有 `repair_count`，还是拆成
-  `deterministic_repair_count` 和 `reviewer_repair_count`？
-- P2 初版是否只支持 Analyzer failures，第二个 PR 再支持 Checker failures；还是从
-  一开始就用同一套 policy 支持两者？
-- 是否需要保存 raw Reviewer output，还是只持久化脱敏后的 parsed patch data？
-- 哪些最小 Catalog context 足够支撑 P2，同时又不会重复当前 Catalog Retriever
-  payload？
+- Contract 同时保留 `analyzer` 与 `checker` failure stage，便于后续扩展；实现路由
+  先覆盖 Analyzer failure，Checker / WDL validation failure 在后续 PR 接入。
+- Reviewer provider 结果只持久化脱敏后的 parsed patch、`rejection_reason` 和
+  diagnostics；不默认保存 raw Reviewer output。
+- `catalog_context` 只传当前 workflow 已使用的 approved recipe/tool metadata，
+  不复用完整 Catalog Retriever payload，也不提供候选工具重选上下文。
+- Reviewer 尝试次数后续实现宜拆成 deterministic 与 Reviewer 计数，便于 run
+  diagnostics 和前端展示区分两类修复来源。

--- a/docs/test-cases.md
+++ b/docs/test-cases.md
@@ -1827,6 +1827,7 @@ result 和 policy 边界。
 输入：
 
 - 一个给 `/workflow/steps/0/inputs/r2` 增加 wiring 的 patch。
+- 一个修复 `/tasks/fastp/outputs/clean_r1/value` task output literal 的 patch。
 - catalog reference：`fastp:1.3.3`。
 - 当前 workflow approved catalog context。
 
@@ -1841,6 +1842,7 @@ result 和 policy 边界。
 覆盖点：
 
 - P2 policy 允许 Reviewer 在 Workflow IR 内修复 call input wiring。
+- P2 policy 允许 Reviewer 修复已有 task output 的 literal expression。
 - catalog reference 必须来自当前 workflow approved context。
 
 ### `test_policy_rejects_wdl_catalog_runtime_and_resource_edits`
@@ -1910,6 +1912,30 @@ result 和 policy 边界。
 
 - patch 引用 catalog metadata 时必须同时提供当前 workflow 的 approved context；
   不能因为调用方漏传 context 而跳过 membership 校验。
+
+### `test_policy_rejects_non_identifier_ir_path_segments`
+
+输入：
+
+- 分别尝试 patch：
+  - `/tasks/foo-bar/outputs/x/value`
+  - `/tasks/foo/outputs/x-y/value`
+  - `/workflow/steps/0/inputs/read-1`
+  - `/workflow/calls/0/inputs/read-1`
+
+执行：
+
+- 调用 `validate_reviewer_patch_policy(...)`。
+
+期望输出：
+
+- 每个 patch 都抛出 `ReviewerPatchPolicyError`。
+
+覆盖点：
+
+- Reviewer policy 的 allowlist path segment 与 `WorkflowIR` identifier 规则一致。
+- 不允许 policy 先接受带非法 task、output 或 call input 名称的 patch，再让 schema
+  validation 在后续阶段失败。
 
 ### `test_policy_rejects_empty_or_nested_workflow_output_paths`
 

--- a/docs/test-cases.md
+++ b/docs/test-cases.md
@@ -1969,13 +1969,17 @@ result 和 policy 边界。
 - `move` 只能在同一个 workflow collection 内调整排序。
 - Reviewer 不能在 canonical `workflow.steps` 和 compatibility `workflow.calls` 之间移动结构。
 
-### `test_repair_result_requires_parsed_patch_or_rejection_reason`
+### `test_repair_result_enforces_status_payload_invariants`
 
 输入：
 
 - `patch_proposed` result。
+- `policy_rejected` result。
+- `no_action` result。
 - 缺失 patch 的 `patch_proposed` result。
 - 缺失 `rejection_reason` 的 `policy_rejected` result。
+- 携带不匹配 payload 的 result，例如 `patch_proposed` 携带 `rejection_reason`、
+  `policy_rejected` 携带 `patch`，以及其他状态携带 `patch` 或 `rejection_reason`。
 
 执行：
 
@@ -1984,12 +1988,16 @@ result 和 policy 边界。
 期望输出：
 
 - 合法 `patch_proposed` 保留 parsed patch。
-- 缺失 patch 或 rejection reason 的结果抛出 `ValidationError`。
+- 合法 `policy_rejected` 保留 rejection reason。
+- 合法 `no_action` 可以保留 diagnostics，但不携带 patch 或 rejection reason。
+- 缺失必填 payload 或携带不匹配 payload 的结果抛出 `ValidationError`。
 
 覆盖点：
 
 - P2 只持久化 parsed patch 与 rejection reason，不把 raw Reviewer output 作为默认
   artifact。
+- Reviewer result 的 `status` 与 payload 保持一一对应，避免下游按状态分支时遇到
+  歧义载荷。
 
 ## `tests/test_graph.py`
 

--- a/docs/test-cases.md
+++ b/docs/test-cases.md
@@ -1884,6 +1884,27 @@ result 和 policy 边界。
 - patch 引用 catalog metadata 时必须同时提供当前 workflow 的 approved context；
   不能因为调用方漏传 context 而跳过 membership 校验。
 
+### `test_policy_rejects_empty_or_nested_workflow_output_paths`
+
+输入：
+
+- 分别尝试 patch：
+  - `/workflow/outputs/`
+  - `/workflow/outputs/clean_r1/value`
+
+执行：
+
+- 调用 `validate_reviewer_patch_policy(...)`。
+
+期望输出：
+
+- 每个 patch 都抛出 `ReviewerPatchPolicyError`。
+
+覆盖点：
+
+- `workflow.outputs` 是 `dict[str, str]`，Reviewer 只能直接修改单个 output entry。
+- policy 不接受空 output key 或 output entry 下的深层 JSON pointer。
+
 ### `test_policy_allows_move_only_for_workflow_step_or_call_items`
 
 输入：

--- a/docs/test-cases.md
+++ b/docs/test-cases.md
@@ -1795,6 +1795,33 @@ result 和 policy 边界。
 
 - Reviewer patch 必须先通过 schema validation。
 
+### `test_reviewer_patch_action_enforces_operation_payload_invariants`
+
+输入：
+
+- 合法 action：
+  - `add` / `replace` 携带非 null `value`。
+  - `remove` 不携带 `value`。
+  - `move` 携带 `from_path`，不携带 `value`。
+- 非法 action：
+  - `add` 缺失 `value`。
+  - `replace` 携带 null `value`。
+  - `remove` / `move` 携带 `value`，包括显式 null。
+
+执行：
+
+- 构造 `ReviewerIRPatch`。
+
+期望输出：
+
+- 合法 action payload 通过 schema validation。
+- 缺失必需 `value` 或携带不允许 `value` 的 action 抛出 `ValidationError`。
+
+覆盖点：
+
+- Reviewer patch action 的 operation 与 payload 保持一一对应，避免把不明确的
+  patch 留到 apply 或 policy 阶段才失败。
+
 ### `test_policy_accepts_allowed_workflow_ir_patch`
 
 输入：

--- a/docs/test-cases.md
+++ b/docs/test-cases.md
@@ -1823,6 +1823,9 @@ result 和 policy 边界。
 - 分别尝试 patch：
   - `/current_wdl`
   - `/catalog/tools/fastp`
+  - `/workflow/steps`
+  - `/workflow/calls`
+  - `/workflow/steps/0/task`
   - `/tasks/fastp/command`
   - `/tasks/fastp/runtime/docker`
   - `/tasks/fastp/runtime/cpu`
@@ -1839,6 +1842,7 @@ result 和 policy 边界。
 
 - Reviewer 不能修改最终 WDL、Catalog、command template、runtime image 或 resource
   sizing fields。
+- Reviewer 不能替换整个 workflow step/call 集合，也不能修改 call 的 task 选择。
 
 ### `test_policy_rejects_catalog_references_outside_current_workflow_context`
 
@@ -1858,6 +1862,48 @@ result 和 policy 边界。
 覆盖点：
 
 - Reviewer 不能借由 catalog references 引入未传入的候选工具上下文。
+
+### `test_policy_rejects_catalog_references_without_context`
+
+输入：
+
+- 一个合法的 call input wiring patch。
+- `catalog_references` 包含 `fastp:1.3.3`。
+- 不传 `catalog_context`。
+
+执行：
+
+- 调用 `validate_reviewer_patch_policy(...)`。
+
+期望输出：
+
+- 抛出 `ReviewerPatchPolicyError`。
+
+覆盖点：
+
+- patch 引用 catalog metadata 时必须同时提供当前 workflow 的 approved context；
+  不能因为调用方漏传 context 而跳过 membership 校验。
+
+### `test_policy_allows_move_only_for_workflow_step_or_call_items`
+
+输入：
+
+- 一个 `move` patch：
+  - `from_path = /workflow/steps/1`
+  - `path = /workflow/steps/0`
+
+执行：
+
+- 调用 `validate_reviewer_patch_policy(...)`。
+
+期望输出：
+
+- policy validation 返回原 patch。
+
+覆盖点：
+
+- P2 policy 允许 Reviewer 通过 list-item pointer 调整 step/call ordering。
+- 该权限不扩展到整体替换 `workflow.steps` 或修改 step 内部 task 选择。
 
 ### `test_repair_result_requires_parsed_patch_or_rejection_reason`
 

--- a/docs/test-cases.md
+++ b/docs/test-cases.md
@@ -1948,6 +1948,27 @@ result 和 policy 边界。
 - `move` 只服务于 `/workflow/steps/<index>` 或 `/workflow/calls/<index>` 的排序修复。
 - Reviewer 不能用 `move` 修改 workflow output、call input wiring 或 task output literal。
 
+### `test_policy_rejects_move_between_workflow_steps_and_calls`
+
+输入：
+
+- 分别尝试 `move`：
+  - `from_path = /workflow/steps/1`，`path = /workflow/calls/0`
+  - `from_path = /workflow/calls/1`，`path = /workflow/steps/0`
+
+执行：
+
+- 调用 `validate_reviewer_patch_policy(...)`。
+
+期望输出：
+
+- 每个 patch 都抛出 `ReviewerPatchPolicyError`。
+
+覆盖点：
+
+- `move` 只能在同一个 workflow collection 内调整排序。
+- Reviewer 不能在 canonical `workflow.steps` 和 compatibility `workflow.calls` 之间移动结构。
+
 ### `test_repair_result_requires_parsed_patch_or_rejection_reason`
 
 输入：

--- a/docs/test-cases.md
+++ b/docs/test-cases.md
@@ -1905,6 +1905,28 @@ result 和 policy 边界。
 - P2 policy 允许 Reviewer 通过 list-item pointer 调整 step/call ordering。
 - 该权限不扩展到整体替换 `workflow.steps` 或修改 step 内部 task 选择。
 
+### `test_policy_rejects_move_outside_workflow_step_or_call_items`
+
+输入：
+
+- 分别尝试 `move`：
+  - `/workflow/outputs/clean_r1`
+  - `/workflow/steps/0/inputs/r2`
+  - `/tasks/fastp/outputs/clean_r1/value`
+
+执行：
+
+- 调用 `validate_reviewer_patch_policy(...)`。
+
+期望输出：
+
+- 每个 patch 都抛出 `ReviewerPatchPolicyError`。
+
+覆盖点：
+
+- `move` 只服务于 `/workflow/steps/<index>` 或 `/workflow/calls/<index>` 的排序修复。
+- Reviewer 不能用 `move` 修改 workflow output、call input wiring 或 task output literal。
+
 ### `test_repair_result_requires_parsed_patch_or_rejection_reason`
 
 输入：

--- a/docs/test-cases.md
+++ b/docs/test-cases.md
@@ -1744,6 +1744,143 @@ Recipe / Tool Catalog 中做确定性词法召回，不访问网络、不引入 
 
 - API 层后续可以将未知 catalog 资源稳定映射为 404。
 
+## `tests/test_reviewer_repair.py`
+
+该文件验证 P2 Reviewer IR 修复闭环的第一批契约模型和 patch policy skeleton。
+它不调用真实 LLM provider，也不接入 Compiler Graph 路由；只固定 request、patch、
+result 和 policy 边界。
+
+### `test_reviewer_repair_request_accepts_workflow_ir_and_minimal_catalog_context`
+
+输入：
+
+- 一个最小 Workflow IR。
+- failure stage：`analyzer`。
+- Analyzer diagnostic：`call 'qc' is missing input 'r2'`。
+- 当前 workflow 已使用的 approved recipe/tool metadata。
+
+执行：
+
+- 构造 `ReviewerRepairRequest`。
+
+期望输出：
+
+- request 保留 `failure_stage == analyzer`。
+- `workflow_ir` 被校验为 Workflow IR model。
+- catalog context 只包含当前 workflow 的 approved tool metadata。
+- constraints 默认包含允许的 patch operation。
+
+覆盖点：
+
+- Reviewer 请求使用结构化数据，而不是在节点之间传递自由 prompt 文本。
+- P2 初版只向 Reviewer 暴露当前 workflow 已使用的 approved catalog metadata。
+
+### `test_reviewer_patch_model_rejects_invalid_shape`
+
+输入：
+
+- operation 为 `rewrite`。
+- path 不是绝对 JSON pointer。
+- confidence 为 `1.5`。
+
+执行：
+
+- 构造 `ReviewerIRPatch`。
+
+期望输出：
+
+- 抛出 `ValidationError`。
+
+覆盖点：
+
+- Reviewer patch 必须先通过 schema validation。
+
+### `test_policy_accepts_allowed_workflow_ir_patch`
+
+输入：
+
+- 一个给 `/workflow/steps/0/inputs/r2` 增加 wiring 的 patch。
+- catalog reference：`fastp:1.3.3`。
+- 当前 workflow approved catalog context。
+
+执行：
+
+- 调用 `validate_reviewer_patch_policy(...)`。
+
+期望输出：
+
+- policy validation 返回原 patch。
+
+覆盖点：
+
+- P2 policy 允许 Reviewer 在 Workflow IR 内修复 call input wiring。
+- catalog reference 必须来自当前 workflow approved context。
+
+### `test_policy_rejects_wdl_catalog_runtime_and_resource_edits`
+
+输入：
+
+- 分别尝试 patch：
+  - `/current_wdl`
+  - `/catalog/tools/fastp`
+  - `/tasks/fastp/command`
+  - `/tasks/fastp/runtime/docker`
+  - `/tasks/fastp/runtime/cpu`
+
+执行：
+
+- 调用 `validate_reviewer_patch_policy(...)`。
+
+期望输出：
+
+- 每个 patch 都抛出 `ReviewerPatchPolicyError`。
+
+覆盖点：
+
+- Reviewer 不能修改最终 WDL、Catalog、command template、runtime image 或 resource
+  sizing fields。
+
+### `test_policy_rejects_catalog_references_outside_current_workflow_context`
+
+输入：
+
+- patch 本身只改 `/workflow/outputs/clean_r1`。
+- `catalog_references` 包含当前 workflow context 外的 `star:2.7.11b`。
+
+执行：
+
+- 调用 `validate_reviewer_patch_policy(...)`。
+
+期望输出：
+
+- 抛出 `ReviewerPatchPolicyError`。
+
+覆盖点：
+
+- Reviewer 不能借由 catalog references 引入未传入的候选工具上下文。
+
+### `test_repair_result_requires_parsed_patch_or_rejection_reason`
+
+输入：
+
+- `patch_proposed` result。
+- 缺失 patch 的 `patch_proposed` result。
+- 缺失 `rejection_reason` 的 `policy_rejected` result。
+
+执行：
+
+- 构造 `ReviewerRepairResult`。
+
+期望输出：
+
+- 合法 `patch_proposed` 保留 parsed patch。
+- 缺失 patch 或 rejection reason 的结果抛出 `ValidationError`。
+
+覆盖点：
+
+- P2 只持久化 parsed patch 与 rejection reason，不把 raw Reviewer output 作为默认
+  artifact。
+
 ## `tests/test_graph.py`
 
 该文件验证 Compiler Graph、Analyzer、Renderer 和 deterministic repairer 的交互。
@@ -3573,6 +3710,7 @@ npm run test:catalog-retrieval
 - Analyzer 对引用、optional input、scatter output 类型提升的处理。
 - Renderer 对 call、scatter、array flatten、workflow output 和 task 的 WDL 渲染。
 - Deterministic repairer 对 call 顺序和 output 字面量的安全修复。
+- Reviewer repair request / patch / result 契约模型与 P2 patch policy skeleton。
 - Workflow service 对结构化编译入口、自然语言规划后编译入口和 API 友好结果对象的封装。
 - FastAPI DTO 对 workflow、catalog 和 event envelope 的输入输出契约。
 - FastAPI endpoints 对 W0 workflow/catalog services 的复用、HTTP 状态映射和响应序列化。
@@ -3588,7 +3726,8 @@ npm run test:catalog-retrieval
 - 多 recipe、多工具候选和更复杂 tool selection。
 - 参数范围错误以外的更多 Tool Catalog schema 边界。
 - nested scatter、conditional step、subworkflow 等 roadmap feature。
-- Reviewer LLM / Resource Agent / Bioinfo Reviewer 等规划中 Agent。
+- Reviewer provider、Compiler Graph 路由、Run observability、Resource Agent 和
+  Bioinfo Reviewer 等规划中 Agent。
 - Nextflow 或其他 backend。
 - 真实自然语言模型调用的在线集成测试。
 - Next.js 工作台、DAG 可视化和 run history 的浏览器级视觉回归测试。

--- a/src/reviewer_repair.py
+++ b/src/reviewer_repair.py
@@ -197,10 +197,18 @@ class ReviewerRepairResult(BaseModel):
 
     @model_validator(mode="after")
     def validate_status_payload(self) -> ReviewerRepairResult:
-        if self.status == ReviewerRepairStatus.PATCH_PROPOSED and self.patch is None:
-            raise ValueError("patch_proposed results must include a parsed patch")
-        if self.status == ReviewerRepairStatus.POLICY_REJECTED and not self.rejection_reason:
-            raise ValueError("policy_rejected results must include a rejection_reason")
+        if self.status == ReviewerRepairStatus.PATCH_PROPOSED:
+            if self.patch is None:
+                raise ValueError("patch_proposed results must include a parsed patch")
+            if self.rejection_reason is not None:
+                raise ValueError("patch_proposed results must not include a rejection_reason")
+        elif self.status == ReviewerRepairStatus.POLICY_REJECTED:
+            if self.patch is not None:
+                raise ValueError("policy_rejected results must not include a patch")
+            if not self.rejection_reason:
+                raise ValueError("policy_rejected results must include a rejection_reason")
+        elif self.patch is not None or self.rejection_reason is not None:
+            raise ValueError("patch and rejection_reason are only allowed for their matching result status")
         return self
 
 

--- a/src/reviewer_repair.py
+++ b/src/reviewer_repair.py
@@ -273,6 +273,9 @@ def _iter_action_paths(action: ReviewerPatchAction) -> list[tuple[str, str]]:
 
 
 def _is_allowed_path(path: str, operation: ReviewerPatchOperation) -> bool:
+    if operation == ReviewerPatchOperation.MOVE:
+        return _is_workflow_step_or_call_path(path)
+
     if path.startswith("/workflow/outputs/"):
         return True
 
@@ -280,9 +283,6 @@ def _is_allowed_path(path: str, operation: ReviewerPatchOperation) -> bool:
         return True
 
     if _is_call_input_path(path):
-        return True
-
-    if operation == ReviewerPatchOperation.MOVE and _is_workflow_step_or_call_path(path):
         return True
 
     return False

--- a/src/reviewer_repair.py
+++ b/src/reviewer_repair.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
-from src.schema import WorkflowIR
+from src.schema import IDENTIFIER_PATTERN, WorkflowIR
 
 
 class ReviewerFailureStage(StrEnum):
@@ -230,7 +230,16 @@ class ReviewerPatchPolicyError(ValueError):
     """Raised when a Reviewer patch attempts to cross the P2 policy boundary."""
 
 
-_TASK_OUTPUT_VALUE_PATTERN = re.compile(r"^/tasks/[^/]+/outputs/[^/]+/value$")
+_IR_IDENTIFIER_SEGMENT_PATTERN = IDENTIFIER_PATTERN.pattern.removeprefix("^").removesuffix("$")
+_TASK_OUTPUT_VALUE_PATTERN = re.compile(
+    rf"^/tasks/{_IR_IDENTIFIER_SEGMENT_PATTERN}/outputs/{_IR_IDENTIFIER_SEGMENT_PATTERN}/value$"
+)
+_CALL_INPUT_PATH_PATTERN = re.compile(
+    rf"^/workflow/(steps|calls)/[0-9]+/inputs/{_IR_IDENTIFIER_SEGMENT_PATTERN}$"
+)
+_WORKFLOW_OUTPUT_PATH_PATTERN = re.compile(
+    rf"^/workflow/outputs/{_IR_IDENTIFIER_SEGMENT_PATTERN}$"
+)
 _FORBIDDEN_TOP_LEVEL_SEGMENTS = {
     "catalog",
     "current_wdl",
@@ -326,11 +335,11 @@ def _is_allowed_path(path: str, operation: ReviewerPatchOperation) -> bool:
 
 
 def _is_call_input_path(path: str) -> bool:
-    return bool(re.match(r"^/workflow/(steps|calls)/[0-9]+/inputs/[^/]+$", path))
+    return bool(_CALL_INPUT_PATH_PATTERN.match(path))
 
 
 def _is_workflow_output_path(path: str) -> bool:
-    return bool(re.match(r"^/workflow/outputs/[A-Za-z_][A-Za-z0-9_]*$", path))
+    return bool(_WORKFLOW_OUTPUT_PATH_PATTERN.match(path))
 
 
 def _is_workflow_step_or_call_path(path: str) -> bool:

--- a/src/reviewer_repair.py
+++ b/src/reviewer_repair.py
@@ -256,6 +256,9 @@ def validate_reviewer_patch_policy(
 
 def _validate_action_policy(action: ReviewerPatchAction) -> list[str]:
     violations = []
+    if action.operation == ReviewerPatchOperation.MOVE:
+        violations.extend(_validate_move_policy(action))
+
     for label, path in _iter_action_paths(action):
         if _is_forbidden_path(path):
             violations.append(f"{label} path '{path}' crosses a forbidden Reviewer repair boundary")
@@ -263,6 +266,18 @@ def _validate_action_policy(action: ReviewerPatchAction) -> list[str]:
         if not _is_allowed_path(path, action.operation):
             violations.append(f"{label} path '{path}' is outside the P2 Reviewer patch allowlist")
     return violations
+
+
+def _validate_move_policy(action: ReviewerPatchAction) -> list[str]:
+    source_collection = _workflow_step_or_call_collection(action.from_path or "")
+    target_collection = _workflow_step_or_call_collection(action.path)
+    if source_collection is None or target_collection is None:
+        return []
+    if source_collection != target_collection:
+        return [
+            "move patch actions must stay within the same workflow steps or calls collection"
+        ]
+    return []
 
 
 def _iter_action_paths(action: ReviewerPatchAction) -> list[tuple[str, str]]:
@@ -297,7 +312,14 @@ def _is_workflow_output_path(path: str) -> bool:
 
 
 def _is_workflow_step_or_call_path(path: str) -> bool:
-    return bool(re.match(r"^/workflow/(steps|calls)/[0-9]+$", path))
+    return _workflow_step_or_call_collection(path) is not None
+
+
+def _workflow_step_or_call_collection(path: str) -> str | None:
+    match = re.match(r"^/workflow/(steps|calls)/[0-9]+$", path)
+    if match is None:
+        return None
+    return match.group(1)
 
 
 def _is_forbidden_path(path: str) -> bool:

--- a/src/reviewer_repair.py
+++ b/src/reviewer_repair.py
@@ -276,7 +276,7 @@ def _is_allowed_path(path: str, operation: ReviewerPatchOperation) -> bool:
     if operation == ReviewerPatchOperation.MOVE:
         return _is_workflow_step_or_call_path(path)
 
-    if path.startswith("/workflow/outputs/"):
+    if _is_workflow_output_path(path):
         return True
 
     if _TASK_OUTPUT_VALUE_PATTERN.match(path):
@@ -290,6 +290,10 @@ def _is_allowed_path(path: str, operation: ReviewerPatchOperation) -> bool:
 
 def _is_call_input_path(path: str) -> bool:
     return bool(re.match(r"^/workflow/(steps|calls)/[0-9]+/inputs/[^/]+$", path))
+
+
+def _is_workflow_output_path(path: str) -> bool:
+    return bool(re.match(r"^/workflow/outputs/[A-Za-z_][A-Za-z0-9_]*$", path))
 
 
 def _is_workflow_step_or_call_path(path: str) -> bool:

--- a/src/reviewer_repair.py
+++ b/src/reviewer_repair.py
@@ -104,7 +104,7 @@ def _default_forbidden_path_descriptions() -> list[str]:
         "final WDL text",
         "Tool Catalog or Recipe Catalog data",
         "task command templates",
-        "runtime container images",
+        "task runtime settings, including container images and resource fields",
         "resource sizing fields",
     ]
 

--- a/src/reviewer_repair.py
+++ b/src/reviewer_repair.py
@@ -149,7 +149,21 @@ class ReviewerPatchAction(BaseModel):
         return value
 
     @model_validator(mode="after")
-    def validate_move_source(self) -> ReviewerPatchAction:
+    def validate_operation_payload(self) -> ReviewerPatchAction:
+        value_was_provided = "value" in self.model_fields_set
+        value_required = self.operation in {
+            ReviewerPatchOperation.ADD,
+            ReviewerPatchOperation.REPLACE,
+        }
+        value_forbidden = self.operation in {
+            ReviewerPatchOperation.REMOVE,
+            ReviewerPatchOperation.MOVE,
+        }
+
+        if value_required and self.value is None:
+            raise ValueError("add and replace patch actions require a non-null value")
+        if value_forbidden and value_was_provided:
+            raise ValueError("remove and move patch actions must not include value")
         if self.operation == ReviewerPatchOperation.MOVE and not self.from_path:
             raise ValueError("move patch actions require from_path")
         if self.operation != ReviewerPatchOperation.MOVE and self.from_path is not None:

--- a/src/reviewer_repair.py
+++ b/src/reviewer_repair.py
@@ -239,7 +239,9 @@ def validate_reviewer_patch_policy(
     for action in patch.actions:
         violations.extend(_validate_action_policy(action))
 
-    if catalog_context is not None:
+    if patch.catalog_references and catalog_context is None:
+        violations.append("catalog_references require approved current-workflow catalog_context")
+    elif catalog_context is not None:
         allowed_references = catalog_context.approved_reference_ids()
         for reference in patch.catalog_references:
             if reference not in allowed_references:
@@ -271,9 +273,6 @@ def _iter_action_paths(action: ReviewerPatchAction) -> list[tuple[str, str]]:
 
 
 def _is_allowed_path(path: str, operation: ReviewerPatchOperation) -> bool:
-    if path in {"/workflow/steps", "/workflow/calls", "/workflow/outputs"}:
-        return True
-
     if path.startswith("/workflow/outputs/"):
         return True
 
@@ -290,13 +289,11 @@ def _is_allowed_path(path: str, operation: ReviewerPatchOperation) -> bool:
 
 
 def _is_call_input_path(path: str) -> bool:
-    if not _is_workflow_step_or_call_path(path):
-        return False
-    return "/inputs/" in path or path.endswith("/inputs")
+    return bool(re.match(r"^/workflow/(steps|calls)/[0-9]+/inputs/[^/]+$", path))
 
 
 def _is_workflow_step_or_call_path(path: str) -> bool:
-    return path.startswith("/workflow/steps/") or path.startswith("/workflow/calls/")
+    return bool(re.match(r"^/workflow/(steps|calls)/[0-9]+$", path))
 
 
 def _is_forbidden_path(path: str) -> bool:

--- a/src/reviewer_repair.py
+++ b/src/reviewer_repair.py
@@ -1,0 +1,322 @@
+from __future__ import annotations
+
+import re
+from enum import StrEnum
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from src.schema import WorkflowIR
+
+
+class ReviewerFailureStage(StrEnum):
+    """Compiler stage that produced diagnostics for Reviewer repair."""
+
+    ANALYZER = "analyzer"
+    # The current checker node is the WDL validation stage, not a separate validator.
+    CHECKER = "checker"
+
+
+class ReviewerPatchOperation(StrEnum):
+    ADD = "add"
+    REPLACE = "replace"
+    REMOVE = "remove"
+    MOVE = "move"
+
+
+class ReviewerRepairStatus(StrEnum):
+    PATCH_PROPOSED = "patch_proposed"
+    NO_ACTION = "no_action"
+    INVALID_REQUEST = "invalid_request"
+    POLICY_REJECTED = "policy_rejected"
+    MODEL_ERROR = "model_error"
+
+
+class ApprovedToolMetadata(BaseModel):
+    """Minimal approved tool context for the current workflow only."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    tool_id: str = Field(min_length=1)
+    version: str | None = None
+    inputs: list[str] = Field(default_factory=list)
+    outputs: list[str] = Field(default_factory=list)
+    trust_status: str = "catalog-approved"
+    runtime_docker: str | None = None
+
+    @field_validator("trust_status")
+    @classmethod
+    def validate_approved_trust_status(cls, value: str) -> str:
+        if value != "catalog-approved":
+            raise ValueError("Reviewer catalog context must contain only catalog-approved tools")
+        return value
+
+
+class ApprovedRecipeMetadata(BaseModel):
+    """Minimal approved recipe context for the current workflow only."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    recipe_id: str = Field(min_length=1)
+    step_ids: list[str] = Field(default_factory=list)
+    tool_ids: list[str] = Field(default_factory=list)
+
+
+class ApprovedCatalogContext(BaseModel):
+    """Approved recipe/tool metadata already used by the current workflow."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    recipes: list[ApprovedRecipeMetadata] = Field(default_factory=list)
+    tools: list[ApprovedToolMetadata] = Field(default_factory=list)
+
+    def approved_reference_ids(self) -> set[str]:
+        references = set()
+        for recipe in self.recipes:
+            references.add(recipe.recipe_id)
+        for tool in self.tools:
+            references.add(tool.tool_id)
+            if tool.version:
+                references.add(f"{tool.tool_id}:{tool.version}")
+        return references
+
+
+def _default_allowed_operations() -> list[ReviewerPatchOperation]:
+    return [
+        ReviewerPatchOperation.ADD,
+        ReviewerPatchOperation.REPLACE,
+        ReviewerPatchOperation.REMOVE,
+        ReviewerPatchOperation.MOVE,
+    ]
+
+
+def _default_allowed_path_descriptions() -> list[str]:
+    return [
+        "/workflow/steps ordering and call input wiring",
+        "/workflow/calls compatibility call input wiring",
+        "/workflow/outputs expressions",
+        "/tasks/<task>/outputs/<output>/value literal repairs",
+    ]
+
+
+def _default_forbidden_path_descriptions() -> list[str]:
+    return [
+        "final WDL text",
+        "Tool Catalog or Recipe Catalog data",
+        "task command templates",
+        "runtime container images",
+        "resource sizing fields",
+    ]
+
+
+class ReviewerRepairConstraints(BaseModel):
+    """Machine-readable policy summary included in Reviewer repair requests."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    allowed_operations: list[ReviewerPatchOperation] = Field(
+        default_factory=_default_allowed_operations,
+        min_length=1,
+    )
+    allowed_path_descriptions: list[str] = Field(default_factory=_default_allowed_path_descriptions)
+    forbidden_path_descriptions: list[str] = Field(default_factory=_default_forbidden_path_descriptions)
+    notes: list[str] = Field(
+        default_factory=lambda: [
+            "Reviewer may only propose Workflow IR patches.",
+            "Accepted patches must be revalidated by schema, Analyzer, Renderer, and Checker.",
+        ]
+    )
+
+
+class ReviewerPatchAction(BaseModel):
+    """One policy-checked patch action against Workflow IR."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    operation: ReviewerPatchOperation
+    path: str = Field(min_length=1)
+    value: Any | None = None
+    from_path: str | None = None
+    reason: str = Field(min_length=1)
+
+    @field_validator("path", "from_path")
+    @classmethod
+    def validate_json_pointer(cls, value: str | None) -> str | None:
+        if value is None:
+            return value
+        if not value.startswith("/"):
+            raise ValueError("patch paths must be absolute JSON pointers")
+        return value
+
+    @model_validator(mode="after")
+    def validate_move_source(self) -> ReviewerPatchAction:
+        if self.operation == ReviewerPatchOperation.MOVE and not self.from_path:
+            raise ValueError("move patch actions require from_path")
+        if self.operation != ReviewerPatchOperation.MOVE and self.from_path is not None:
+            raise ValueError("from_path is only allowed for move patch actions")
+        return self
+
+
+class ReviewerIRPatch(BaseModel):
+    """Structured patch proposed by Reviewer repair."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    summary: str = Field(min_length=1)
+    actions: list[ReviewerPatchAction] = Field(min_length=1)
+    diagnostic_references: list[str] = Field(default_factory=list)
+    catalog_references: list[str] = Field(default_factory=list)
+    confidence: float | None = Field(default=None, ge=0.0, le=1.0)
+
+
+class ReviewerRepairRequest(BaseModel):
+    """Structured request passed to Reviewer repair provider."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    workflow_ir: WorkflowIR
+    failure_stage: ReviewerFailureStage
+    analysis_errors: list[str] = Field(default_factory=list)
+    analysis_warnings: list[str] = Field(default_factory=list)
+    validation_message: str = ""
+    repair_history: list[str] = Field(default_factory=list)
+    catalog_context: ApprovedCatalogContext = Field(default_factory=ApprovedCatalogContext)
+    attempt_index: int = Field(ge=1)
+    constraints: ReviewerRepairConstraints = Field(default_factory=ReviewerRepairConstraints)
+
+
+class ReviewerRepairResult(BaseModel):
+    """Parsed Reviewer repair provider result; raw model output is not persisted."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    status: ReviewerRepairStatus
+    patch: ReviewerIRPatch | None = None
+    rejection_reason: str | None = None
+    diagnostics: list[str] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def validate_status_payload(self) -> ReviewerRepairResult:
+        if self.status == ReviewerRepairStatus.PATCH_PROPOSED and self.patch is None:
+            raise ValueError("patch_proposed results must include a parsed patch")
+        if self.status == ReviewerRepairStatus.POLICY_REJECTED and not self.rejection_reason:
+            raise ValueError("policy_rejected results must include a rejection_reason")
+        return self
+
+
+class ReviewerPatchPolicyError(ValueError):
+    """Raised when a Reviewer patch attempts to cross the P2 policy boundary."""
+
+
+_TASK_OUTPUT_VALUE_PATTERN = re.compile(r"^/tasks/[^/]+/outputs/[^/]+/value$")
+_FORBIDDEN_TOP_LEVEL_SEGMENTS = {
+    "catalog",
+    "current_wdl",
+    "final_wdl",
+    "generated_wdl",
+    "recipe_catalog",
+    "recipes",
+    "tool_catalog",
+    "tools",
+    "wdl",
+}
+_RESOURCE_FIELD_SEGMENTS = {
+    "cpu",
+    "disks",
+    "gpu",
+    "memory",
+    "preemptible",
+}
+
+
+def validate_reviewer_patch_policy(
+    patch: ReviewerIRPatch,
+    catalog_context: ApprovedCatalogContext | None = None,
+) -> ReviewerIRPatch:
+    """Validate P2 Reviewer patch boundaries without applying the patch."""
+
+    violations: list[str] = []
+    for action in patch.actions:
+        violations.extend(_validate_action_policy(action))
+
+    if catalog_context is not None:
+        allowed_references = catalog_context.approved_reference_ids()
+        for reference in patch.catalog_references:
+            if reference not in allowed_references:
+                violations.append(
+                    f"catalog reference '{reference}' is not in the approved current-workflow context"
+                )
+
+    if violations:
+        raise ReviewerPatchPolicyError("; ".join(violations))
+    return patch
+
+
+def _validate_action_policy(action: ReviewerPatchAction) -> list[str]:
+    violations = []
+    for label, path in _iter_action_paths(action):
+        if _is_forbidden_path(path):
+            violations.append(f"{label} path '{path}' crosses a forbidden Reviewer repair boundary")
+            continue
+        if not _is_allowed_path(path, action.operation):
+            violations.append(f"{label} path '{path}' is outside the P2 Reviewer patch allowlist")
+    return violations
+
+
+def _iter_action_paths(action: ReviewerPatchAction) -> list[tuple[str, str]]:
+    paths = [("target", action.path)]
+    if action.from_path is not None:
+        paths.append(("source", action.from_path))
+    return paths
+
+
+def _is_allowed_path(path: str, operation: ReviewerPatchOperation) -> bool:
+    if path in {"/workflow/steps", "/workflow/calls", "/workflow/outputs"}:
+        return True
+
+    if path.startswith("/workflow/outputs/"):
+        return True
+
+    if _TASK_OUTPUT_VALUE_PATTERN.match(path):
+        return True
+
+    if _is_call_input_path(path):
+        return True
+
+    if operation == ReviewerPatchOperation.MOVE and _is_workflow_step_or_call_path(path):
+        return True
+
+    return False
+
+
+def _is_call_input_path(path: str) -> bool:
+    if not _is_workflow_step_or_call_path(path):
+        return False
+    return "/inputs/" in path or path.endswith("/inputs")
+
+
+def _is_workflow_step_or_call_path(path: str) -> bool:
+    return path.startswith("/workflow/steps/") or path.startswith("/workflow/calls/")
+
+
+def _is_forbidden_path(path: str) -> bool:
+    segments = _json_pointer_segments(path)
+    if not segments:
+        return True
+
+    if segments[0] in _FORBIDDEN_TOP_LEVEL_SEGMENTS:
+        return True
+
+    if len(segments) >= 3 and segments[0] == "tasks" and segments[2] in {"command", "runtime"}:
+        return True
+
+    for index, segment in enumerate(segments):
+        previous = segments[index - 1] if index else ""
+        if segment in _RESOURCE_FIELD_SEGMENTS and previous in {"resources", "runtime"}:
+            return True
+
+    return False
+
+
+def _json_pointer_segments(path: str) -> list[str]:
+    return [segment.replace("~1", "/").replace("~0", "~") for segment in path.split("/")[1:]]

--- a/tests/test_reviewer_repair.py
+++ b/tests/test_reviewer_repair.py
@@ -281,6 +281,31 @@ class ReviewerRepairContractTests(unittest.TestCase):
                 with self.assertRaises(ReviewerPatchPolicyError):
                     validate_reviewer_patch_policy(patch)
 
+    def test_policy_rejects_move_between_workflow_steps_and_calls(self):
+        moves = [
+            ("/workflow/steps/1", "/workflow/calls/0"),
+            ("/workflow/calls/1", "/workflow/steps/0"),
+        ]
+
+        for from_path, path in moves:
+            with self.subTest(from_path=from_path, path=path):
+                patch = ReviewerIRPatch.model_validate(
+                    {
+                        "summary": "Move across workflow collections.",
+                        "actions": [
+                            {
+                                "operation": "move",
+                                "from_path": from_path,
+                                "path": path,
+                                "reason": "Cross-collection moves are structural changes.",
+                            }
+                        ],
+                    }
+                )
+
+                with self.assertRaisesRegex(ReviewerPatchPolicyError, "same workflow"):
+                    validate_reviewer_patch_policy(patch)
+
     def test_repair_result_requires_parsed_patch_or_rejection_reason(self):
         patch = ReviewerIRPatch.model_validate(
             {

--- a/tests/test_reviewer_repair.py
+++ b/tests/test_reviewer_repair.py
@@ -1,0 +1,219 @@
+import unittest
+
+from pydantic import ValidationError
+
+from src.reviewer_repair import (
+    ApprovedCatalogContext,
+    ReviewerFailureStage,
+    ReviewerIRPatch,
+    ReviewerPatchPolicyError,
+    ReviewerRepairRequest,
+    ReviewerRepairResult,
+    ReviewerRepairStatus,
+    validate_reviewer_patch_policy,
+)
+
+
+def sample_workflow_ir():
+    return {
+        "workflow": {
+            "name": "ReviewerRepairDemo",
+            "inputs": {
+                "raw_r1": "File",
+                "raw_r2": "File",
+            },
+            "steps": [
+                {
+                    "kind": "call",
+                    "id": "qc",
+                    "task": "fastp",
+                    "inputs": {
+                        "r1": "raw_r1",
+                        "r2": "raw_r2",
+                    },
+                }
+            ],
+            "outputs": {
+                "clean_r1": "qc.clean_r1",
+            },
+        },
+        "tasks": {
+            "fastp": {
+                "inputs": {
+                    "r1": "File",
+                    "r2": "File",
+                },
+                "command": "fastp -i ~{r1} -I ~{r2} -o clean_R1.fq.gz -O clean_R2.fq.gz",
+                "outputs": {
+                    "clean_r1": {
+                        "type": "File",
+                        "value": "\"clean_R1.fq.gz\"",
+                    }
+                },
+                "runtime": {
+                    "docker": "quay.io/biocontainers/fastp:1.3.3--h43da1c4_0",
+                    "cpu": 4,
+                    "memory": "8G",
+                },
+            }
+        },
+    }
+
+
+def sample_catalog_context():
+    return {
+        "recipes": [
+            {
+                "recipe_id": "rnaseq_differential_expression",
+                "step_ids": ["qc"],
+                "tool_ids": ["fastp"],
+            }
+        ],
+        "tools": [
+            {
+                "tool_id": "fastp",
+                "version": "1.3.3",
+                "inputs": ["r1", "r2"],
+                "outputs": ["clean_r1"],
+                "trust_status": "catalog-approved",
+                "runtime_docker": "quay.io/biocontainers/fastp:1.3.3--h43da1c4_0",
+            }
+        ],
+    }
+
+
+class ReviewerRepairContractTests(unittest.TestCase):
+    def test_reviewer_repair_request_accepts_workflow_ir_and_minimal_catalog_context(self):
+        request = ReviewerRepairRequest.model_validate(
+            {
+                "workflow_ir": sample_workflow_ir(),
+                "failure_stage": ReviewerFailureStage.ANALYZER,
+                "analysis_errors": ["call 'qc' is missing input 'r2'"],
+                "analysis_warnings": [],
+                "validation_message": "",
+                "repair_history": [],
+                "catalog_context": sample_catalog_context(),
+                "attempt_index": 1,
+            }
+        )
+
+        self.assertEqual(request.failure_stage, ReviewerFailureStage.ANALYZER)
+        self.assertEqual(request.workflow_ir.workflow.name, "ReviewerRepairDemo")
+        self.assertEqual(request.catalog_context.tools[0].tool_id, "fastp")
+        self.assertEqual(request.constraints.allowed_operations[0].value, "add")
+
+    def test_reviewer_patch_model_rejects_invalid_shape(self):
+        with self.assertRaises(ValidationError):
+            ReviewerIRPatch.model_validate(
+                {
+                    "summary": "Invalid patch.",
+                    "actions": [
+                        {
+                            "operation": "rewrite",
+                            "path": "workflow/steps/0/inputs/r2",
+                            "value": "raw_r2",
+                            "reason": "Unsupported operation and non-pointer path.",
+                        }
+                    ],
+                    "confidence": 1.5,
+                }
+            )
+
+    def test_policy_accepts_allowed_workflow_ir_patch(self):
+        patch = ReviewerIRPatch.model_validate(
+            {
+                "summary": "Repair missing call input wiring.",
+                "actions": [
+                    {
+                        "operation": "add",
+                        "path": "/workflow/steps/0/inputs/r2",
+                        "value": "raw_r2",
+                        "reason": "The existing workflow input satisfies the missing task input.",
+                    }
+                ],
+                "diagnostic_references": ["call 'qc' is missing input 'r2'"],
+                "catalog_references": ["fastp:1.3.3"],
+                "confidence": 0.8,
+            }
+        )
+        context = ApprovedCatalogContext.model_validate(sample_catalog_context())
+
+        validated = validate_reviewer_patch_policy(patch, catalog_context=context)
+
+        self.assertIs(validated, patch)
+
+    def test_policy_rejects_wdl_catalog_runtime_and_resource_edits(self):
+        forbidden_paths = [
+            "/current_wdl",
+            "/catalog/tools/fastp",
+            "/tasks/fastp/command",
+            "/tasks/fastp/runtime/docker",
+            "/tasks/fastp/runtime/cpu",
+        ]
+
+        for path in forbidden_paths:
+            with self.subTest(path=path):
+                patch = ReviewerIRPatch.model_validate(
+                    {
+                        "summary": "Forbidden edit.",
+                        "actions": [
+                            {
+                                "operation": "replace",
+                                "path": path,
+                                "value": "forbidden",
+                                "reason": "This crosses the P2 repair boundary.",
+                            }
+                        ],
+                    }
+                )
+
+                with self.assertRaisesRegex(ReviewerPatchPolicyError, "forbidden"):
+                    validate_reviewer_patch_policy(patch)
+
+    def test_policy_rejects_catalog_references_outside_current_workflow_context(self):
+        patch = ReviewerIRPatch.model_validate(
+            {
+                "summary": "Use an unavailable catalog tool.",
+                "actions": [
+                    {
+                        "operation": "replace",
+                        "path": "/workflow/outputs/clean_r1",
+                        "value": "qc.clean_r1",
+                        "reason": "Output expression stays inside Workflow IR.",
+                    }
+                ],
+                "catalog_references": ["star:2.7.11b"],
+            }
+        )
+        context = ApprovedCatalogContext.model_validate(sample_catalog_context())
+
+        with self.assertRaisesRegex(ReviewerPatchPolicyError, "not in the approved"):
+            validate_reviewer_patch_policy(patch, catalog_context=context)
+
+    def test_repair_result_requires_parsed_patch_or_rejection_reason(self):
+        patch = ReviewerIRPatch.model_validate(
+            {
+                "summary": "Repair output expression.",
+                "actions": [
+                    {
+                        "operation": "replace",
+                        "path": "/workflow/outputs/clean_r1",
+                        "value": "qc.clean_r1",
+                        "reason": "Use an existing call output.",
+                    }
+                ],
+            }
+        )
+
+        result = ReviewerRepairResult(status=ReviewerRepairStatus.PATCH_PROPOSED, patch=patch)
+        self.assertEqual(result.patch.summary, "Repair output expression.")
+
+        with self.assertRaises(ValidationError):
+            ReviewerRepairResult(status=ReviewerRepairStatus.PATCH_PROPOSED)
+
+        with self.assertRaises(ValidationError):
+            ReviewerRepairResult(status=ReviewerRepairStatus.POLICY_REJECTED)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_reviewer_repair.py
+++ b/tests/test_reviewer_repair.py
@@ -211,6 +211,31 @@ class ReviewerRepairContractTests(unittest.TestCase):
         with self.assertRaisesRegex(ReviewerPatchPolicyError, "catalog_references require"):
             validate_reviewer_patch_policy(patch)
 
+    def test_policy_rejects_empty_or_nested_workflow_output_paths(self):
+        invalid_paths = [
+            "/workflow/outputs/",
+            "/workflow/outputs/clean_r1/value",
+        ]
+
+        for path in invalid_paths:
+            with self.subTest(path=path):
+                patch = ReviewerIRPatch.model_validate(
+                    {
+                        "summary": "Patch invalid workflow output path.",
+                        "actions": [
+                            {
+                                "operation": "replace",
+                                "path": path,
+                                "value": "qc.clean_r1",
+                                "reason": "Workflow outputs are direct string expressions.",
+                            }
+                        ],
+                    }
+                )
+
+                with self.assertRaises(ReviewerPatchPolicyError):
+                    validate_reviewer_patch_policy(patch)
+
     def test_policy_allows_move_only_for_workflow_step_or_call_items(self):
         patch = ReviewerIRPatch.model_validate(
             {

--- a/tests/test_reviewer_repair.py
+++ b/tests/test_reviewer_repair.py
@@ -306,7 +306,7 @@ class ReviewerRepairContractTests(unittest.TestCase):
                 with self.assertRaisesRegex(ReviewerPatchPolicyError, "same workflow"):
                     validate_reviewer_patch_policy(patch)
 
-    def test_repair_result_requires_parsed_patch_or_rejection_reason(self):
+    def test_repair_result_enforces_status_payload_invariants(self):
         patch = ReviewerIRPatch.model_validate(
             {
                 "summary": "Repair output expression.",
@@ -324,11 +324,53 @@ class ReviewerRepairContractTests(unittest.TestCase):
         result = ReviewerRepairResult(status=ReviewerRepairStatus.PATCH_PROPOSED, patch=patch)
         self.assertEqual(result.patch.summary, "Repair output expression.")
 
+        rejected = ReviewerRepairResult(
+            status=ReviewerRepairStatus.POLICY_REJECTED,
+            rejection_reason="Patch attempted to edit a forbidden path.",
+        )
+        self.assertEqual(rejected.rejection_reason, "Patch attempted to edit a forbidden path.")
+
+        no_action = ReviewerRepairResult(
+            status=ReviewerRepairStatus.NO_ACTION,
+            diagnostics=["No safe patch was identified."],
+        )
+        self.assertIsNone(no_action.patch)
+
         with self.assertRaises(ValidationError):
             ReviewerRepairResult(status=ReviewerRepairStatus.PATCH_PROPOSED)
 
         with self.assertRaises(ValidationError):
             ReviewerRepairResult(status=ReviewerRepairStatus.POLICY_REJECTED)
+
+        invalid_payloads = [
+            {
+                "status": ReviewerRepairStatus.PATCH_PROPOSED,
+                "patch": patch,
+                "rejection_reason": "Policy rejected the patch.",
+            },
+            {
+                "status": ReviewerRepairStatus.POLICY_REJECTED,
+                "patch": patch,
+                "rejection_reason": "Policy rejected the patch.",
+            },
+            {
+                "status": ReviewerRepairStatus.NO_ACTION,
+                "patch": patch,
+            },
+            {
+                "status": ReviewerRepairStatus.INVALID_REQUEST,
+                "rejection_reason": "Request was malformed.",
+            },
+            {
+                "status": ReviewerRepairStatus.MODEL_ERROR,
+                "patch": patch,
+            },
+        ]
+
+        for payload in invalid_payloads:
+            with self.subTest(status=payload["status"]):
+                with self.assertRaises(ValidationError):
+                    ReviewerRepairResult(**payload)
 
 
 if __name__ == "__main__":

--- a/tests/test_reviewer_repair.py
+++ b/tests/test_reviewer_repair.py
@@ -230,6 +230,32 @@ class ReviewerRepairContractTests(unittest.TestCase):
 
         self.assertIs(validated, patch)
 
+    def test_policy_rejects_move_outside_workflow_step_or_call_items(self):
+        move_paths = [
+            "/workflow/outputs/clean_r1",
+            "/workflow/steps/0/inputs/r2",
+            "/tasks/fastp/outputs/clean_r1/value",
+        ]
+
+        for path in move_paths:
+            with self.subTest(path=path):
+                patch = ReviewerIRPatch.model_validate(
+                    {
+                        "summary": "Move a non-ordering path.",
+                        "actions": [
+                            {
+                                "operation": "move",
+                                "from_path": path,
+                                "path": path,
+                                "reason": "MOVE is reserved for step or call item ordering.",
+                            }
+                        ],
+                    }
+                )
+
+                with self.assertRaises(ReviewerPatchPolicyError):
+                    validate_reviewer_patch_policy(patch)
+
     def test_repair_result_requires_parsed_patch_or_rejection_reason(self):
         patch = ReviewerIRPatch.model_validate(
             {

--- a/tests/test_reviewer_repair.py
+++ b/tests/test_reviewer_repair.py
@@ -118,6 +118,82 @@ class ReviewerRepairContractTests(unittest.TestCase):
                 }
             )
 
+    def test_reviewer_patch_action_enforces_operation_payload_invariants(self):
+        patch = ReviewerIRPatch.model_validate(
+            {
+                "summary": "Valid action payloads.",
+                "actions": [
+                    {
+                        "operation": "add",
+                        "path": "/workflow/steps/0/inputs/r2",
+                        "value": "raw_r2",
+                        "reason": "Add a missing call input.",
+                    },
+                    {
+                        "operation": "replace",
+                        "path": "/workflow/outputs/clean_r1",
+                        "value": "qc.clean_r1",
+                        "reason": "Replace the workflow output expression.",
+                    },
+                    {
+                        "operation": "remove",
+                        "path": "/workflow/outputs/old_output",
+                        "reason": "Remove an invalid workflow output.",
+                    },
+                    {
+                        "operation": "move",
+                        "from_path": "/workflow/steps/1",
+                        "path": "/workflow/steps/0",
+                        "reason": "Move the upstream call before the dependent call.",
+                    },
+                ],
+            }
+        )
+        self.assertEqual(len(patch.actions), 4)
+
+        invalid_actions = [
+            {
+                "operation": "add",
+                "path": "/workflow/steps/0/inputs/r2",
+                "reason": "Missing value.",
+            },
+            {
+                "operation": "replace",
+                "path": "/workflow/outputs/clean_r1",
+                "value": None,
+                "reason": "Null value.",
+            },
+            {
+                "operation": "remove",
+                "path": "/workflow/outputs/old_output",
+                "value": "old.step",
+                "reason": "Remove must not include value.",
+            },
+            {
+                "operation": "remove",
+                "path": "/workflow/outputs/old_output",
+                "value": None,
+                "reason": "Explicit null value is still a provided value.",
+            },
+            {
+                "operation": "move",
+                "from_path": "/workflow/steps/1",
+                "path": "/workflow/steps/0",
+                "value": "unused",
+                "reason": "Move must not include value.",
+            },
+        ]
+
+        for action in invalid_actions:
+            with self.subTest(operation=action["operation"], reason=action["reason"]):
+                with self.assertRaises(ValidationError):
+                    ReviewerIRPatch.model_validate(
+                        {
+                            "summary": "Invalid action payload.",
+                            "actions": [action],
+                        }
+                    )
+
     def test_policy_accepts_allowed_workflow_ir_patch(self):
         patch = ReviewerIRPatch.model_validate(
             {

--- a/tests/test_reviewer_repair.py
+++ b/tests/test_reviewer_repair.py
@@ -204,6 +204,12 @@ class ReviewerRepairContractTests(unittest.TestCase):
                         "path": "/workflow/steps/0/inputs/r2",
                         "value": "raw_r2",
                         "reason": "The existing workflow input satisfies the missing task input.",
+                    },
+                    {
+                        "operation": "replace",
+                        "path": "/tasks/fastp/outputs/clean_r1/value",
+                        "value": "\"clean_R1.fq.gz\"",
+                        "reason": "Repair the task output literal expression.",
                     }
                 ],
                 "diagnostic_references": ["call 'qc' is missing input 'r2'"],
@@ -286,6 +292,33 @@ class ReviewerRepairContractTests(unittest.TestCase):
 
         with self.assertRaisesRegex(ReviewerPatchPolicyError, "catalog_references require"):
             validate_reviewer_patch_policy(patch)
+
+    def test_policy_rejects_non_identifier_ir_path_segments(self):
+        invalid_paths = [
+            "/tasks/foo-bar/outputs/x/value",
+            "/tasks/foo/outputs/x-y/value",
+            "/workflow/steps/0/inputs/read-1",
+            "/workflow/calls/0/inputs/read-1",
+        ]
+
+        for path in invalid_paths:
+            with self.subTest(path=path):
+                patch = ReviewerIRPatch.model_validate(
+                    {
+                        "summary": "Patch an invalid identifier path segment.",
+                        "actions": [
+                            {
+                                "operation": "replace",
+                                "path": path,
+                                "value": "raw_r2",
+                                "reason": "Policy should reject invalid Workflow IR identifiers.",
+                            }
+                        ],
+                    }
+                )
+
+                with self.assertRaises(ReviewerPatchPolicyError):
+                    validate_reviewer_patch_policy(patch)
 
     def test_policy_rejects_empty_or_nested_workflow_output_paths(self):
         invalid_paths = [

--- a/tests/test_reviewer_repair.py
+++ b/tests/test_reviewer_repair.py
@@ -29,7 +29,6 @@ def sample_workflow_ir():
                     "task": "fastp",
                     "inputs": {
                         "r1": "raw_r1",
-                        "r2": "raw_r2",
                     },
                 }
             ],
@@ -146,6 +145,9 @@ class ReviewerRepairContractTests(unittest.TestCase):
         forbidden_paths = [
             "/current_wdl",
             "/catalog/tools/fastp",
+            "/workflow/steps",
+            "/workflow/calls",
+            "/workflow/steps/0/task",
             "/tasks/fastp/command",
             "/tasks/fastp/runtime/docker",
             "/tasks/fastp/runtime/cpu",
@@ -167,7 +169,7 @@ class ReviewerRepairContractTests(unittest.TestCase):
                     }
                 )
 
-                with self.assertRaisesRegex(ReviewerPatchPolicyError, "forbidden"):
+                with self.assertRaises(ReviewerPatchPolicyError):
                     validate_reviewer_patch_policy(patch)
 
     def test_policy_rejects_catalog_references_outside_current_workflow_context(self):
@@ -189,6 +191,44 @@ class ReviewerRepairContractTests(unittest.TestCase):
 
         with self.assertRaisesRegex(ReviewerPatchPolicyError, "not in the approved"):
             validate_reviewer_patch_policy(patch, catalog_context=context)
+
+    def test_policy_rejects_catalog_references_without_context(self):
+        patch = ReviewerIRPatch.model_validate(
+            {
+                "summary": "Repair missing call input wiring.",
+                "actions": [
+                    {
+                        "operation": "add",
+                        "path": "/workflow/steps/0/inputs/r2",
+                        "value": "raw_r2",
+                        "reason": "The existing workflow input satisfies the missing task input.",
+                    }
+                ],
+                "catalog_references": ["fastp:1.3.3"],
+            }
+        )
+
+        with self.assertRaisesRegex(ReviewerPatchPolicyError, "catalog_references require"):
+            validate_reviewer_patch_policy(patch)
+
+    def test_policy_allows_move_only_for_workflow_step_or_call_items(self):
+        patch = ReviewerIRPatch.model_validate(
+            {
+                "summary": "Move a call to satisfy dependencies.",
+                "actions": [
+                    {
+                        "operation": "move",
+                        "from_path": "/workflow/steps/1",
+                        "path": "/workflow/steps/0",
+                        "reason": "Move the upstream call before the dependent call.",
+                    }
+                ],
+            }
+        )
+
+        validated = validate_reviewer_patch_policy(patch)
+
+        self.assertIs(validated, patch)
 
     def test_repair_result_requires_parsed_patch_or_rejection_reason(self):
         patch = ReviewerIRPatch.model_validate(


### PR DESCRIPTION
## Summary

- Add P2.1 Reviewer repair contract models for structured requests, patches, results, and minimal approved catalog context.
- Add a narrow patch policy skeleton that accepts Workflow IR wiring/output/literal repair targets and rejects WDL, Catalog, command, runtime image, and resource edits.
- Record the confirmed P2.1 decisions and document the new contract tests.

## Validation

- `.\.venv\Scripts\python.exe -m unittest tests.test_reviewer_repair -v` passed.
- `.\.venv\Scripts\python.exe -m unittest discover -v` was run locally; 3 existing graph tests failed because no WDL validator is installed in this environment, and 4 tests were skipped.