### PR TITLE
Add Reviewer patch application layer

### DIFF
--- a/docs/test-cases.md
+++ b/docs/test-cases.md
@@ -2272,6 +2272,145 @@ result 和 policy 边界。
 - Reviewer result 的 `status` 与 payload 保持一一对应，避免下游按状态分支时遇到
   歧义载荷。
 
+## `tests/test_reviewer_patcher.py`
+
+该文件验证 P2.2 Reviewer patch application layer。该层不调用 LLM provider，
+也不接入 Compiler Graph 路由；它只负责把已解析、policy-checked 的
+`ReviewerIRPatch` 安全应用到 Workflow IR copy，并在返回前重新通过
+`WorkflowIR` schema validation。
+
+### `test_apply_reviewer_patch_updates_allowed_workflow_ir_paths`
+
+输入：
+
+- 一个缺少 `r2` call input 的 Workflow IR。
+- patch actions：
+  - 给 `/workflow/steps/0/inputs/r2` 增加 `raw_r2`。
+  - 替换 `/workflow/outputs/clean_r1`。
+  - 替换 `/tasks/fastp/outputs/clean_r1/value`。
+- 当前 workflow approved catalog context。
+
+执行：
+
+- 调用 `apply_reviewer_patch(...)`。
+
+期望输出：
+
+- 返回 `WorkflowIR` model。
+- `workflow.steps` 中的 call input 被修复。
+- compatibility `workflow.calls` 被同步更新。
+- workflow output 和 task output literal 被更新。
+- 原始 IR dict 不包含新增的 `r2`。
+
+覆盖点：
+
+- P2.2 应用层可以应用当前 allowlist 内的 wiring、workflow output 和 task output
+  literal patch。
+- patch 应用在 copy 上执行，不原地修改原始 Workflow IR。
+
+### `test_apply_reviewer_patch_removes_workflow_output_without_mutating_original`
+
+输入：
+
+- 一个包含 `legacy_report` workflow output 的 Workflow IR。
+- `remove` action 指向 `/workflow/outputs/legacy_report`。
+
+执行：
+
+- 调用 `apply_reviewer_patch(...)`。
+
+期望输出：
+
+- 返回 IR 中不再包含 `legacy_report`。
+- 原始 IR 仍保留 `legacy_report`。
+
+覆盖点：
+
+- `remove` 支持 allowlist 内的 object entry 删除。
+- 删除失败不会通过共享引用污染原始 IR。
+
+### `test_apply_reviewer_patch_moves_workflow_steps_and_syncs_calls`
+
+输入：
+
+- 一个 step 顺序为 `align -> qc` 的 Workflow IR。
+- `move` action：`from_path = /workflow/steps/1`，`path = /workflow/steps/0`。
+
+执行：
+
+- 调用 `apply_reviewer_patch(...)`。
+
+期望输出：
+
+- 返回 IR 中 `workflow.steps` 顺序为 `qc -> align`。
+- compatibility `workflow.calls` 同步为 `qc -> align`。
+- 原始 IR 的第一步仍是 `align`。
+
+覆盖点：
+
+- Reviewer patch application 支持 workflow step ordering 修复。
+- canonical `workflow.steps` 修改后会刷新 compatibility `workflow.calls`。
+
+### `test_apply_reviewer_patch_rejects_forbidden_path_without_mutating_original`
+
+输入：
+
+- patch 尝试替换 `/tasks/fastp/runtime/docker`。
+
+执行：
+
+- 调用 `apply_reviewer_patch(...)`。
+
+期望输出：
+
+- 抛出 `ReviewerPatchPolicyError`。
+- 原始 runtime docker 不变。
+
+覆盖点：
+
+- application layer 会先执行 Reviewer patch policy validation。
+- forbidden path 不会进入实际修改阶段。
+
+### `test_apply_reviewer_patch_rejects_missing_replace_target_without_mutating_original`
+
+输入：
+
+- patch 尝试 `replace` 不存在的 `/workflow/steps/0/inputs/r2`。
+
+执行：
+
+- 调用 `apply_reviewer_patch(...)`。
+
+期望输出：
+
+- 抛出 `ReviewerPatchApplicationError`。
+- 原始 call input 不包含 `r2`。
+
+覆盖点：
+
+- `add` 与 `replace` 的 application 语义保持区分。
+- 应用失败时原始 IR 保持不变。
+
+### `test_apply_reviewer_patch_rejects_schema_invalid_candidate_without_mutating_original`
+
+输入：
+
+- patch 尝试把 `/workflow/outputs/clean_r1` 替换为数组值。
+
+执行：
+
+- 调用 `apply_reviewer_patch(...)`。
+
+期望输出：
+
+- 抛出 `ReviewerPatchApplicationError`，错误说明 candidate 不是合法 Workflow IR。
+- 原始 workflow output 仍是字符串表达式。
+
+覆盖点：
+
+- patch 应用完成后仍必须重新通过 `WorkflowIR` schema validation。
+- schema-invalid candidate 不会被交给 graph re-entry。
+
 ## `tests/test_graph.py`
 
 该文件验证 Compiler Graph、Analyzer、Renderer 和 deterministic repairer 的交互。

