### PR TITLE
Polish W6 demo readiness states

### DIFF
--- a/web/app/catalog/page.tsx
+++ b/web/app/catalog/page.tsx
@@ -1,10 +1,10 @@
-import { ArrowLeft, CheckCircle2, Container, Database, ShieldCheck } from "lucide-react";
+import { ArrowLeft, CheckCircle2, Container, Database, RotateCcw, ShieldCheck } from "lucide-react";
 import Link from "next/link";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { apiDocsUrl } from "@/lib/api";
-import { rnaseqRecipeSteps } from "@/lib/examples";
+import { rnaseqDemoWorkspaceHref, rnaseqRecipeSteps } from "@/lib/examples";
 
 const tools = [
   ["fastp", "读段质量控制", "quay.io/biocontainers/fastp"],
@@ -24,17 +24,24 @@ export default function CatalogPage() {
         </Link>
       </Button>
 
-      <div className="mb-8 max-w-3xl">
-        <div className="flex flex-wrap gap-3">
-          <Badge variant="secondary">W3 静态预览</Badge>
-          <Badge variant="outline">示例数据</Badge>
+      <div className="mb-8 flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+        <div className="max-w-3xl">
+          <div className="flex flex-wrap gap-3">
+            <Badge variant="secondary">W6 Catalog boundary</Badge>
+            <Badge variant="outline">RNA-seq 示例</Badge>
+          </div>
+          <h1 className="mt-4 text-3xl font-semibold tracking-normal">Recipe 与 Tool Catalog 预览</h1>
+          <p className="mt-3 leading-7 text-muted-foreground">
+            Catalog 是生信步骤、准入工具、命令模板、输出 schema 和 runtime container 的正式边界。
+            当前页面用 RNA-seq DEG 示例解释目录契约；工作台和历史页会展示这些边界如何约束 Plan、IR 和 WDL。
+          </p>
         </div>
-        <h1 className="mt-4 text-3xl font-semibold tracking-normal">Recipe 与 Tool Catalog 预览</h1>
-        <p className="mt-3 leading-7 text-muted-foreground">
-          Catalog 是生信步骤、准入工具、命令模板、输出 schema 和 runtime container 的正式边界。
-          当前页面使用 RNA-seq 示例说明目录页的信息结构；真实 recipe / tool 数据会在后续从
-          FastAPI catalog endpoints 读取。
-        </p>
+        <Button asChild variant="outline">
+          <Link href={rnaseqDemoWorkspaceHref}>
+            <RotateCcw className="h-4 w-4" />
+            运行 RNA-seq 示例
+          </Link>
+        </Button>
       </div>
 
       <div className="grid gap-6 lg:grid-cols-[0.9fr_1.1fr]">
@@ -90,7 +97,7 @@ export default function CatalogPage() {
           <div>
             <h2 className="font-semibold">Catalog 页面边界</h2>
             <p className="mt-1 text-sm text-muted-foreground">
-              W3 先固定页面信息架构，避免把工具选择逻辑放进前端。
+              页面只解释 Catalog 契约；工具选择、命令模板和容器来源仍由后端 Catalog 约束。
             </p>
           </div>
           <Button asChild variant="outline">
@@ -120,9 +127,9 @@ export default function CatalogPage() {
             </p>
           </div>
           <div className="rounded-md border bg-background p-4">
-            <div className="font-semibold text-primary">后续接入</div>
+            <div className="font-semibold text-primary">API contract</div>
             <p className="mt-2 text-sm leading-6 text-muted-foreground">
-              从 `/api/recipes` 和 `/api/tools` 读取真实 catalog，并支持工具详情页。
+              `/api/recipes` 和 `/api/tools` 保留为 Catalog 查询入口；前端不推断或替换工具定义。
             </p>
           </div>
         </div>

--- a/web/app/runs/[runId]/page.tsx
+++ b/web/app/runs/[runId]/page.tsx
@@ -18,7 +18,7 @@ import { CatalogRetrievalSummary } from "@/components/run/catalog-retrieval-summ
 import { RunEventsTimeline } from "@/components/run/run-events-timeline";
 import { RunFailureSummary } from "@/components/run/run-failure-summary";
 import { WorkflowGraphPanel } from "@/components/workflow-graph/workflow-graph";
-import { getRunSnapshot } from "@/lib/api";
+import { apiDocsUrl, formatApiError, getRunSnapshot } from "@/lib/api";
 import { hasCatalogRetrieval } from "@/lib/catalog-retrieval";
 import { rnaseqDemoWorkspaceHref } from "@/lib/examples";
 import type { JsonObject, RunStatus, WorkflowRunSnapshotResponse } from "@/lib/types";
@@ -95,7 +95,7 @@ function getRequestLabel(request: string | JsonObject | null): string {
 
 function formatError(error: unknown): string {
   console.error("Failed to load run detail.", error);
-  return "Run 详情暂时无法读取，请确认 FastAPI 服务正在运行，或从历史列表重新进入。";
+  return formatApiError(error, "Run 详情暂时无法读取，请确认 FastAPI 服务正在运行，或从历史列表重新进入。");
 }
 
 function StatItem({ label, value }: { label: string; value: string }) {
@@ -140,7 +140,7 @@ function RunDetail({ snapshot }: { snapshot: WorkflowRunSnapshotResponse }) {
               {statusLabels[snapshot.status]}
             </Badge>
             <Badge variant="outline">{kindLabel}</Badge>
-            <Badge variant="secondary">W5 详情回放</Badge>
+            <Badge variant="secondary">可回放详情</Badge>
           </div>
           <h1 className="mt-4 break-words text-3xl font-semibold tracking-normal">
             Run 详情回放
@@ -262,6 +262,17 @@ export default async function RunDetailPage({
             <p className="mt-3 break-words text-sm leading-6 text-muted-foreground">
               {errorMessage}
             </p>
+            <div className="mt-4 flex flex-wrap gap-2">
+              <Button asChild size="sm">
+                <Link href={rnaseqDemoWorkspaceHref}>
+                  <RotateCcw className="h-4 w-4" />
+                  运行示例
+                </Link>
+              </Button>
+              <Button asChild variant="outline" size="sm">
+                <Link href={apiDocsUrl}>查看 API 文档</Link>
+              </Button>
+            </div>
           </div>
         </div>
       )}

--- a/web/app/runs/page.tsx
+++ b/web/app/runs/page.tsx
@@ -14,7 +14,7 @@ import Link from "next/link";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { listRuns } from "@/lib/api";
+import { apiDocsUrl, formatApiError, listRuns } from "@/lib/api";
 import { rnaseqDemoWorkspaceHref } from "@/lib/examples";
 import type { RunListResponse, RunStatus, RunSummary } from "@/lib/types";
 
@@ -94,7 +94,7 @@ function formatDateTime(value: string | null): string {
 
 function formatError(error: unknown): string {
   console.error("Failed to load run history.", error);
-  return "Run 历史记录暂时无法读取，请确认 FastAPI 服务正在运行后重试。";
+  return formatApiError(error, "Run 历史记录暂时无法读取，请确认 FastAPI 服务正在运行后重试。");
 }
 
 function buildRunsHref(status: RunStatus | "all", page = 1): string {
@@ -265,7 +265,7 @@ export default async function RunsPage({
       <div className="mb-8 flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
         <div className="max-w-3xl">
           <div className="flex flex-wrap gap-3">
-            <Badge variant="secondary">W5 历史列表</Badge>
+            <Badge variant="secondary">W6 demo readiness</Badge>
             <Badge variant="outline">真实 run 数据</Badge>
           </div>
           <h1 className="mt-4 text-3xl font-semibold tracking-normal">Run 回放与审计</h1>
@@ -314,6 +314,17 @@ export default async function RunsPage({
                 历史记录读取失败
               </div>
               <p className="mt-2 break-words text-sm leading-6 text-muted-foreground">{errorMessage}</p>
+              <div className="mt-4 flex flex-wrap gap-2">
+                <Button asChild size="sm">
+                  <Link href={rnaseqDemoWorkspaceHref}>
+                    <RotateCcw className="h-4 w-4" />
+                    运行示例
+                  </Link>
+                </Button>
+                <Button asChild variant="outline" size="sm">
+                  <Link href={apiDocsUrl}>查看 API 文档</Link>
+                </Button>
+              </div>
             </div>
           ) : runList ? (
             <RunsList firstPageHref={buildRunsHref(selectedFilter)} response={runList} />

--- a/web/app/workspace/page.tsx
+++ b/web/app/workspace/page.tsx
@@ -27,7 +27,7 @@ export default async function WorkspacePage({
           </Button>
           <div className="flex flex-wrap items-center gap-3">
             <h1 className="text-3xl font-semibold tracking-normal">Workflow 工作台</h1>
-            <Badge variant="secondary">W5 Workbench</Badge>
+            <Badge variant="secondary">W6 demo path</Badge>
             <Badge variant="outline">真实 run 接入</Badge>
           </div>
           <p className="mt-3 max-w-2xl text-muted-foreground">

--- a/web/app/workspace/workspace-workbench.tsx
+++ b/web/app/workspace/workspace-workbench.tsx
@@ -23,7 +23,9 @@ import { Button } from "@/components/ui/button";
 import {
   createNaturalLanguageRun,
   createStructuredCompileRun,
+  formatApiError,
   getRunSnapshot,
+  apiDocsUrl,
 } from "@/lib/api";
 import { hasCatalogRetrieval } from "@/lib/catalog-retrieval";
 import { rnaseqExamplePrompt, rnaseqRecipePlan, rnaseqRecipeSteps } from "@/lib/examples";
@@ -114,10 +116,7 @@ function getStatusIcon(status: RunStatus, isPolling: boolean) {
 }
 
 function formatRunError(error: unknown): string {
-  if (error instanceof Error) {
-    return error.message;
-  }
-  return "请求处理失败，请稍后重试。";
+  return formatApiError(error, "请求处理失败，请稍后重试。");
 }
 
 function validationLabel(diagnostics: DiagnosticReport): string {
@@ -369,9 +368,16 @@ export function WorkspaceWorkbench({
           </div>
 
           {submitErrorMessage ? (
-            <div className="mt-4 flex items-start gap-2 rounded-md border border-destructive/40 bg-background p-4 text-sm text-destructive">
-              <AlertCircle className="mt-0.5 h-4 w-4 flex-none" />
-              <span className="break-words">{submitErrorMessage}</span>
+            <div className="mt-4 rounded-md border border-destructive/40 bg-background p-4">
+              <div className="flex items-start gap-2 text-sm text-destructive">
+                <AlertCircle className="mt-0.5 h-4 w-4 flex-none" />
+                <span className="break-words">{submitErrorMessage}</span>
+              </div>
+              <div className="mt-3 flex flex-wrap gap-2">
+                <Button asChild variant="outline" size="sm">
+                  <Link href={apiDocsUrl}>查看 API 文档</Link>
+                </Button>
+              </div>
             </div>
           ) : null}
         </section>
@@ -405,9 +411,16 @@ export function WorkspaceWorkbench({
           </div>
 
           {pollErrorMessage ? (
-            <div className="mt-4 flex items-start gap-2 rounded-md border border-destructive/40 bg-background p-4 text-sm text-destructive">
-              <AlertCircle className="mt-0.5 h-4 w-4 flex-none" />
-              <span className="break-words">Run 状态查询失败：{pollErrorMessage}</span>
+            <div className="mt-4 rounded-md border border-destructive/40 bg-background p-4">
+              <div className="flex items-start gap-2 text-sm text-destructive">
+                <AlertCircle className="mt-0.5 h-4 w-4 flex-none" />
+                <span className="break-words">Run 状态查询失败：{pollErrorMessage}</span>
+              </div>
+              <div className="mt-3 flex flex-wrap gap-2">
+                <Button asChild variant="outline" size="sm">
+                  <Link href="/runs">查看历史</Link>
+                </Button>
+              </div>
             </div>
           ) : null}
 

--- a/web/lib/api.ts
+++ b/web/lib/api.ts
@@ -17,6 +17,26 @@ export const apiBaseUrl =
 
 export const apiDocsUrl = `${apiBaseUrl}/docs`;
 
+export function formatApiError(error: unknown, fallback: string): string {
+  if (!(error instanceof Error)) {
+    return fallback;
+  }
+
+  const message = error.message;
+  const lowerMessage = message.toLowerCase();
+  const isConnectionFailure =
+    lowerMessage.includes("fetch failed") ||
+    lowerMessage.includes("failed to fetch") ||
+    lowerMessage.includes("econnrefused") ||
+    lowerMessage.includes("networkerror");
+
+  if (isConnectionFailure) {
+    return `FastAPI 服务暂时不可达（${apiBaseUrl}）。请确认 API 在线后重试。`;
+  }
+
+  return message || fallback;
+}
+
 type JsonRequestInit = RequestInit & {
   next?: {
     revalidate?: number;


### PR DESCRIPTION
## Summary
- Refresh demo readiness copy across the workspace, run history, run detail, and catalog pages.
- Add clearer recovery paths for API-unavailable and run-read failures.
- Update the catalog preview to present the W6 catalog boundary instead of earlier-stage static preview language.

## Verification
- `npm.cmd run lint`
- `npm.cmd run test:graph`
- `npm.cmd run build`