### PR TITLE
Add retrieval evaluation baseline

### DIFF
--- a/docs/r2-retrieval-evaluation-roadmap.md
+++ b/docs/r2-retrieval-evaluation-roadmap.md
@@ -52,18 +52,24 @@ retrieval query set
 {
   "id": "rnaseq_deg_basic_en",
   "query": "Run bulk RNA-seq differential expression from paired-end FASTQ files.",
+  "supported": true,
   "expected_recipe": "rnaseq_differential_expression",
   "expected_tools": ["fastp", "salmon", "tximport", "deseq2", "multiqc"],
   "expected_roles": {
     "read_quality_control": ["fastp"],
-    "transcript_quantification": ["salmon"],
-    "gene_count_summary": ["tximport"],
+    "expression_quantification": ["salmon"],
+    "transcript_to_gene_count_summary": ["tximport"],
     "differential_expression": ["deseq2"],
-    "quality_report": ["multiqc"]
+    "quality_control_summary": ["multiqc"]
   },
   "notes": "Basic RNA-seq DEG request without explicit tool names."
 }
 ```
+
+`supported: false` 用于当前 approved Catalog 暂不支持的负例。负例不定义
+`expected_recipe`、`expected_tools` 或 `expected_roles`，因此不会拉低当前
+RNA-seq baseline recall；它们单独用于观察 fallback、误召回和未来 Catalog
+扩展需求。
 
 建议第一批 20 条，覆盖：
 
@@ -77,6 +83,24 @@ retrieval query set
 - 参数相关请求，例如 paired-end reads、contrast、threads。
 
 建议文件：
+
+```text
+tests/fixtures/retrieval_queries.json
+```
+
+### R2a Current-Catalog Baseline Scope
+
+R2 不要求先扩充工具数量。第一步先基于当前 approved Catalog 建立可重复
+baseline：
+
+- 12 条当前支持范围内的 RNA-seq DEG / QC / quantification / reporting 查询。
+- 4 条 unsupported negative queries，覆盖 ChIP-seq、scRNA-seq、variant
+  calling 和 metagenomics。
+- 指标仅声明为 current-catalog baseline，不代表多 workflow family 检索能力。
+- 后续增加更多 approved tools / recipes 后，再扩展到 20-40 条跨领域 query，
+  并用同一 eval contract 比较 lexical、vector 和 hybrid backend。
+
+当前 fixture：
 
 ```text
 tests/fixtures/retrieval_queries.json
@@ -105,15 +129,10 @@ lexical_v1 Fallback Rate
 
 ## Eval Script
 
-建议新增一个独立脚本或 unittest：
+当前新增独立脚本与 unittest：
 
 ```text
 scripts/evaluate_retrieval.py
-```
-
-或：
-
-```text
 tests/test_retrieval_evaluation.py
 ```
 
@@ -125,6 +144,37 @@ tests/test_retrieval_evaluation.py
 - fallback queries。
 
 输出格式建议同时支持人类可读 summary 和 JSON artifact，便于后续前端或文档展示。
+
+当前命令：
+
+```powershell
+.\.venv\Scripts\python.exe scripts\evaluate_retrieval.py
+```
+
+初始 `lexical_v1` current-catalog baseline：
+
+| Metric | Value |
+| --- | ---: |
+| Query count | 16 |
+| Supported queries | 12 |
+| Unsupported queries | 4 |
+| Recipe Recall@3 | 1.0000 |
+| Recipe MRR | 1.0000 |
+| Tool Recall@8 | 0.9722 |
+| Tool MRR | 1.0000 |
+| Role Coverage | 0.9722 |
+| Fallback Rate | 0.0625 |
+| Supported Fallback Rate | 0.0000 |
+| Unsupported Fallback Rate | 0.2500 |
+
+已知 baseline 观察：
+
+- `rnaseq_params_threads_contrast_en` 未召回 `tximport`，说明参数型 query
+  可能需要更强的 recipe-step 或 role-aware expansion。
+- `unsupported_chipseq_peak_calling_en`、`unsupported_scrnaseq_clustering_en`
+  和 `unsupported_variant_calling_en` 产生 direct lexical match，说明当前
+  lexical fallback 不是 unsupported intent detector；负例评估只用于暴露风险，
+  不改变 full Catalog validation 边界。
 
 ## Vector / Hybrid Retriever
 

--- a/docs/test-cases.md
+++ b/docs/test-cases.md
@@ -1715,6 +1715,26 @@ baseline metrics。Fixture 不扩展正式 Catalog，也不伪造工具；unsupp
 
 - Unsupported negative cases 不能同时声明正例答案，避免 baseline 指标语义混乱。
 
+### `test_rejects_non_object_fixture_entries`
+
+输入：
+
+- `tests/fixtures/invalid_non_object_queries.json`，其中 JSON array 第一项不是 object。
+
+执行：
+
+- 调用 `load_retrieval_queries(...)`。
+
+期望输出：
+
+- 抛出 `ValueError`。
+- 错误消息包含 `entry at index 0 must be an object`。
+
+覆盖点：
+
+- Query fixture loader 对格式错误的 entry 返回清晰错误，而不是泄漏底层
+  `AttributeError`。
+
 ## `tests/test_catalog_service.py`
 
 该文件验证 W0 catalog 查询服务。服务层返回 JSON-ready 的 recipe/tool 记录，供 FastAPI 的 catalog 查询端点复用。

--- a/docs/test-cases.md
+++ b/docs/test-cases.md
@@ -1608,6 +1608,113 @@ Recipe / Tool Catalog 中做确定性词法召回，不访问网络、不引入 
 
 - Retriever 在进入 scoring 前拒绝不可分析的空 query。
 