--- a/docs/test-cases.md
+++ b/docs/test-cases.md
@@ -2141,7 +2141,6 @@ result 和 policy 边界。
   - `/tasks/foo-bar/outputs/x/value`
   - `/tasks/foo/outputs/x-y/value`
   - `/workflow/steps/0/inputs/read-1`
-  - `/workflow/calls/0/inputs/read-1`
 
 执行：
 
@@ -2178,7 +2177,7 @@ result 和 policy 边界。
 - `workflow.outputs` 是 `dict[str, str]`，Reviewer 只能直接修改单个 output entry。
 - policy 不接受空 output key 或 output entry 下的深层 JSON pointer。
 
-### `test_policy_allows_move_only_for_workflow_step_or_call_items`
+### `test_policy_allows_move_only_for_workflow_step_items`
 
 输入：
 
@@ -2196,10 +2195,10 @@ result 和 policy 边界。
 
 覆盖点：
 
-- P2 policy 允许 Reviewer 通过 list-item pointer 调整 step/call ordering。
+- P2 policy 允许 Reviewer 通过 list-item pointer 调整 canonical step ordering。
 - 该权限不扩展到整体替换 `workflow.steps` 或修改 step 内部 task 选择。
 
-### `test_policy_rejects_move_outside_workflow_step_or_call_items`
+### `test_policy_rejects_move_outside_workflow_step_items`
 
 输入：
 
@@ -2218,16 +2217,15 @@ result 和 policy 边界。
 
 覆盖点：
 
-- `move` 只服务于 `/workflow/steps/<index>` 或 `/workflow/calls/<index>` 的排序修复。
+- `move` 只服务于 `/workflow/steps/<index>` 的排序修复。
 - Reviewer 不能用 `move` 修改 workflow output、call input wiring 或 task output literal。
 
-### `test_policy_rejects_move_between_workflow_steps_and_calls`
+### `test_policy_rejects_all_workflow_calls_patch_operations`
 
 输入：
 
-- 分别尝试 `move`：
-  - `from_path = /workflow/steps/1`，`path = /workflow/calls/0`
-  - `from_path = /workflow/calls/1`，`path = /workflow/steps/0`
+- 分别尝试针对 `/workflow/calls/...` 的 `add`、`replace`、`remove` 和 `move`
+  patch。
 
 执行：
 
@@ -2235,12 +2233,12 @@ result 和 policy 边界。
 
 期望输出：
 
-- 每个 patch 都抛出 `ReviewerPatchPolicyError`。
+- 四种 operation 都抛出 `ReviewerPatchPolicyError`。
 
 覆盖点：
 
-- `move` 只能在同一个 workflow collection 内调整排序。
-- Reviewer 不能在 canonical `workflow.steps` 和 compatibility `workflow.calls` 之间移动结构。
+- `workflow.steps` 是 Reviewer 唯一可修改的 canonical DAG。
+- `workflow.calls` 是只读 compatibility view，不能被 Reviewer patch 修改或排序。
 
 ### `test_repair_result_enforces_status_payload_invariants`
 
@@ -2370,6 +2368,26 @@ result 和 policy 边界。
 
 - application layer 会先执行 Reviewer patch policy validation。
 - forbidden path 不会进入实际修改阶段。
+
+### `test_apply_reviewer_patch_rejects_compatibility_calls_path_without_mutating_original`
+
+输入：
+
+- patch 尝试替换 `/workflow/calls/0/inputs/r1`。
+
+执行：
+
+- 调用 `apply_reviewer_patch(...)`。
+
+期望输出：
+
+- 抛出 `ReviewerPatchPolicyError`。
+- 原始 `workflow.steps` 和 `workflow.calls` wiring 都保持不变。
+
+覆盖点：
+
+- application layer 不接受 compatibility `workflow.calls` patch。
+- Reviewer 只能修改 canonical `workflow.steps`，再由应用层单向同步 `workflow.calls`。
 
 ### `test_apply_reviewer_patch_rejects_missing_replace_target_without_mutating_original`
 

