### PR TITLE
Polish W6 portfolio demo entry points

### DIFF
--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -6,9 +6,9 @@ import "@xyflow/react/dist/style.css";
 import "./globals.css";
 
 export const metadata: Metadata = {
-  title: "AI-bioworkflow",
+  title: "AI-bioworkflow | Bioinformatics Workflow Compiler",
   description:
-    "可解释的生信 Workflow 生成与编译系统，从自然语言需求到 Recipe Tool Plan、Workflow IR 和可验证 WDL。",
+    "面向作品集展示的生信 workflow compiler demo，从 Recipe Tool Plan、Workflow IR 到可验证 WDL，并提供 run timeline、DAG 和失败回放。",
 };
 
 export default function RootLayout({

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -116,34 +116,59 @@ const stackRows = [
 
 export default function Home() {
   const workspaceHref = "/workspace?example=rnaseq-deg";
+  const demoRoutes: Array<{
+    title: string;
+    href: string;
+  }> = [
+    {
+      title: "运行 RNA-seq 示例",
+      href: workspaceHref,
+    },
+    {
+      title: "回看 Run 历史",
+      href: "/runs",
+    },
+    {
+      title: "审阅 Catalog 边界",
+      href: "/catalog",
+    },
+  ];
+  const demoHighlights = ["Timeline", "Plan / IR / WDL", "Diagnostics", "Workflow IR DAG", "Failed replay"];
 
   return (
     <div>
       <section className="workflow-backdrop border-b">
-        <div className="mx-auto flex min-h-[680px] max-w-7xl flex-col justify-center px-6 py-14 sm:px-8 lg:px-10">
+        <div className="mx-auto flex min-h-[620px] max-w-7xl flex-col justify-center px-6 py-12 sm:px-8 lg:px-10">
           <div className="w-full max-w-[calc(100vw-3rem)] sm:max-w-2xl">
             <div className="flex flex-wrap items-center gap-3">
-              <Badge variant="secondary">可解释的生信 Workflow 生成与编译系统</Badge>
-              <Badge variant="outline">W5 Run history + DAG</Badge>
+              <Badge variant="secondary">Bioinformatics workflow compiler</Badge>
+              <Badge variant="outline">W6 portfolio demo hub</Badge>
             </div>
             <h1 className="mt-6 text-4xl font-semibold tracking-normal text-foreground sm:text-5xl lg:text-6xl">
               AI-bioworkflow
             </h1>
             <p className="mt-6 max-w-xl break-words text-base leading-7 text-muted-foreground sm:text-lg sm:leading-8">
-              从自然语言需求到结构化计划、Workflow IR 与可验证 WDL，
-              展示工具目录、静态分析、确定性渲染、DAG 审阅和历史回放。
+              一个把自然语言或结构化生信需求编译成可验证 WDL 的工程作品集：
+              LLM 停在 Recipe Tool Plan 边界，Workflow IR、Analyzer、Renderer 和 Checker
+              负责确定性的编译闭环。
             </p>
             <div className="mt-8 flex flex-wrap gap-3">
               <Button asChild>
                 <Link href={workspaceHref}>
-                  打开 RNA-seq 示例
+                  运行 RNA-seq 示例
                   <ArrowRight className="h-4 w-4" />
                 </Link>
               </Button>
               <Button asChild variant="outline">
                 <Link href="/runs">
                   <History className="h-4 w-4" />
-                  查看 Run 历史
+                  Run 历史
+                </Link>
+              </Button>
+              <Button asChild variant="outline">
+                <Link href="/catalog">
+                  <Database className="h-4 w-4" />
+                  Catalog
                 </Link>
               </Button>
               <Button asChild variant="outline">
@@ -151,16 +176,30 @@ export default function Home() {
               </Button>
             </div>
 
-            <div className="mt-10 grid w-full max-w-[calc(100vw-3rem)] gap-3 text-sm sm:max-w-2xl sm:grid-cols-3">
-              {[
-                ["边界", "LLM 负责规划"],
-                ["契约", "Recipe Tool Plan -> Workflow IR"],
-                ["回放", "Timeline + DAG + Diagnostics"],
-              ].map(([label, body]) => (
-                <div key={label} className="rounded-md border bg-white/88 p-4 shadow-sm backdrop-blur">
-                  <div className="font-semibold text-primary">{label}</div>
-                  <div className="mt-2 leading-6 text-muted-foreground">{body}</div>
+            <div className="mt-7 max-w-2xl rounded-md border bg-white/82 p-3 shadow-sm backdrop-blur">
+              <div className="flex flex-wrap items-center gap-x-3 gap-y-2 text-sm">
+                <div className="flex items-center gap-2 font-semibold text-primary">
+                  <FlaskConical className="h-4 w-4 text-accent" />
+                  推荐演示路径
                 </div>
+                <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 text-muted-foreground">
+                  {demoRoutes.map((route, index) => (
+                    <span key={route.title} className="inline-flex items-center gap-2">
+                      <Link href={route.href} className="font-medium text-foreground hover:text-primary">
+                        {index + 1}. {route.title}
+                      </Link>
+                      {index < demoRoutes.length - 1 ? <ArrowRight className="h-3.5 w-3.5 text-primary/70" /> : null}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            </div>
+
+            <div className="mt-8 flex max-w-2xl flex-wrap gap-2">
+              {demoHighlights.map((item) => (
+                <Badge key={item} variant="outline" className="bg-white/80">
+                  {item}
+                </Badge>
               ))}
             </div>
           </div>

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -20,7 +20,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { apiDocsUrl } from "@/lib/api";
-import { rnaseqExamplePrompt, rnaseqRecipeSteps } from "@/lib/examples";
+import { rnaseqDemoWorkspaceHref, rnaseqExamplePrompt, rnaseqRecipeSteps } from "@/lib/examples";
 
 const pipelineStages = [
   {
@@ -115,14 +115,13 @@ const stackRows = [
 ];
 
 export default function Home() {
-  const workspaceHref = "/workspace?example=rnaseq-deg";
   const demoRoutes: Array<{
     title: string;
     href: string;
   }> = [
     {
       title: "运行 RNA-seq 示例",
-      href: workspaceHref,
+      href: rnaseqDemoWorkspaceHref,
     },
     {
       title: "回看 Run 历史",
@@ -154,7 +153,7 @@ export default function Home() {
             </p>
             <div className="mt-8 flex flex-wrap gap-3">
               <Button asChild>
-                <Link href={workspaceHref}>
+                <Link href={rnaseqDemoWorkspaceHref}>
                   运行 RNA-seq 示例
                   <ArrowRight className="h-4 w-4" />
                 </Link>
@@ -289,7 +288,7 @@ export default function Home() {
             </p>
           </div>
           <Button asChild variant="outline">
-            <Link href={workspaceHref}>打开工作台</Link>
+            <Link href={rnaseqDemoWorkspaceHref}>打开工作台</Link>
           </Button>
         </div>
         <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">

--- a/web/app/runs/[runId]/page.tsx
+++ b/web/app/runs/[runId]/page.tsx
@@ -20,6 +20,7 @@ import { RunFailureSummary } from "@/components/run/run-failure-summary";
 import { WorkflowGraphPanel } from "@/components/workflow-graph/workflow-graph";
 import { getRunSnapshot } from "@/lib/api";
 import { hasCatalogRetrieval } from "@/lib/catalog-retrieval";
+import { rnaseqDemoWorkspaceHref } from "@/lib/examples";
 import type { JsonObject, RunStatus, WorkflowRunSnapshotResponse } from "@/lib/types";
 
 export const dynamic = "force-dynamic";
@@ -156,7 +157,7 @@ function RunDetail({ snapshot }: { snapshot: WorkflowRunSnapshotResponse }) {
             </Link>
           </Button>
           <Button asChild>
-            <Link href="/workspace?example=rnaseq-deg">
+            <Link href={rnaseqDemoWorkspaceHref}>
               <RotateCcw className="h-4 w-4" />
               运行示例
             </Link>

--- a/web/app/runs/page.tsx
+++ b/web/app/runs/page.tsx
@@ -15,6 +15,7 @@ import Link from "next/link";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { listRuns } from "@/lib/api";
+import { rnaseqDemoWorkspaceHref } from "@/lib/examples";
 import type { RunListResponse, RunStatus, RunSummary } from "@/lib/types";
 
 export const dynamic = "force-dynamic";
@@ -207,7 +208,7 @@ function RunsList({
           运行一次 RNA-seq 示例后，这里会显示持久化 run 摘要。
         </p>
         <Button asChild className="mt-5">
-          <Link href="/workspace?example=rnaseq-deg">
+          <Link href={rnaseqDemoWorkspaceHref}>
             <RotateCcw className="h-4 w-4" />
             打开工作台
           </Link>
@@ -273,7 +274,7 @@ export default async function RunsPage({
           </p>
         </div>
         <Button asChild variant="outline">
-          <Link href="/workspace?example=rnaseq-deg">
+          <Link href={rnaseqDemoWorkspaceHref}>
             <RotateCcw className="h-4 w-4" />
             运行 RNA-seq 示例
           </Link>

--- a/web/app/workspace/page.tsx
+++ b/web/app/workspace/page.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { apiDocsUrl } from "@/lib/api";
-import { rnaseqExamplePrompt } from "@/lib/examples";
+import { rnaseqDemoExampleSlug, rnaseqExamplePrompt } from "@/lib/examples";
 import { WorkspaceWorkbench } from "./workspace-workbench";
 
 export default async function WorkspacePage({
@@ -13,7 +13,7 @@ export default async function WorkspacePage({
   searchParams: Promise<{ example?: string }>;
 }) {
   const params = await searchParams;
-  const isExample = params.example === "rnaseq-deg";
+  const isExample = params.example === rnaseqDemoExampleSlug;
 
   return (
     <div className="mx-auto max-w-7xl px-6 py-8 sm:px-8 lg:px-10">

--- a/web/components/site-header.tsx
+++ b/web/components/site-header.tsx
@@ -3,10 +3,10 @@ import Link from "next/link";
 
 import { Button } from "@/components/ui/button";
 import { apiDocsUrl } from "@/lib/api";
+import { rnaseqDemoWorkspaceHref } from "@/lib/examples";
 
-const primaryDemoHref = "/workspace?example=rnaseq-deg";
 const navLinks = [
-  { label: "运行示例", href: primaryDemoHref },
+  { label: "运行示例", href: rnaseqDemoWorkspaceHref },
   { label: "Run 历史", href: "/runs" },
   { label: "Catalog", href: "/catalog" },
   { label: "系统视图", href: "/#surfaces" },
@@ -32,7 +32,7 @@ export function SiteHeader() {
         </nav>
         <div className="flex items-center gap-2">
           <Button asChild size="sm" className="h-9">
-            <Link href={primaryDemoHref} aria-label="运行 RNA-seq 示例">
+            <Link href={rnaseqDemoWorkspaceHref} aria-label="运行 RNA-seq 示例">
               <PlayCircle className="h-4 w-4" />
               <span className="hidden sm:inline">运行示例</span>
             </Link>

--- a/web/components/site-header.tsx
+++ b/web/components/site-header.tsx
@@ -1,8 +1,17 @@
-import { Braces, Github } from "lucide-react";
+import { Braces, Github, PlayCircle } from "lucide-react";
 import Link from "next/link";
 
 import { Button } from "@/components/ui/button";
 import { apiDocsUrl } from "@/lib/api";
+
+const primaryDemoHref = "/workspace?example=rnaseq-deg";
+const navLinks = [
+  { label: "运行示例", href: primaryDemoHref },
+  { label: "Run 历史", href: "/runs" },
+  { label: "Catalog", href: "/catalog" },
+  { label: "系统视图", href: "/#surfaces" },
+  { label: "API 文档", href: apiDocsUrl },
+];
 
 export function SiteHeader() {
   return (
@@ -15,30 +24,25 @@ export function SiteHeader() {
           AI-bioworkflow
         </Link>
         <nav className="hidden items-center gap-6 text-sm font-medium text-muted-foreground md:flex">
-          <Link className="hover:text-foreground" href="/#overview">
-            概览
-          </Link>
-          <Link className="hover:text-foreground" href="/#case">
-            示例案例
-          </Link>
-          <Link className="hover:text-foreground" href="/#surfaces">
-            系统视图
-          </Link>
-          <Link className="hover:text-foreground" href="/workspace?example=rnaseq-deg">
-            工作台预览
-          </Link>
-          <Link className="hover:text-foreground" href={apiDocsUrl}>
-            API 文档
-          </Link>
-          <Link className="hover:text-foreground" href="https://github.com/yuanzhw/AI-bioworkflow">
-            代码仓库
-          </Link>
+          {navLinks.map((link) => (
+            <Link key={link.href} className="hover:text-foreground" href={link.href}>
+              {link.label}
+            </Link>
+          ))}
         </nav>
-        <Button asChild variant="outline" size="icon" aria-label="打开代码仓库">
-          <Link href="https://github.com/yuanzhw/AI-bioworkflow">
-            <Github className="h-4 w-4" />
-          </Link>
-        </Button>
+        <div className="flex items-center gap-2">
+          <Button asChild size="sm" className="h-9">
+            <Link href={primaryDemoHref} aria-label="运行 RNA-seq 示例">
+              <PlayCircle className="h-4 w-4" />
+              <span className="hidden sm:inline">运行示例</span>
+            </Link>
+          </Button>
+          <Button asChild variant="outline" size="icon" aria-label="打开代码仓库">
+            <Link href="https://github.com/yuanzhw/AI-bioworkflow">
+              <Github className="h-4 w-4" />
+            </Link>
+          </Button>
+        </div>
       </div>
     </header>
   );

--- a/web/lib/examples.ts
+++ b/web/lib/examples.ts
@@ -1,5 +1,8 @@
 import type { JsonObject } from "@/lib/types";
 
+export const rnaseqDemoExampleSlug = "rnaseq-deg";
+export const rnaseqDemoWorkspaceHref = `/workspace?example=${rnaseqDemoExampleSlug}`;
+
 export const rnaseqExamplePrompt =
   "构建一个 bulk RNA-seq 差异表达分析工作流，输入多个样本的 paired-end FASTQ 文件。每个样本先运行 fastp 做读段质控，再用 Salmon 做转录本定量，随后通过 tximport 汇总到基因层面，用 DESeq2 完成差异表达分析，并返回 MultiQC 质控报告。";
 


### PR DESCRIPTION
## Summary
- Rework the homepage hero into a clearer W6 portfolio demo hub.
- Promote the RNA-seq demo, run history, and catalog as primary entry points.
- Update site navigation and metadata to emphasize the workflow compiler demo.

## Verification
- `npm.cmd run lint`
- `npm.cmd run test:graph`
- `npm.cmd run build`