+## `tests/test_retrieval_evaluation.py`
+
+该文件验证 R2 retrieval evaluation baseline。Evaluation 读取人工标注 query
+fixture，调用当前 Approved Catalog Retriever，并计算 current-catalog
+baseline metrics。Fixture 不扩展正式 Catalog，也不伪造工具；unsupported
+负例单独统计，不污染当前 RNA-seq supported recall。
+
+### `test_loads_current_catalog_query_fixture`
+
+输入：
+
+- `tests/fixtures/retrieval_queries.json`。
+
+执行：
+
+- 调用 `load_retrieval_queries(...)`。
+
+期望输出：
+
+- fixture 共 16 条 query。
+- 12 条 `supported == True`，4 条 `supported == False`。
+- 第一条 query id 为 `rnaseq_deg_basic_en`。
+- 第一条 query 的 expected tools 包含 `fastp`。
+
+覆盖点：
+
+- R2 query set schema 可被稳定读取。
+- 当前 baseline 明确区分 supported RNA-seq 查询和 unsupported 负例。
+
+### `test_evaluates_current_catalog_baseline`
+
+输入：
+
+- 当前正式 Tool Catalog。
+- 当前正式 Recipe Catalog。
+- `tests/fixtures/retrieval_queries.json`。
+
+执行：
+
+- 调用 `evaluate_retrieval_queries(...)`。
+
+期望输出：
+
+- `strategy == "lexical_v1"`。
+- `top_k_recipes == 3`。
+- `top_k_tools == 8`。
+- `query_count == 16`。
+- `supported_query_count == 12`。
+- `unsupported_query_count == 4`。
+- 每个 metric 均为 0 到 1 之间的稳定数值。
+
+覆盖点：
+
+- 当前 Catalog 可以生成可重复 retrieval baseline。
+- Baseline artifact 包含 per-query retrieval、miss、fallback 与 aggregate metrics。
+
+### `test_computes_supported_metrics_and_tracks_unsupported_matches`
+
+输入：
+
+- 三条 synthetic query：
+  - supported hit。
+  - supported miss。
+  - unsupported direct match。
+- fake retriever 返回固定 recipes、tools 和 fallback 状态。
+
+执行：
+
+- 调用 `evaluate_retrieval_queries(..., retriever=fake_retriever)`。
+
+期望输出：
+
+- `recipe_recall_at_k == 0.5`。
+- `recipe_mrr == 0.5`。
+- `tool_recall_at_k == 0.25`。
+- `tool_mrr == 0.5`。
+- `role_coverage == 0.25`。
+- `fallback_rate == 0.3333`。
+- `supported_fallback_rate == 0.5`。
+- `unsupported_fallback_rate == 0.0`。
+- `unsupported_direct_match_query_ids == ["q3"]`。
+
+覆盖点：
+
+- Supported queries 参与 recall / MRR / role coverage。
+- Unsupported queries 不污染 supported recall，但会暴露 direct-match 风险。
+- Fallback rate 按 all / supported / unsupported 三个视角记录。
+
+### `test_rejects_unsupported_queries_with_expected_hits`
+
+输入：
+
+- 一条 `supported == False` 但定义了 `expected_recipe` 的 query dict。
+
+执行：
+
+- 调用 `RetrievalQuery.from_dict(...)`。
+
+期望输出：
+
+- 抛出 `ValueError`。
+- 错误消息包含 `unsupported queries must not define expected hits`。
+
+覆盖点：
+
+- Unsupported negative cases 不能同时声明正例答案，避免 baseline 指标语义混乱。
+
 ## `tests/test_catalog_service.py`
 
 该文件验证 W0 catalog 查询服务。服务层返回 JSON-ready 的 recipe/tool 记录，供 FastAPI 的 catalog 查询端点复用。