--- a/src/reviewer_patcher.py
+++ b/src/reviewer_patcher.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+import copy
+from typing import Any
+
+from pydantic import ValidationError
+
+from src.reviewer_repair import (
+    ApprovedCatalogContext,
+    ReviewerIRPatch,
+    ReviewerPatchAction,
+    ReviewerPatchOperation,
+    ReviewerPatchPolicyError,
+    validate_reviewer_patch_policy,
+)
+from src.schema import WorkflowIR, coerce_workflow_ir
+
+
+class ReviewerPatchApplicationError(ReviewerPatchPolicyError):
+    """Raised when a policy-allowed Reviewer patch cannot be applied safely."""
+
+
+def apply_reviewer_patch(
+    workflow_ir: WorkflowIR | dict[str, Any],
+    patch: ReviewerIRPatch,
+    catalog_context: ApprovedCatalogContext | None = None,
+) -> WorkflowIR:
+    """Apply a policy-checked Reviewer patch to a Workflow IR copy.
+
+    The original Workflow IR object is never mutated. The returned candidate has
+    already been revalidated against the WorkflowIR schema.
+    """
+
+    source_ir = coerce_workflow_ir(workflow_ir)
+    validate_reviewer_patch_policy(patch, catalog_context=catalog_context)
+
+    candidate = source_ir.model_dump(mode="python")
+    for action in patch.actions:
+        _apply_action(candidate, action)
+
+    try:
+        return WorkflowIR.model_validate(candidate)
+    except ValidationError as exc:
+        raise ReviewerPatchApplicationError(
+            f"applied Reviewer patch produced invalid Workflow IR: {exc}"
+        ) from exc
+
+
+def _apply_action(candidate: dict[str, Any], action: ReviewerPatchAction) -> None:
+    if action.operation == ReviewerPatchOperation.MOVE:
+        _apply_move(candidate, action)
+    elif action.operation == ReviewerPatchOperation.ADD:
+        _apply_add(candidate, action.path, action.value)
+    elif action.operation == ReviewerPatchOperation.REPLACE:
+        _apply_replace(candidate, action.path, action.value)
+    elif action.operation == ReviewerPatchOperation.REMOVE:
+        _apply_remove(candidate, action.path)
+    else:
+        raise ReviewerPatchApplicationError(f"unsupported Reviewer patch operation: {action.operation}")
+
+
+def _apply_add(candidate: dict[str, Any], path: str, value: Any) -> None:
+    parent, key = _resolve_parent(candidate, path)
+    if not isinstance(parent, dict):
+        raise ReviewerPatchApplicationError(f"add target parent for '{path}' is not an object")
+    if key in parent:
+        raise ReviewerPatchApplicationError(f"add target '{path}' already exists")
+    parent[key] = value
+    _sync_calls_after_steps_patch(candidate, path)
+
+
+def _apply_replace(candidate: dict[str, Any], path: str, value: Any) -> None:
+    parent, key = _resolve_parent(candidate, path)
+    if isinstance(parent, dict):
+        if key not in parent:
+            raise ReviewerPatchApplicationError(f"replace target '{path}' does not exist")
+        parent[key] = value
+        _sync_calls_after_steps_patch(candidate, path)
+        return
+
+    if isinstance(parent, list):
+        index = _parse_existing_index(key, parent, path)
+        parent[index] = value
+        _sync_calls_after_steps_patch(candidate, path)
+        return
+
+    raise ReviewerPatchApplicationError(f"replace target parent for '{path}' is not editable")
+
+
+def _apply_remove(candidate: dict[str, Any], path: str) -> None:
+    parent, key = _resolve_parent(candidate, path)
+    if isinstance(parent, dict):
+        if key not in parent:
+            raise ReviewerPatchApplicationError(f"remove target '{path}' does not exist")
+        del parent[key]
+        _sync_calls_after_steps_patch(candidate, path)
+        return
+
+    if isinstance(parent, list):
+        index = _parse_existing_index(key, parent, path)
+        parent.pop(index)
+        _sync_calls_after_steps_patch(candidate, path)
+        return
+
+    raise ReviewerPatchApplicationError(f"remove target parent for '{path}' is not editable")
+
+
+def _apply_move(candidate: dict[str, Any], action: ReviewerPatchAction) -> None:
+    if action.from_path is None:
+        raise ReviewerPatchApplicationError("move patch actions require from_path")
+
+    source_parent, source_key = _resolve_parent(candidate, action.from_path)
+    target_parent, target_key = _resolve_parent(candidate, action.path)
+    if source_parent is not target_parent or not isinstance(source_parent, list):
+        raise ReviewerPatchApplicationError(
+            f"move paths must resolve to the same workflow list: {action.from_path} -> {action.path}"
+        )
+
+    source_index = _parse_existing_index(source_key, source_parent, action.from_path)
+    item = source_parent.pop(source_index)
+    target_index = _parse_insert_index(target_key, source_parent, action.path)
+    source_parent.insert(target_index, item)
+    _sync_calls_after_steps_patch(candidate, action.path)
+
+
+def _resolve_parent(candidate: dict[str, Any], path: str) -> tuple[Any, str]:
+    segments = _json_pointer_segments(path)
+    if not segments:
+        raise ReviewerPatchApplicationError("patch path must not target the Workflow IR root")
+
+    current: Any = candidate
+    for segment in segments[:-1]:
+        if isinstance(current, dict):
+            if segment not in current:
+                raise ReviewerPatchApplicationError(f"patch path '{path}' does not exist")
+            current = current[segment]
+            continue
+
+        if isinstance(current, list):
+            index = _parse_existing_index(segment, current, path)
+            current = current[index]
+            continue
+
+        raise ReviewerPatchApplicationError(f"patch path '{path}' crosses a scalar value")
+
+    return current, segments[-1]
+
+
+def _parse_existing_index(segment: str, values: list[Any], path: str) -> int:
+    index = _parse_index(segment, path)
+    if index >= len(values):
+        raise ReviewerPatchApplicationError(f"list index in patch path '{path}' is out of range")
+    return index
+
+
+def _parse_insert_index(segment: str, values: list[Any], path: str) -> int:
+    index = _parse_index(segment, path)
+    if index > len(values):
+        raise ReviewerPatchApplicationError(f"list insert index in patch path '{path}' is out of range")
+    return index
+
+
+def _parse_index(segment: str, path: str) -> int:
+    try:
+        index = int(segment)
+    except ValueError as exc:
+        raise ReviewerPatchApplicationError(f"patch path '{path}' contains a non-integer list index") from exc
+    if index < 0:
+        raise ReviewerPatchApplicationError(f"patch path '{path}' contains a negative list index")
+    return index
+
+
+def _sync_calls_after_steps_patch(candidate: dict[str, Any], path: str) -> None:
+    if not path.startswith("/workflow/steps/"):
+        return
+
+    workflow = candidate.get("workflow")
+    if not isinstance(workflow, dict):
+        return
+
+    steps = workflow.get("steps")
+    if isinstance(steps, list):
+        workflow["calls"] = _flatten_call_steps(steps)
+
+
+def _flatten_call_steps(steps: list[Any]) -> list[dict[str, Any]]:
+    calls: list[dict[str, Any]] = []
+    for step in steps:
+        if not isinstance(step, dict):
+            continue
+        if step.get("kind", "call") == "call":
+            calls.append(copy.deepcopy(step))
+        elif step.get("kind") == "scatter":
+            body = step.get("body", [])
+            if isinstance(body, list):
+                calls.extend(_flatten_call_steps(body))
+    return calls
+
+
+def _json_pointer_segments(path: str) -> list[str]:
+    return [segment.replace("~1", "/").replace("~0", "~") for segment in path.split("/")[1:]]

--- a/src/reviewer_repair.py
+++ b/src/reviewer_repair.py
@@ -93,7 +93,6 @@ def _default_allowed_operations() -> list[ReviewerPatchOperation]:
 def _default_allowed_path_descriptions() -> list[str]:
     return [
         "/workflow/steps ordering and call input wiring",
-        "/workflow/calls compatibility call input wiring",
         "/workflow/outputs expressions",
         "/tasks/<task>/outputs/<output>/value literal repairs",
     ]
@@ -123,6 +122,7 @@ class ReviewerRepairConstraints(BaseModel):
     notes: list[str] = Field(
         default_factory=lambda: [
             "Reviewer may only propose Workflow IR patches.",
+            "workflow.steps is canonical; workflow.calls is compatibility-only and must not be patched.",
             "Accepted patches must be revalidated by schema, Analyzer, Renderer, and Checker.",
         ]
     )
@@ -235,8 +235,9 @@ _TASK_OUTPUT_VALUE_PATTERN = re.compile(
     rf"^/tasks/{_IR_IDENTIFIER_SEGMENT_PATTERN}/outputs/{_IR_IDENTIFIER_SEGMENT_PATTERN}/value$"
 )
 _CALL_INPUT_PATH_PATTERN = re.compile(
-    rf"^/workflow/(steps|calls)/[0-9]+/inputs/{_IR_IDENTIFIER_SEGMENT_PATTERN}$"
+    rf"^/workflow/steps/[0-9]+/inputs/{_IR_IDENTIFIER_SEGMENT_PATTERN}$"
 )