--- a/scripts/evaluate_retrieval.py
+++ b/scripts/evaluate_retrieval.py
@@ -22,7 +22,7 @@ from src.catalog.retrieval_eval import (
 from src.recipes.loader import load_recipe_catalog
 
 
-DEFAULT_QUERY_FIXTURE = Path("tests/fixtures/retrieval_queries.json")
+DEFAULT_QUERY_FIXTURE = PROJECT_ROOT / "tests" / "fixtures" / "retrieval_queries.json"
 
 
 def parse_args() -> argparse.Namespace:

--- a/scripts/evaluate_retrieval.py
+++ b/scripts/evaluate_retrieval.py
@@ -1,0 +1,138 @@
+"""Run the approved catalog retriever evaluation fixture."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from src.catalog.loader import load_tool_catalog
+from src.catalog.retrieval_eval import (
+    DEFAULT_TOP_K_RECIPES,
+    DEFAULT_TOP_K_TOOLS,
+    evaluate_retrieval_queries,
+    load_retrieval_queries,
+)
+from src.recipes.loader import load_recipe_catalog
+
+
+DEFAULT_QUERY_FIXTURE = Path("tests/fixtures/retrieval_queries.json")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Evaluate approved catalog retrieval against labeled query fixtures.",
+    )
+    parser.add_argument(
+        "--queries",
+        type=Path,
+        default=DEFAULT_QUERY_FIXTURE,
+        help=f"Path to retrieval query fixture. Default: {DEFAULT_QUERY_FIXTURE}",
+    )
+    parser.add_argument(
+        "--top-k-recipes",
+        type=int,
+        default=DEFAULT_TOP_K_RECIPES,
+        help=f"Recipe Recall@K cutoff. Default: {DEFAULT_TOP_K_RECIPES}",
+    )
+    parser.add_argument(
+        "--top-k-tools",
+        type=int,
+        default=DEFAULT_TOP_K_TOOLS,
+        help=f"Tool Recall@K cutoff. Default: {DEFAULT_TOP_K_TOOLS}",
+    )
+    parser.add_argument(
+        "--json-output",
+        type=Path,
+        help="Optional path to write the full JSON evaluation artifact.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Print the full JSON evaluation artifact instead of a summary.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    tool_catalog = load_tool_catalog()
+    recipe_catalog = load_recipe_catalog(tool_catalog=tool_catalog)
+    queries = load_retrieval_queries(args.queries)
+    evaluation = evaluate_retrieval_queries(
+        queries,
+        tool_catalog,
+        recipe_catalog,
+        top_k_recipes=args.top_k_recipes,
+        top_k_tools=args.top_k_tools,
+    )
+
+    if args.json_output:
+        args.json_output.parent.mkdir(parents=True, exist_ok=True)
+        args.json_output.write_text(
+            json.dumps(evaluation, indent=2, ensure_ascii=False) + "\n",
+            encoding="utf-8",
+        )
+
+    if args.json:
+        print(json.dumps(evaluation, indent=2, ensure_ascii=False))
+    else:
+        print(_format_summary(evaluation))
+    return 0
+
+
+def _format_summary(evaluation: dict[str, Any]) -> str:
+    metrics = evaluation["metrics"]
+    lines = [
+        f"Retrieval strategy: {evaluation['strategy']}",
+        (
+            f"Queries: {evaluation['query_count']} "
+            f"({evaluation['supported_query_count']} supported, "
+            f"{evaluation['unsupported_query_count']} unsupported)"
+        ),
+        f"Recipe Recall@{evaluation['top_k_recipes']}: {metrics['recipe_recall_at_k']:.4f}",
+        f"Recipe MRR: {metrics['recipe_mrr']:.4f}",
+        f"Tool Recall@{evaluation['top_k_tools']}: {metrics['tool_recall_at_k']:.4f}",
+        f"Tool MRR: {metrics['tool_mrr']:.4f}",
+        f"Role Coverage: {metrics['role_coverage']:.4f}",
+        f"Fallback Rate: {metrics['fallback_rate']:.4f}",
+        f"Supported Fallback Rate: {metrics['supported_fallback_rate']:.4f}",
+        f"Unsupported Fallback Rate: {metrics['unsupported_fallback_rate']:.4f}",
+    ]
+
+    if evaluation["fallback_query_ids"]:
+        lines.append("Fallback queries: " + ", ".join(evaluation["fallback_query_ids"]))
+    if evaluation["unsupported_direct_match_query_ids"]:
+        lines.append(
+            "Unsupported direct-match queries: "
+            + ", ".join(evaluation["unsupported_direct_match_query_ids"])
+        )
+
+    missed = [
+        result
+        for result in evaluation["queries"]
+        if result["missed_expected_recipe"] or result["missed_expected_tools"] or result["missed_roles"]
+    ]
+    if missed:
+        lines.append("Misses:")
+        for result in missed:
+            details: list[str] = []
+            if result["missed_expected_recipe"]:
+                details.append(f"recipe={result['missed_expected_recipe']}")
+            if result["missed_expected_tools"]:
+                details.append("tools=" + ",".join(result["missed_expected_tools"]))
+            if result["missed_roles"]:
+                details.append("roles=" + ",".join(result["missed_roles"]))
+            lines.append(f"  - {result['id']}: " + "; ".join(details))
+
+    return "\n".join(lines)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/catalog/retrieval_eval.py
+++ b/src/catalog/retrieval_eval.py
@@ -67,11 +67,23 @@ def load_retrieval_queries(path: str | Path) -> list[RetrievalQuery]:
     data = json.loads(fixture_path.read_text(encoding="utf-8"))
     if not isinstance(data, list):
         raise ValueError("retrieval query fixture must contain a JSON array")
-    queries = [RetrievalQuery.from_dict(item) for item in data]
-    ids = [query.id for query in queries]
-    duplicate_ids = sorted({query_id for query_id in ids if ids.count(query_id) > 1})
+
+    queries: list[RetrievalQuery] = []
+    seen_ids: set[str] = set()
+    duplicate_ids: list[str] = []
+    for index, item in enumerate(data):
+        if not isinstance(item, dict):
+            raise ValueError(f"retrieval query entry at index {index} must be an object")
+        query = RetrievalQuery.from_dict(item)
+        if query.id in seen_ids:
+            duplicate_ids.append(query.id)
+        else:
+            seen_ids.add(query.id)
+        queries.append(query)
+
     if duplicate_ids:
-        raise ValueError(f"duplicate retrieval query ids: {', '.join(duplicate_ids)}")
+        duplicate_summary = ", ".join(sorted(set(duplicate_ids)))
+        raise ValueError(f"duplicate retrieval query ids: {duplicate_summary}")
     return queries
 
 

--- a/src/catalog/retrieval_eval.py
+++ b/src/catalog/retrieval_eval.py
@@ -1,0 +1,296 @@
+"""Evaluation helpers for approved catalog retrieval baselines."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from src.catalog.loader import ToolCatalog
+from src.catalog.retriever import retrieve_catalog_context
+from src.recipes.loader import RecipeCatalog
+
+
+DEFAULT_TOP_K_RECIPES = 3
+DEFAULT_TOP_K_TOOLS = 8
+RetrievalFn = Callable[[str, ToolCatalog, RecipeCatalog, int, int], dict[str, Any]]
+
+
+@dataclass(frozen=True)
+class RetrievalQuery:
+    """A labeled natural-language query for retriever evaluation."""
+
+    id: str
+    query: str
+    supported: bool
+    expected_recipe: str | None
+    expected_tools: list[str]
+    expected_roles: dict[str, list[str]]
+    notes: str | None = None
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "RetrievalQuery":
+        query_id = _required_str(data, "id")
+        query = _required_str(data, "query")
+        supported = data.get("supported", True)
+        if not isinstance(supported, bool):
+            raise ValueError(f"{query_id}: supported must be a boolean")
+
+        expected_recipe_raw = data.get("expected_recipe")
+        if expected_recipe_raw is not None and not isinstance(expected_recipe_raw, str):
+            raise ValueError(f"{query_id}: expected_recipe must be a string or null")
+
+        expected_tools = _string_list(data.get("expected_tools", []), f"{query_id}: expected_tools")
+        expected_roles = _expected_roles(data.get("expected_roles", {}), query_id)
+        notes = data.get("notes")
+        if notes is not None and not isinstance(notes, str):
+            raise ValueError(f"{query_id}: notes must be a string or null")
+        if not supported and (expected_recipe_raw is not None or expected_tools or expected_roles):
+            raise ValueError(f"{query_id}: unsupported queries must not define expected hits")
+
+        return cls(
+            id=query_id,
+            query=query,
+            supported=supported,
+            expected_recipe=expected_recipe_raw,
+            expected_tools=expected_tools,
+            expected_roles=expected_roles,
+            notes=notes,
+        )
+
+
+def load_retrieval_queries(path: str | Path) -> list[RetrievalQuery]:
+    """Load a JSON query fixture and validate its public schema."""
+    fixture_path = Path(path)
+    data = json.loads(fixture_path.read_text(encoding="utf-8"))
+    if not isinstance(data, list):
+        raise ValueError("retrieval query fixture must contain a JSON array")
+    queries = [RetrievalQuery.from_dict(item) for item in data]
+    ids = [query.id for query in queries]
+    duplicate_ids = sorted({query_id for query_id in ids if ids.count(query_id) > 1})
+    if duplicate_ids:
+        raise ValueError(f"duplicate retrieval query ids: {', '.join(duplicate_ids)}")
+    return queries
+
+
+def evaluate_retrieval_queries(
+    queries: Sequence[RetrievalQuery],
+    tool_catalog: ToolCatalog,
+    recipe_catalog: RecipeCatalog,
+    *,
+    top_k_recipes: int = DEFAULT_TOP_K_RECIPES,
+    top_k_tools: int = DEFAULT_TOP_K_TOOLS,
+    retriever: RetrievalFn = retrieve_catalog_context,
+) -> dict[str, Any]:
+    """Evaluate a retriever over labeled current-catalog query fixtures."""
+    if top_k_recipes < 1:
+        raise ValueError("top_k_recipes must be >= 1")
+    if top_k_tools < 1:
+        raise ValueError("top_k_tools must be >= 1")
+
+    per_query = [
+        _evaluate_one_query(
+            query,
+            tool_catalog,
+            recipe_catalog,
+            top_k_recipes=top_k_recipes,
+            top_k_tools=top_k_tools,
+            retriever=retriever,
+        )
+        for query in queries
+    ]
+
+    supported_results = [result for result in per_query if result["supported"]]
+    recipe_results = [result for result in supported_results if result["expected_recipe"]]
+    tool_results = [result for result in supported_results if result["expected_tools"]]
+    role_results = [result for result in supported_results if result["expected_roles"]]
+
+    fallback_query_ids = [result["id"] for result in per_query if result["fallback_used"]]
+    supported_fallback_query_ids = [
+        result["id"] for result in supported_results if result["fallback_used"]
+    ]
+    unsupported_results = [result for result in per_query if not result["supported"]]
+    unsupported_fallback_query_ids = [
+        result["id"] for result in unsupported_results if result["fallback_used"]
+    ]
+    unsupported_direct_match_query_ids = [
+        result["id"] for result in unsupported_results if not result["fallback_used"]
+    ]
+
+    return {
+        "strategy": _first_strategy(per_query),
+        "top_k_recipes": top_k_recipes,
+        "top_k_tools": top_k_tools,
+        "query_count": len(per_query),
+        "supported_query_count": len(supported_results),
+        "unsupported_query_count": len(unsupported_results),
+        "metrics": {
+            "recipe_recall_at_k": _mean(
+                1.0 if result["expected_recipe_recalled"] else 0.0
+                for result in recipe_results
+            ),
+            "recipe_mrr": _mean(result["expected_recipe_reciprocal_rank"] for result in recipe_results),
+            "tool_recall_at_k": _mean(result["tool_recall"] for result in tool_results),
+            "tool_mrr": _mean(result["first_expected_tool_reciprocal_rank"] for result in tool_results),
+            "role_coverage": _mean(result["role_coverage"] for result in role_results),
+            "fallback_rate": _rate(len(fallback_query_ids), len(per_query)),
+            "supported_fallback_rate": _rate(
+                len(supported_fallback_query_ids),
+                len(supported_results),
+            ),
+            "unsupported_fallback_rate": _rate(
+                len(unsupported_fallback_query_ids),
+                len(unsupported_results),
+            ),
+        },
+        "fallback_query_ids": fallback_query_ids,
+        "unsupported_direct_match_query_ids": unsupported_direct_match_query_ids,
+        "queries": per_query,
+    }
+
+
+def _evaluate_one_query(
+    query: RetrievalQuery,
+    tool_catalog: ToolCatalog,
+    recipe_catalog: RecipeCatalog,
+    *,
+    top_k_recipes: int,
+    top_k_tools: int,
+    retriever: RetrievalFn,
+) -> dict[str, Any]:
+    retrieval = retriever(
+        query.query,
+        tool_catalog,
+        recipe_catalog,
+        top_k_recipes,
+        top_k_tools,
+    )
+    retrieved_recipe_ids = [str(recipe["id"]) for recipe in retrieval.get("recipes", [])]
+    retrieved_tool_ids = [str(tool["id"]) for tool in retrieval.get("tools", [])]
+
+    expected_recipe_rank = _rank_of(query.expected_recipe, retrieved_recipe_ids)
+    expected_tool_ranks = {
+        tool_id: _rank_of(tool_id, retrieved_tool_ids)
+        for tool_id in query.expected_tools
+    }
+    recalled_tools = [
+        tool_id for tool_id, rank in expected_tool_ranks.items() if rank is not None
+    ]
+    missed_tools = [
+        tool_id for tool_id, rank in expected_tool_ranks.items() if rank is None
+    ]
+    role_coverage = _role_coverage(query.expected_roles, retrieved_tool_ids)
+
+    return {
+        "id": query.id,
+        "query": query.query,
+        "supported": query.supported,
+        "expected_recipe": query.expected_recipe,
+        "expected_tools": query.expected_tools,
+        "expected_roles": query.expected_roles,
+        "retrieved_recipes": retrieved_recipe_ids,
+        "retrieved_tools": retrieved_tool_ids,
+        "expected_recipe_recalled": expected_recipe_rank is not None,
+        "expected_recipe_rank": expected_recipe_rank,
+        "expected_recipe_reciprocal_rank": _reciprocal_rank(expected_recipe_rank),
+        "missed_expected_recipe": (
+            query.expected_recipe if query.expected_recipe and expected_recipe_rank is None else None
+        ),
+        "recalled_expected_tools": recalled_tools,
+        "missed_expected_tools": missed_tools,
+        "tool_recall": _rate(len(recalled_tools), len(query.expected_tools)),
+        "first_expected_tool_reciprocal_rank": _first_reciprocal_rank(expected_tool_ranks.values()),
+        "covered_roles": role_coverage["covered_roles"],
+        "missed_roles": role_coverage["missed_roles"],
+        "role_coverage": role_coverage["coverage"],
+        "fallback_used": bool(retrieval.get("fallback_used")),
+        "fallback_reason": retrieval.get("fallback_reason"),
+        "strategy": retrieval.get("strategy"),
+        "notes": query.notes,
+    }
+
+
+def _role_coverage(
+    expected_roles: dict[str, list[str]],
+    retrieved_tool_ids: list[str],
+) -> dict[str, Any]:
+    retrieved = set(retrieved_tool_ids)
+    covered_roles: list[str] = []
+    missed_roles: list[str] = []
+    for role, tools in expected_roles.items():
+        if any(tool_id in retrieved for tool_id in tools):
+            covered_roles.append(role)
+        else:
+            missed_roles.append(role)
+    return {
+        "covered_roles": covered_roles,
+        "missed_roles": missed_roles,
+        "coverage": _rate(len(covered_roles), len(expected_roles)),
+    }
+
+
+def _first_strategy(per_query: list[dict[str, Any]]) -> str | None:
+    for result in per_query:
+        strategy = result.get("strategy")
+        if isinstance(strategy, str):
+            return strategy
+    return None
+
+
+def _rank_of(expected: str | None, retrieved_ids: list[str]) -> int | None:
+    if expected is None:
+        return None
+    try:
+        return retrieved_ids.index(expected) + 1
+    except ValueError:
+        return None
+
+
+def _reciprocal_rank(rank: int | None) -> float:
+    return 0.0 if rank is None else 1.0 / rank
+
+
+def _first_reciprocal_rank(ranks: Sequence[int | None]) -> float:
+    concrete_ranks = [rank for rank in ranks if rank is not None]
+    if not concrete_ranks:
+        return 0.0
+    return 1.0 / min(concrete_ranks)
+
+
+def _mean(values: Any) -> float:
+    concrete_values = list(values)
+    if not concrete_values:
+        return 0.0
+    return round(sum(concrete_values) / len(concrete_values), 4)
+
+
+def _rate(numerator: int, denominator: int) -> float:
+    if denominator == 0:
+        return 0.0
+    return round(numerator / denominator, 4)
+
+
+def _required_str(data: dict[str, Any], key: str) -> str:
+    value = data.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{key} must be a non-empty string")
+    return value
+
+
+def _string_list(value: Any, label: str) -> list[str]:
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        raise ValueError(f"{label} must be a list of strings")
+    return value
+
+
+def _expected_roles(value: Any, query_id: str) -> dict[str, list[str]]:
+    if not isinstance(value, dict):
+        raise ValueError(f"{query_id}: expected_roles must be an object")
+    roles: dict[str, list[str]] = {}
+    for role, tools in value.items():
+        if not isinstance(role, str):
+            raise ValueError(f"{query_id}: expected_roles keys must be strings")
+        roles[role] = _string_list(tools, f"{query_id}: expected_roles.{role}")
+    return roles

--- a/tests/fixtures/invalid_non_object_queries.json
+++ b/tests/fixtures/invalid_non_object_queries.json
@@ -1,0 +1,3 @@
+[
+  "not an object"
+]

--- a/tests/fixtures/retrieval_queries.json
+++ b/tests/fixtures/retrieval_queries.json
@@ -1,0 +1,204 @@
+[
+  {
+    "id": "rnaseq_deg_basic_en",
+    "query": "Run bulk RNA-seq differential expression from paired-end FASTQ files with QC, transcript quantification, gene-level counts, and a workflow summary report.",
+    "supported": true,
+    "expected_recipe": "rnaseq_differential_expression",
+    "expected_tools": ["fastp", "salmon", "tximport", "deseq2", "multiqc"],
+    "expected_roles": {
+      "read_quality_control": ["fastp"],
+      "expression_quantification": ["salmon"],
+      "transcript_to_gene_count_summary": ["tximport"],
+      "differential_expression": ["deseq2"],
+      "quality_control_summary": ["multiqc"]
+    },
+    "notes": "Basic supported RNA-seq DEG request without explicit tool names."
+  },
+  {
+    "id": "rnaseq_deg_explicit_tools_en",
+    "query": "Build a workflow using fastp, Salmon, tximport, DESeq2, and MultiQC for bulk RNA-seq differential expression.",
+    "supported": true,
+    "expected_recipe": "rnaseq_differential_expression",
+    "expected_tools": ["fastp", "salmon", "tximport", "deseq2", "multiqc"],
+    "expected_roles": {
+      "read_quality_control": ["fastp"],
+      "expression_quantification": ["salmon"],
+      "transcript_to_gene_count_summary": ["tximport"],
+      "differential_expression": ["deseq2"],
+      "quality_control_summary": ["multiqc"]
+    },
+    "notes": "Supported request with every approved RNA-seq tool named explicitly."
+  },
+  {
+    "id": "rnaseq_deg_cn_mixed_tools",
+    "query": "为 bulk RNAseq 样本做差异表达分析，使用 fastp 清理 FASTQ、Salmon 定量、tximport 汇总到 gene counts、DESeq2 输出 DEG 表，并生成 MultiQC 报告。",
+    "supported": true,
+    "expected_recipe": "rnaseq_differential_expression",
+    "expected_tools": ["fastp", "salmon", "tximport", "deseq2", "multiqc"],
+    "expected_roles": {
+      "read_quality_control": ["fastp"],
+      "expression_quantification": ["salmon"],
+      "transcript_to_gene_count_summary": ["tximport"],
+      "differential_expression": ["deseq2"],
+      "quality_control_summary": ["multiqc"]
+    },
+    "notes": "Chinese request with common English tool names and RNAseq abbreviation."
+  },
+  {
+    "id": "rnaseq_deg_abbrev_en",
+    "query": "Create a DEG workflow for bulk RNAseq paired-end reads, including adapter trimming, transcript quantification, transcript-to-gene summarization, and a QC report.",
+    "supported": true,
+    "expected_recipe": "rnaseq_differential_expression",
+    "expected_tools": ["fastp", "salmon", "tximport", "deseq2", "multiqc"],
+    "expected_roles": {
+      "read_quality_control": ["fastp"],
+      "expression_quantification": ["salmon"],
+      "transcript_to_gene_count_summary": ["tximport"],
+      "differential_expression": ["deseq2"],
+      "quality_control_summary": ["multiqc"]
+    },
+    "notes": "Uses DEG and RNAseq shorthand while describing all major roles."
+  },
+  {
+    "id": "rnaseq_deg_no_tool_names_en",
+    "query": "Identify differentially expressed genes from RNA sequencing FASTQs and create a workflow-level quality-control summary.",
+    "supported": true,
+    "expected_recipe": "rnaseq_differential_expression",
+    "expected_tools": ["fastp", "salmon", "tximport", "deseq2", "multiqc"],
+    "expected_roles": {
+      "read_quality_control": ["fastp"],
+      "expression_quantification": ["salmon"],
+      "transcript_to_gene_count_summary": ["tximport"],
+      "differential_expression": ["deseq2"],
+      "quality_control_summary": ["multiqc"]
+    },
+    "notes": "Supported natural-language request that does not name specific tools."
+  },
+  {
+    "id": "rnaseq_deg_salmon_deseq2_en",
+    "query": "Use Salmon quantification and DESeq2 for differential expression on paired-end bulk RNA-seq data, starting from raw FASTQs.",
+    "supported": true,
+    "expected_recipe": "rnaseq_differential_expression",
+    "expected_tools": ["fastp", "salmon", "tximport", "deseq2"],
+    "expected_roles": {
+      "read_quality_control": ["fastp"],
+      "expression_quantification": ["salmon"],
+      "transcript_to_gene_count_summary": ["tximport"],
+      "differential_expression": ["deseq2"]
+    },
+    "notes": "Explicitly names Salmon and DESeq2; tximport is expected for transcript-to-gene counts."
+  },
+  {
+    "id": "rnaseq_quant_gene_counts_en",
+    "query": "Quantify bulk RNA-seq reads and produce a transcript-to-gene count matrix from quant.sf files.",
+    "supported": true,
+    "expected_recipe": "rnaseq_differential_expression",
+    "expected_tools": ["salmon", "tximport"],
+    "expected_roles": {
+      "expression_quantification": ["salmon"],
+      "transcript_to_gene_count_summary": ["tximport"]
+    },
+    "notes": "Partial supported request focused on quantification and gene-level counts."
+  },
+  {
+    "id": "rnaseq_quality_report_en",
+    "query": "Prepare a quality report for paired FASTQ RNA-seq samples with adapter trimming and a workflow summary.",
+    "supported": true,
+    "expected_recipe": "rnaseq_differential_expression",
+    "expected_tools": ["fastp", "multiqc"],
+    "expected_roles": {
+      "read_quality_control": ["fastp"],
+      "quality_control_summary": ["multiqc"]
+    },
+    "notes": "Partial supported request focused on read QC and reporting."
+  },
+  {
+    "id": "rnaseq_params_threads_contrast_en",
+    "query": "Run RNA-seq DEG analysis with 8 threads for quantification and a DESeq2 contrast named condition.",
+    "supported": true,
+    "expected_recipe": "rnaseq_differential_expression",
+    "expected_tools": ["salmon", "tximport", "deseq2"],
+    "expected_roles": {
+      "expression_quantification": ["salmon"],
+      "transcript_to_gene_count_summary": ["tximport"],
+      "differential_expression": ["deseq2"]
+    },
+    "notes": "Supported request with parameter hints for threads and contrast."
+  },
+  {
+    "id": "rnaseq_inputs_metadata_en",
+    "query": "Differential expression from sample metadata, a tx2gene mapping table, and a Salmon transcriptome index for paired-end RNA-seq.",
+    "supported": true,
+    "expected_recipe": "rnaseq_differential_expression",
+    "expected_tools": ["fastp", "salmon", "tximport", "deseq2"],
+    "expected_roles": {
+      "read_quality_control": ["fastp"],
+      "expression_quantification": ["salmon"],
+      "transcript_to_gene_count_summary": ["tximport"],
+      "differential_expression": ["deseq2"]
+    },
+    "notes": "Supported request emphasizing recipe inputs instead of step names."
+  },
+  {
+    "id": "rnaseq_gene_counts_cn_mixed",
+    "query": "从 Salmon quant.sf 生成 gene-level counts，再做 DESeq2 差异分析和 QC 汇总。",
+    "supported": true,
+    "expected_recipe": "rnaseq_differential_expression",
+    "expected_tools": ["tximport", "deseq2", "multiqc"],
+    "expected_roles": {
+      "transcript_to_gene_count_summary": ["tximport"],
+      "differential_expression": ["deseq2"],
+      "quality_control_summary": ["multiqc"]
+    },
+    "notes": "Chinese partial request for post-quantification summary and DEG."
+  },
+  {
+    "id": "rnaseq_multiqc_logs_en",
+    "query": "Aggregate fastp JSON and HTML reports plus Salmon logs into MultiQC for an RNA-seq DEG workflow.",
+    "supported": true,
+    "expected_recipe": "rnaseq_differential_expression",
+    "expected_tools": ["fastp", "salmon", "multiqc"],
+    "expected_roles": {
+      "read_quality_control": ["fastp"],
+      "expression_quantification": ["salmon"],
+      "quality_control_summary": ["multiqc"]
+    },
+    "notes": "Supported request focused on tagged QC outputs and workflow summary."
+  },
+  {
+    "id": "unsupported_chipseq_peak_calling_en",
+    "query": "Run ChIP-seq peak calling with MACS2 and generate peak annotation tracks.",
+    "supported": false,
+    "expected_recipe": null,
+    "expected_tools": [],
+    "expected_roles": {},
+    "notes": "Negative case: ChIP-seq is outside the current approved catalog."
+  },
+  {
+    "id": "unsupported_scrnaseq_clustering_en",
+    "query": "Analyze single-cell RNA-seq UMI counts with normalization, clustering, marker genes, and UMAP plots.",
+    "supported": false,
+    "expected_recipe": null,
+    "expected_tools": [],
+    "expected_roles": {},
+    "notes": "Negative case: scRNA-seq is not represented by the current bulk RNA-seq recipe."
+  },
+  {
+    "id": "unsupported_variant_calling_en",
+    "query": "Call germline variants from WES BAM files and produce a filtered VCF.",
+    "supported": false,
+    "expected_recipe": null,
+    "expected_tools": [],
+    "expected_roles": {},
+    "notes": "Negative case: variant calling tools are not in the approved catalog."
+  },
+  {
+    "id": "unsupported_metagenomics_cn",
+    "query": "做宏基因组物种注释和丰度分析，输出 taxonomy profile 和可视化报告。",
+    "supported": false,
+    "expected_recipe": null,
+    "expected_tools": [],
+    "expected_roles": {},
+    "notes": "Negative case: metagenomics is outside the current approved catalog."
+  }
+]

--- a/tests/test_retrieval_evaluation.py
+++ b/tests/test_retrieval_evaluation.py
@@ -11,7 +11,7 @@ from src.catalog.retrieval_eval import (
 from src.recipes import load_recipe_catalog
 
 
-FIXTURE_PATH = Path("tests/fixtures/retrieval_queries.json")
+FIXTURE_PATH = Path(__file__).resolve().parent / "fixtures" / "retrieval_queries.json"
 
 
 def fake_retriever(
@@ -147,6 +147,10 @@ class RetrievalEvaluationTests(unittest.TestCase):
                     "expected_roles": {},
                 }
             )
+
+    def test_rejects_non_object_fixture_entries(self):
+        with self.assertRaisesRegex(ValueError, "entry at index 0 must be an object"):
+            load_retrieval_queries(FIXTURE_PATH.with_name("invalid_non_object_queries.json"))
 
 
 if __name__ == "__main__":

--- a/tests/test_retrieval_evaluation.py
+++ b/tests/test_retrieval_evaluation.py
@@ -1,0 +1,153 @@
+import unittest
+from pathlib import Path
+from typing import Any
+
+from src.catalog import load_tool_catalog
+from src.catalog.retrieval_eval import (
+    RetrievalQuery,
+    evaluate_retrieval_queries,
+    load_retrieval_queries,
+)
+from src.recipes import load_recipe_catalog
+
+
+FIXTURE_PATH = Path("tests/fixtures/retrieval_queries.json")
+
+
+def fake_retriever(
+    query: str,
+    _tool_catalog,
+    _recipe_catalog,
+    _top_k_recipes: int,
+    _top_k_tools: int,
+) -> dict[str, Any]:
+    fixtures = {
+        "supported hit": {
+            "recipes": [{"id": "rnaseq_differential_expression"}],
+            "tools": [{"id": "fastp"}, {"id": "salmon"}],
+            "fallback_used": False,
+            "fallback_reason": None,
+        },
+        "supported miss": {
+            "recipes": [{"id": "other_recipe"}],
+            "tools": [{"id": "multiqc"}],
+            "fallback_used": True,
+            "fallback_reason": "synthetic fallback",
+        },
+        "unsupported direct match": {
+            "recipes": [{"id": "rnaseq_differential_expression"}],
+            "tools": [{"id": "fastp"}],
+            "fallback_used": False,
+            "fallback_reason": None,
+        },
+    }
+    retrieval = fixtures[query]
+    return {
+        "query": query,
+        "strategy": "fake_v1",
+        **retrieval,
+    }
+
+
+class RetrievalEvaluationTests(unittest.TestCase):
+    def setUp(self):
+        self.tool_catalog = load_tool_catalog()
+        self.recipe_catalog = load_recipe_catalog(tool_catalog=self.tool_catalog)
+
+    def test_loads_current_catalog_query_fixture(self):
+        queries = load_retrieval_queries(FIXTURE_PATH)
+
+        self.assertEqual(len(queries), 16)
+        self.assertEqual(sum(1 for query in queries if query.supported), 12)
+        self.assertEqual(sum(1 for query in queries if not query.supported), 4)
+        self.assertEqual(queries[0].id, "rnaseq_deg_basic_en")
+        self.assertIn("fastp", queries[0].expected_tools)
+
+    def test_evaluates_current_catalog_baseline(self):
+        queries = load_retrieval_queries(FIXTURE_PATH)
+
+        result = evaluate_retrieval_queries(
+            queries,
+            self.tool_catalog,
+            self.recipe_catalog,
+        )
+
+        self.assertEqual(result["strategy"], "lexical_v1")
+        self.assertEqual(result["top_k_recipes"], 3)
+        self.assertEqual(result["top_k_tools"], 8)
+        self.assertEqual(result["query_count"], 16)
+        self.assertEqual(result["supported_query_count"], 12)
+        self.assertEqual(result["unsupported_query_count"], 4)
+        self.assertEqual(len(result["queries"]), 16)
+        for metric in result["metrics"].values():
+            self.assertGreaterEqual(metric, 0.0)
+            self.assertLessEqual(metric, 1.0)
+
+    def test_computes_supported_metrics_and_tracks_unsupported_matches(self):
+        queries = [
+            RetrievalQuery(
+                id="q1",
+                query="supported hit",
+                supported=True,
+                expected_recipe="rnaseq_differential_expression",
+                expected_tools=["fastp", "deseq2"],
+                expected_roles={
+                    "read_quality_control": ["fastp"],
+                    "differential_expression": ["deseq2"],
+                },
+            ),
+            RetrievalQuery(
+                id="q2",
+                query="supported miss",
+                supported=True,
+                expected_recipe="rnaseq_differential_expression",
+                expected_tools=["deseq2"],
+                expected_roles={"differential_expression": ["deseq2"]},
+            ),
+            RetrievalQuery(
+                id="q3",
+                query="unsupported direct match",
+                supported=False,
+                expected_recipe=None,
+                expected_tools=[],
+                expected_roles={},
+            ),
+        ]
+
+        result = evaluate_retrieval_queries(
+            queries,
+            self.tool_catalog,
+            self.recipe_catalog,
+            retriever=fake_retriever,
+        )
+
+        self.assertEqual(result["strategy"], "fake_v1")
+        self.assertEqual(result["metrics"]["recipe_recall_at_k"], 0.5)
+        self.assertEqual(result["metrics"]["recipe_mrr"], 0.5)
+        self.assertEqual(result["metrics"]["tool_recall_at_k"], 0.25)
+        self.assertEqual(result["metrics"]["tool_mrr"], 0.5)
+        self.assertEqual(result["metrics"]["role_coverage"], 0.25)
+        self.assertEqual(result["metrics"]["fallback_rate"], 0.3333)
+        self.assertEqual(result["metrics"]["supported_fallback_rate"], 0.5)
+        self.assertEqual(result["metrics"]["unsupported_fallback_rate"], 0.0)
+        self.assertEqual(result["fallback_query_ids"], ["q2"])
+        self.assertEqual(result["unsupported_direct_match_query_ids"], ["q3"])
+        self.assertEqual(result["queries"][1]["missed_expected_tools"], ["deseq2"])
+        self.assertEqual(result["queries"][1]["missed_roles"], ["differential_expression"])
+
+    def test_rejects_unsupported_queries_with_expected_hits(self):
+        with self.assertRaisesRegex(ValueError, "unsupported queries must not define expected hits"):
+            RetrievalQuery.from_dict(
+                {
+                    "id": "bad",
+                    "query": "unsupported",
+                    "supported": False,
+                    "expected_recipe": "rnaseq_differential_expression",
+                    "expected_tools": [],
+                    "expected_roles": {},
+                }
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add a current-catalog retrieval query fixture for RNA-seq retrieval evaluation.
- Add evaluation helpers and a script for lexical_v1 baseline metrics.
- Document baseline scope, current results, and test coverage for R2 retrieval evaluation.

## Notes

This baseline intentionally uses the current approved Catalog. It separates supported RNA-seq queries from unsupported negative cases, so the metrics establish a reproducible current-catalog baseline rather than claiming multi-workflow retrieval coverage.

## Validation

- `./.venv/Scripts/python.exe -m unittest tests.test_catalog_retriever tests.test_retrieval_evaluation -v`
- `./.venv/Scripts/python.exe scripts/evaluate_retrieval.py`

Full unittest discovery was attempted earlier in this branch and the R2-related tests passed; three pre-existing graph tests require a local WDL validator / Java / WOMtool configuration in this environment.