+_WORKFLOW_STEP_PATH_PATTERN = re.compile(r"^/workflow/steps/[0-9]+$")
 _WORKFLOW_OUTPUT_PATH_PATTERN = re.compile(
     rf"^/workflow/outputs/{_IR_IDENTIFIER_SEGMENT_PATTERN}$"
 )
@@ -287,9 +288,6 @@ def validate_reviewer_patch_policy(
 
 def _validate_action_policy(action: ReviewerPatchAction) -> list[str]:
     violations = []
-    if action.operation == ReviewerPatchOperation.MOVE:
-        violations.extend(_validate_move_policy(action))
-
     for label, path in _iter_action_paths(action):
         if _is_forbidden_path(path):
             violations.append(f"{label} path '{path}' crosses a forbidden Reviewer repair boundary")
@@ -297,18 +295,6 @@ def _validate_action_policy(action: ReviewerPatchAction) -> list[str]:
         if not _is_allowed_path(path, action.operation):
             violations.append(f"{label} path '{path}' is outside the P2 Reviewer patch allowlist")
     return violations
-
-
-def _validate_move_policy(action: ReviewerPatchAction) -> list[str]:
-    source_collection = _workflow_step_or_call_collection(action.from_path or "")
-    target_collection = _workflow_step_or_call_collection(action.path)
-    if source_collection is None or target_collection is None:
-        return []
-    if source_collection != target_collection:
-        return [
-            "move patch actions must stay within the same workflow steps or calls collection"
-        ]
-    return []
 
 
 def _iter_action_paths(action: ReviewerPatchAction) -> list[tuple[str, str]]:
@@ -320,7 +306,7 @@ def _iter_action_paths(action: ReviewerPatchAction) -> list[tuple[str, str]]:
 
 def _is_allowed_path(path: str, operation: ReviewerPatchOperation) -> bool:
     if operation == ReviewerPatchOperation.MOVE:
-        return _is_workflow_step_or_call_path(path)
+        return bool(_WORKFLOW_STEP_PATH_PATTERN.match(path))
 
     if _is_workflow_output_path(path):
         return True
@@ -340,17 +326,6 @@ def _is_call_input_path(path: str) -> bool:
 
 def _is_workflow_output_path(path: str) -> bool:
     return bool(_WORKFLOW_OUTPUT_PATH_PATTERN.match(path))
-
-
-def _is_workflow_step_or_call_path(path: str) -> bool:
-    return _workflow_step_or_call_collection(path) is not None
-
-
-def _workflow_step_or_call_collection(path: str) -> str | None:
-    match = re.match(r"^/workflow/(steps|calls)/[0-9]+$", path)
-    if match is None:
-        return None
-    return match.group(1)
 
 
 def _is_forbidden_path(path: str) -> bool:

--- a/tests/test_reviewer_patcher.py
+++ b/tests/test_reviewer_patcher.py
@@ -240,6 +240,28 @@ class ReviewerPatcherTests(unittest.TestCase):
             "quay.io/biocontainers/fastp:1.3.3--h43da1c4_0",
         )
 
+    def test_apply_reviewer_patch_rejects_compatibility_calls_path_without_mutating_original(self):
+        original = sample_workflow_ir()
+        patch = ReviewerIRPatch.model_validate(
+            {
+                "summary": "Attempt to patch the compatibility calls view.",
+                "actions": [
+                    {
+                        "operation": "replace",
+                        "path": "/workflow/calls/0/inputs/r1",
+                        "value": "raw_r2",
+                        "reason": "Only canonical workflow steps may be patched.",
+                    }
+                ],
+            }
+        )
+
+        with self.assertRaises(ReviewerPatchPolicyError):
+            apply_reviewer_patch(original, patch)
+
+        self.assertEqual(original["workflow"]["steps"][0]["inputs"]["r1"], "raw_r1")
+        self.assertEqual(original["workflow"]["calls"][0]["inputs"]["r1"], "raw_r1")
+
     def test_apply_reviewer_patch_rejects_missing_replace_target_without_mutating_original(self):
         original = sample_workflow_ir()
         patch = ReviewerIRPatch.model_validate(

--- a/tests/test_reviewer_patcher.py
+++ b/tests/test_reviewer_patcher.py
@@ -1,0 +1,287 @@
+import unittest
+
+from src.reviewer_patcher import (
+    ReviewerPatchApplicationError,
+    apply_reviewer_patch,
+)
+from src.reviewer_repair import (
+    ApprovedCatalogContext,
+    ReviewerIRPatch,
+    ReviewerPatchPolicyError,
+)
+from src.schema import WorkflowIR
+
+
+def sample_workflow_ir():
+    return {
+        "workflow": {
+            "name": "ReviewerPatchDemo",
+            "inputs": {
+                "raw_r1": "File",
+                "raw_r2": "File",
+            },
+            "steps": [
+                {
+                    "kind": "call",
+                    "id": "qc",
+                    "task": "fastp",
+                    "inputs": {
+                        "r1": "raw_r1",
+                    },
+                }
+            ],
+            "calls": [
+                {
+                    "kind": "call",
+                    "id": "qc",
+                    "task": "fastp",
+                    "inputs": {
+                        "r1": "raw_r1",
+                    },
+                }
+            ],
+            "outputs": {
+                "clean_r1": "qc.clean_r1",
+                "legacy_report": "qc.clean_r1",
+            },
+        },
+        "tasks": {
+            "fastp": {
+                "inputs": {
+                    "r1": "File",
+                    "r2": "File",
+                },
+                "command": "fastp -i ~{r1} -I ~{r2} -o clean_R1.fq.gz -O clean_R2.fq.gz",
+                "outputs": {
+                    "clean_r1": {
+                        "type": "File",
+                        "value": "\"old_clean_R1.fq.gz\"",
+                    }
+                },
+                "runtime": {
+                    "docker": "quay.io/biocontainers/fastp:1.3.3--h43da1c4_0",
+                    "cpu": 4,
+                    "memory": "8G",
+                },
+            }
+        },
+    }
+
+
+def sample_ordering_ir():
+    workflow_ir = sample_workflow_ir()
+    workflow_ir["workflow"]["steps"] = [
+        {
+            "kind": "call",
+            "id": "align",
+            "task": "bwa_mem",
+            "inputs": {
+                "r1": "qc.clean_r1",
+            },
+        },
+        workflow_ir["workflow"]["steps"][0],
+    ]
+    workflow_ir["workflow"]["calls"] = [
+        {
+            "kind": "call",
+            "id": "align",
+            "task": "bwa_mem",
+            "inputs": {
+                "r1": "qc.clean_r1",
+            },
+        },
+        workflow_ir["workflow"]["calls"][0],
+    ]
+    workflow_ir["tasks"]["bwa_mem"] = {
+        "inputs": {
+            "r1": "File",
+        },
+        "command": "bwa mem ref.fa ~{r1}",
+        "outputs": {
+            "bam": {
+                "type": "File",
+                "value": "\"aligned.bam\"",
+            }
+        },
+        "runtime": {
+            "docker": "ubuntu:22.04",
+        },
+    }
+    return workflow_ir
+
+
+def sample_catalog_context():
+    return ApprovedCatalogContext.model_validate(
+        {
+            "recipes": [
+                {
+                    "recipe_id": "rnaseq_differential_expression",
+                    "step_ids": ["qc"],
+                    "tool_ids": ["fastp"],
+                }
+            ],
+            "tools": [
+                {
+                    "tool_id": "fastp",
+                    "version": "1.3.3",
+                    "inputs": ["r1", "r2"],
+                    "outputs": ["clean_r1"],
+                    "trust_status": "catalog-approved",
+                    "runtime_docker": "quay.io/biocontainers/fastp:1.3.3--h43da1c4_0",
+                }
+            ],
+        }
+    )
+
+
+class ReviewerPatcherTests(unittest.TestCase):
+    def test_apply_reviewer_patch_updates_allowed_workflow_ir_paths(self):
+        original = sample_workflow_ir()
+        patch = ReviewerIRPatch.model_validate(
+            {
+                "summary": "Repair missing call input and output literals.",
+                "actions": [
+                    {
+                        "operation": "add",
+                        "path": "/workflow/steps/0/inputs/r2",
+                        "value": "raw_r2",
+                        "reason": "Use an existing workflow input for the missing task input.",
+                    },
+                    {
+                        "operation": "replace",
+                        "path": "/workflow/outputs/clean_r1",
+                        "value": "qc.clean_r1",
+                        "reason": "Keep the workflow output wired to an existing call output.",
+                    },
+                    {
+                        "operation": "replace",
+                        "path": "/tasks/fastp/outputs/clean_r1/value",
+                        "value": "\"clean_R1.fq.gz\"",
+                        "reason": "Use the repaired output literal.",
+                    },
+                ],
+                "catalog_references": ["fastp:1.3.3"],
+            }
+        )
+
+        patched = apply_reviewer_patch(original, patch, catalog_context=sample_catalog_context())
+
+        self.assertIsInstance(patched, WorkflowIR)
+        self.assertEqual(patched.workflow.steps[0].inputs["r2"], "raw_r2")
+        self.assertEqual(patched.workflow.calls[0].inputs["r2"], "raw_r2")
+        self.assertEqual(patched.workflow.outputs["clean_r1"], "qc.clean_r1")
+        self.assertEqual(patched.tasks["fastp"].outputs["clean_r1"].value, "\"clean_R1.fq.gz\"")
+        self.assertNotIn("r2", original["workflow"]["steps"][0]["inputs"])
+        self.assertNotIn("r2", original["workflow"]["calls"][0]["inputs"])
+
+    def test_apply_reviewer_patch_removes_workflow_output_without_mutating_original(self):
+        original = sample_workflow_ir()
+        patch = ReviewerIRPatch.model_validate(
+            {
+                "summary": "Remove obsolete workflow output.",
+                "actions": [
+                    {
+                        "operation": "remove",
+                        "path": "/workflow/outputs/legacy_report",
+                        "reason": "The output references an obsolete report.",
+                    }
+                ],
+            }
+        )
+
+        patched = apply_reviewer_patch(original, patch)
+
+        self.assertNotIn("legacy_report", patched.workflow.outputs)
+        self.assertIn("legacy_report", original["workflow"]["outputs"])
+
+    def test_apply_reviewer_patch_moves_workflow_steps_and_syncs_calls(self):
+        original = sample_ordering_ir()
+        patch = ReviewerIRPatch.model_validate(
+            {
+                "summary": "Move upstream call before dependent call.",
+                "actions": [
+                    {
+                        "operation": "move",
+                        "from_path": "/workflow/steps/1",
+                        "path": "/workflow/steps/0",
+                        "reason": "The qc call must run before align consumes qc.clean_r1.",
+                    }
+                ],
+            }
+        )
+
+        patched = apply_reviewer_patch(original, patch)
+
+        self.assertEqual([step.id for step in patched.workflow.steps], ["qc", "align"])
+        self.assertEqual([call.id for call in patched.workflow.calls], ["qc", "align"])
+        self.assertEqual(original["workflow"]["steps"][0]["id"], "align")
+
+    def test_apply_reviewer_patch_rejects_forbidden_path_without_mutating_original(self):
+        original = sample_workflow_ir()
+        patch = ReviewerIRPatch.model_validate(
+            {
+                "summary": "Attempt forbidden runtime edit.",
+                "actions": [
+                    {
+                        "operation": "replace",
+                        "path": "/tasks/fastp/runtime/docker",
+                        "value": "ubuntu:22.04",
+                        "reason": "Reviewer must not change runtime images.",
+                    }
+                ],
+            }
+        )
+
+        with self.assertRaises(ReviewerPatchPolicyError):
+            apply_reviewer_patch(original, patch)
+
+        self.assertEqual(
+            original["tasks"]["fastp"]["runtime"]["docker"],
+            "quay.io/biocontainers/fastp:1.3.3--h43da1c4_0",
+        )
+
+    def test_apply_reviewer_patch_rejects_missing_replace_target_without_mutating_original(self):
+        original = sample_workflow_ir()
+        patch = ReviewerIRPatch.model_validate(
+            {
+                "summary": "Replace a missing call input.",
+                "actions": [
+                    {
+                        "operation": "replace",
+                        "path": "/workflow/steps/0/inputs/r2",
+                        "value": "raw_r2",
+                        "reason": "The input must exist for replace.",
+                    }
+                ],
+            }
+        )
+
+        with self.assertRaisesRegex(ReviewerPatchApplicationError, "does not exist"):
+            apply_reviewer_patch(original, patch)
+
+        self.assertNotIn("r2", original["workflow"]["steps"][0]["inputs"])
+
+    def test_apply_reviewer_patch_rejects_schema_invalid_candidate_without_mutating_original(self):
+        original = sample_workflow_ir()
+        patch = ReviewerIRPatch.model_validate(
+            {
+                "summary": "Set workflow output to an invalid value type.",
+                "actions": [
+                    {
+                        "operation": "replace",
+                        "path": "/workflow/outputs/clean_r1",
+                        "value": ["qc.clean_r1"],
+                        "reason": "Workflow outputs must remain string expressions.",
+                    }
+                ],
+            }
+        )
+
+        with self.assertRaisesRegex(ReviewerPatchApplicationError, "invalid Workflow IR"):
+            apply_reviewer_patch(original, patch)
+
+        self.assertEqual(original["workflow"]["outputs"]["clean_r1"], "qc.clean_r1")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_reviewer_repair.py
+++ b/tests/test_reviewer_repair.py
@@ -298,7 +298,6 @@ class ReviewerRepairContractTests(unittest.TestCase):
             "/tasks/foo-bar/outputs/x/value",
             "/tasks/foo/outputs/x-y/value",
             "/workflow/steps/0/inputs/read-1",
-            "/workflow/calls/0/inputs/read-1",
         ]
 
         for path in invalid_paths:
@@ -345,7 +344,7 @@ class ReviewerRepairContractTests(unittest.TestCase):
                 with self.assertRaises(ReviewerPatchPolicyError):
                     validate_reviewer_patch_policy(patch)
 
-    def test_policy_allows_move_only_for_workflow_step_or_call_items(self):
+    def test_policy_allows_move_only_for_workflow_step_items(self):
         patch = ReviewerIRPatch.model_validate(
             {
                 "summary": "Move a call to satisfy dependencies.",
@@ -364,7 +363,7 @@ class ReviewerRepairContractTests(unittest.TestCase):
 
         self.assertIs(validated, patch)
 
-    def test_policy_rejects_move_outside_workflow_step_or_call_items(self):
+    def test_policy_rejects_move_outside_workflow_step_items(self):
         move_paths = [
             "/workflow/outputs/clean_r1",
             "/workflow/steps/0/inputs/r2",
@@ -381,7 +380,7 @@ class ReviewerRepairContractTests(unittest.TestCase):
                                 "operation": "move",
                                 "from_path": path,
                                 "path": path,
-                                "reason": "MOVE is reserved for step or call item ordering.",
+                                "reason": "MOVE is reserved for workflow step ordering.",
                             }
                         ],
                     }
@@ -390,29 +389,43 @@ class ReviewerRepairContractTests(unittest.TestCase):
                 with self.assertRaises(ReviewerPatchPolicyError):
                     validate_reviewer_patch_policy(patch)
 
-    def test_policy_rejects_move_between_workflow_steps_and_calls(self):
-        moves = [
-            ("/workflow/steps/1", "/workflow/calls/0"),
-            ("/workflow/calls/1", "/workflow/steps/0"),
+    def test_policy_rejects_all_workflow_calls_patch_operations(self):
+        actions = [
+            {
+                "operation": "add",
+                "path": "/workflow/calls/0/inputs/r2",
+                "value": "raw_r2",
+                "reason": "Compatibility calls must not be patched.",
+            },
+            {
+                "operation": "replace",
+                "path": "/workflow/calls/0/inputs/r1",
+                "value": "raw_r2",
+                "reason": "Compatibility calls must not be patched.",
+            },
+            {
+                "operation": "remove",
+                "path": "/workflow/calls/0/inputs/r1",
+                "reason": "Compatibility calls must not be patched.",
+            },
+            {
+                "operation": "move",
+                "from_path": "/workflow/calls/1",
+                "path": "/workflow/calls/0",
+                "reason": "Compatibility calls must not be reordered.",
+            },
         ]
 
-        for from_path, path in moves:
-            with self.subTest(from_path=from_path, path=path):
+        for action in actions:
+            with self.subTest(operation=action["operation"]):
                 patch = ReviewerIRPatch.model_validate(
                     {
-                        "summary": "Move across workflow collections.",
-                        "actions": [
-                            {
-                                "operation": "move",
-                                "from_path": from_path,
-                                "path": path,
-                                "reason": "Cross-collection moves are structural changes.",
-                            }
-                        ],
+                        "summary": "Attempt to patch compatibility calls.",
+                        "actions": [action],
                     }
                 )
 
-                with self.assertRaisesRegex(ReviewerPatchPolicyError, "same workflow"):
+                with self.assertRaisesRegex(ReviewerPatchPolicyError, "outside the P2"):
                     validate_reviewer_patch_policy(patch)
 
     def test_repair_result_enforces_status_payload_invariants(self):


### PR DESCRIPTION
## Summary

- add a policy-gated application layer for applying `ReviewerIRPatch` actions to a copy of Workflow IR
- support approved `add`, `replace`, `remove`, and `move` operations while synchronizing compatibility `workflow.calls` after canonical `workflow.steps` changes
- revalidate every patched candidate through the `WorkflowIR` schema and preserve the original IR on policy or application failures
- add focused unit coverage and document the P2.2 test cases

## Why

P2.1 established the Reviewer repair contracts and patch policy. P2.2 turns policy-approved patches into validated Workflow IR candidates while preserving the deterministic compiler boundary. Provider integration and Compiler Graph routing remain out of scope for this PR and are planned for P2.3.

## Impact

This provides the bounded patch-application boundary needed for the next Reviewer integration stage, without allowing direct WDL edits or catalog/runtime changes.

## Validation

- `./.venv/Scripts/python.exe -m unittest tests.test_reviewer_repair tests.test_reviewer_patcher -v` — 19 tests passed
- staged diff format check passed
- the full local suite still has three known WDL compilation failures because no WOMtool/miniwdl validator is available in the local environment; these failures are unrelated to this change