### PR TITLE
Update retrieval evaluation for expanded RNA-seq catalog

### DIFF
--- a/docs/r2-retrieval-evaluation-roadmap.md
+++ b/docs/r2-retrieval-evaluation-roadmap.md
@@ -54,15 +54,15 @@ retrieval query set
   "query": "Run bulk RNA-seq differential expression from paired-end FASTQ files.",
   "supported": true,
   "expected_recipe": "rnaseq_differential_expression",
-  "expected_tools": ["fastp", "salmon", "tximport", "deseq2", "multiqc"],
+  "expected_tools": ["fastp", "salmon", "tximport", "multiqc"],
   "expected_roles": {
     "read_quality_control": ["fastp"],
     "expression_quantification": ["salmon"],
     "transcript_to_gene_count_summary": ["tximport"],
-    "differential_expression": ["deseq2"],
+    "differential_expression": ["deseq2", "edger", "limma_voom"],
     "quality_control_summary": ["multiqc"]
   },
-  "notes": "Basic RNA-seq DEG request without explicit tool names."
+  "notes": "Basic RNA-seq DEG request without explicit DE backend names."
 }
 ```
 
@@ -71,13 +71,15 @@ retrieval query set
 RNA-seq baseline recall；它们单独用于观察 fallback、误召回和未来 Catalog
 扩展需求。
 
-建议第一批 20 条，覆盖：
+当前 query set 覆盖：
 
 - 英文 RNA-seq DEG 请求。
 - 中文 RNA-seq DEG 请求。
 - 缩写表达，例如 DEG、RNAseq、bulk RNA。
 - 明确工具名请求，例如 use Salmon and DESeq2。
 - 只描述分析目标但不说工具名。
+- RNA-seq reference preparation，例如 Salmon index 和 GTF -> tx2gene。
+- edgeR 和 limma-voom 等 differential expression 替代后端。
 - Catalog 暂不支持的负例，例如 ChIP-seq、scRNA-seq、variant calling。
 - 模糊需求，例如 quality report、quantification、gene-level counts。
 - 参数相关请求，例如 paired-end reads、contrast、threads。
@@ -106,6 +108,22 @@ baseline：
 tests/fixtures/retrieval_queries.json
 ```
 
+### R2b Expanded RNA-seq Catalog Baseline
+
+在 Catalog 增加 `rnaseq_reference_preparation`、`salmon_index`、`gtf_tx2gene`、
+`edger` 和 `limma_voom` 后，query set 扩展为：
+
+- 20 条当前支持范围内的 RNA-seq DEG / reference prep / QC / quantification /
+  reporting 查询。
+- 4 条 unsupported negative queries，继续覆盖 ChIP-seq、scRNA-seq、variant
+  calling 和 metagenomics。
+- 泛化 differential expression query 不再硬性要求 `deseq2`；它们通过
+  `expected_roles.differential_expression` 表达 `deseq2`、`edger` 或
+  `limma_voom` 任一 approved backend 均可覆盖该 role。
+- 显式指定 differential expression backend 的 query 仍将对应 tool 记录在
+  `expected_tools` 中，并且只允许该 tool 覆盖
+  `expected_roles.differential_expression`。
+
 ## Metrics
 
 第一版 eval 应保持轻量、可解释、可在本地稳定运行。
@@ -116,6 +134,8 @@ tests/fixtures/retrieval_queries.json
 | `Tool Recall@K` | expected tools 中有多少出现在 top-K tools | 判断候选工具是否完整 |
 | `MRR` | 第一个正确 recipe 或 tool 的 reciprocal rank | 判断排序质量 |
 | `Role Coverage` | expected_roles 中每个 role 是否至少有一个正确 tool | 判断 workflow step 覆盖 |
+| `Planner Context Tool Recall` | raw retrieved tools 加上 retrieved recipes 的 allowed tools 后覆盖多少 expected tools | 判断 Planner prompt 候选上下文是否完整 |
+| `Planner Context Role Coverage` | Planner candidate context 是否覆盖每个 expected role | 区分 raw retriever miss 和 prompt context 可用性 |
 | `Fallback Rate` | 触发 fallback 的 query 占比 | 判断 catalog 覆盖和检索置信度 |
 
 初始目标不是追求高分，而是建立可重复 baseline：
@@ -124,6 +144,7 @@ tests/fixtures/retrieval_queries.json
 lexical_v1 Recipe Recall@3
 lexical_v1 Tool Recall@8
 lexical_v1 Role Coverage
+lexical_v1 Planner Context Role Coverage
 lexical_v1 Fallback Rate
 ```
 
@@ -151,26 +172,32 @@ tests/test_retrieval_evaluation.py
 .\.venv\Scripts\python.exe scripts\evaluate_retrieval.py
 ```
 
-初始 `lexical_v1` current-catalog baseline：
+当前 `lexical_v1` expanded RNA-seq catalog baseline：
 
 | Metric | Value |
 | --- | ---: |
-| Query count | 16 |
-| Supported queries | 12 |
+| Query count | 24 |
+| Supported queries | 20 |
 | Unsupported queries | 4 |
 | Recipe Recall@3 | 1.0000 |
-| Recipe MRR | 1.0000 |
-| Tool Recall@8 | 0.9722 |
-| Tool MRR | 1.0000 |
-| Role Coverage | 0.9722 |
-| Fallback Rate | 0.0625 |
+| Recipe MRR | 0.9500 |
+| Tool Recall@8 | 0.9708 |
+| Tool MRR | 0.9600 |
+| Role Coverage | 0.9733 |
+| Planner Context Tool Recall | 1.0000 |
+| Planner Context Role Coverage | 1.0000 |
+| Fallback Rate | 0.0417 |
 | Supported Fallback Rate | 0.0000 |
 | Unsupported Fallback Rate | 0.2500 |
 
 已知 baseline 观察：
 
-- `rnaseq_params_threads_contrast_en` 未召回 `tximport`，说明参数型 query
-  可能需要更强的 recipe-step 或 role-aware expansion。
+- `rnaseq_deg_no_tool_names_en` 和 `rnaseq_params_threads_contrast_en` 的 raw
+  tool retrieval 未直接召回 `tximport`，说明 query 只描述目标或参数时，
+  lexical tool recall 仍会漏掉中间步骤。
+- Planner Context Tool Recall 和 Planner Context Role Coverage 均为 1.0000，
+  说明当 top recipe 召回正确时，Planner prompt 中通过 recipe allowed tools
+  补齐的候选上下文仍覆盖所需工具和 role。
 - `unsupported_chipseq_peak_calling_en`、`unsupported_scrnaseq_clustering_en`
   和 `unsupported_variant_calling_en` 产生 direct lexical match，说明当前
   lexical fallback 不是 unsupported intent detector；负例评估只用于暴露风险，

--- a/docs/test-cases.md
+++ b/docs/test-cases.md
@@ -1704,9 +1704,9 @@ Recipe / Tool Catalog 中做确定性词法召回，不访问网络、不引入 
 ## `tests/test_retrieval_evaluation.py`
 
 该文件验证 R2 retrieval evaluation baseline。Evaluation 读取人工标注 query
-fixture，调用当前 Approved Catalog Retriever，并计算 current-catalog
-baseline metrics。Fixture 不扩展正式 Catalog，也不伪造工具；unsupported
-负例单独统计，不污染当前 RNA-seq supported recall。
+fixture，调用当前 Approved Catalog Retriever，并计算 expanded RNA-seq
+catalog baseline metrics。Fixture 不伪造工具；unsupported 负例单独统计，
+不污染当前 RNA-seq supported recall。
 
 ### `test_loads_current_catalog_query_fixture`
 
@@ -1720,15 +1720,21 @@ baseline metrics。Fixture 不扩展正式 Catalog，也不伪造工具；unsupp
 
 期望输出：
 
-- fixture 共 16 条 query。
-- 12 条 `supported == True`，4 条 `supported == False`。
+- fixture 共 24 条 query。
+- 20 条 `supported == True`，4 条 `supported == False`。
 - 第一条 query id 为 `rnaseq_deg_basic_en`。
 - 第一条 query 的 expected tools 包含 `fastp`。
+- fixture 包含 `rnaseq_reference_prep_basic_en`。
+- fixture 包含 `rnaseq_deg_alternative_backends_en`。
+- 显式指定 DESeq2 的 query 将 `deseq2` 记录为 required expected tool。
+- 未指定 differential expression backend 的 query 允许 `deseq2`、`edger`
+  或 `limma_voom` 任一 approved tool 覆盖该 role。
 
 覆盖点：
 
 - R2 query set schema 可被稳定读取。
 - 当前 baseline 明确区分 supported RNA-seq 查询和 unsupported 负例。
+- Fixture 标注明确区分显式 tool intent 和通用 role intent。
 
 ### `test_evaluates_current_catalog_baseline`
 
@@ -1747,8 +1753,8 @@ baseline metrics。Fixture 不扩展正式 Catalog，也不伪造工具；unsupp
 - `strategy == "lexical_v1"`。
 - `top_k_recipes == 3`。
 - `top_k_tools == 8`。
-- `query_count == 16`。
-- `supported_query_count == 12`。
+- `query_count == 24`。
+- `supported_query_count == 20`。
 - `unsupported_query_count == 4`。
 - 每个 metric 均为 0 到 1 之间的稳定数值。
 
@@ -1778,14 +1784,20 @@ baseline metrics。Fixture 不扩展正式 Catalog，也不伪造工具；unsupp
 - `tool_recall_at_k == 0.25`。
 - `tool_mrr == 0.5`。
 - `role_coverage == 0.25`。
+- `planner_context_tool_recall == 0.5`。
+- `planner_context_role_coverage == 0.5`。
 - `fallback_rate == 0.3333`。
 - `supported_fallback_rate == 0.5`。
 - `unsupported_fallback_rate == 0.0`。
 - `unsupported_direct_match_query_ids == ["q3"]`。
+- 第一条 query 的 `planner_context_tools` 包含 `deseq2`。
+- 第二条 query 的 `planner_context_missed_expected_tools == ["deseq2"]`。
 
 覆盖点：
 
 - Supported queries 参与 recall / MRR / role coverage。
+- Planner context metrics 会把 retrieved recipe 的 allowed tools 纳入候选上下文，
+  区分 raw retrieval miss 和 Planner prompt candidate coverage。
 - Unsupported queries 不污染 supported recall，但会暴露 direct-match 风险。
 - Fallback rate 按 all / supported / unsupported 三个视角记录。
 

--- a/docs/test-cases.md
+++ b/docs/test-cases.md
@@ -1801,6 +1801,32 @@ catalog baseline metrics。Fixture 不伪造工具；unsupported 负例单独统
 - Unsupported queries 不污染 supported recall，但会暴露 direct-match 风险。
 - Fallback rate 按 all / supported / unsupported 三个视角记录。
 
+### `test_deduplicates_planner_context_tool_ids_from_multiple_versions`
+
+输入：
+
+- 一条 supported synthetic query。
+- fake retriever 返回两个不同版本的 `salmon`，随后返回 `fastp`。
+- retrieved recipe 的 allowed tools 可以补齐 `deseq2`。
+
+执行：
+
+- 调用
+  `evaluate_retrieval_queries(..., retriever=multi_version_fake_retriever)`。
+
+期望输出：
+
+- `planner_context_tools` 保持首次召回顺序，以 `salmon`、`fastp` 开头。
+- `planner_context_tools` 仅包含一次 `salmon`。
+- `planner_context_tool_recall == 1.0`。
+- `planner_context_role_coverage == 1.0`。
+
+覆盖点：
+
+- 同一 tool ID 的多个 Catalog 版本不会在 tool-level Planner context artifact
+  中产生重复项。
+- 去重不改变 Planner context recall 或 role coverage。
+
 ### `test_rejects_unsupported_queries_with_expected_hits`
 
 输入：

--- a/scripts/evaluate_retrieval.py
+++ b/scripts/evaluate_retrieval.py
@@ -101,6 +101,8 @@ def _format_summary(evaluation: dict[str, Any]) -> str:
         f"Tool Recall@{evaluation['top_k_tools']}: {metrics['tool_recall_at_k']:.4f}",
         f"Tool MRR: {metrics['tool_mrr']:.4f}",
         f"Role Coverage: {metrics['role_coverage']:.4f}",
+        f"Planner Context Tool Recall: {metrics['planner_context_tool_recall']:.4f}",
+        f"Planner Context Role Coverage: {metrics['planner_context_role_coverage']:.4f}",
         f"Fallback Rate: {metrics['fallback_rate']:.4f}",
         f"Supported Fallback Rate: {metrics['supported_fallback_rate']:.4f}",
         f"Unsupported Fallback Rate: {metrics['unsupported_fallback_rate']:.4f}",
@@ -129,6 +131,24 @@ def _format_summary(evaluation: dict[str, Any]) -> str:
                 details.append("tools=" + ",".join(result["missed_expected_tools"]))
             if result["missed_roles"]:
                 details.append("roles=" + ",".join(result["missed_roles"]))
+            lines.append(f"  - {result['id']}: " + "; ".join(details))
+
+    planner_context_missed = [
+        result
+        for result in evaluation["queries"]
+        if (
+            result["planner_context_missed_expected_tools"]
+            or result["planner_context_missed_roles"]
+        )
+    ]
+    if planner_context_missed:
+        lines.append("Planner context misses:")
+        for result in planner_context_missed:
+            details = []
+            if result["planner_context_missed_expected_tools"]:
+                details.append("tools=" + ",".join(result["planner_context_missed_expected_tools"]))
+            if result["planner_context_missed_roles"]:
+                details.append("roles=" + ",".join(result["planner_context_missed_roles"]))
             lines.append(f"  - {result['id']}: " + "; ".join(details))
 
     return "\n".join(lines)

--- a/src/catalog/retrieval_eval.py
+++ b/src/catalog/retrieval_eval.py
@@ -268,8 +268,14 @@ def _planner_context_tool_ids(
     retrieved_tool_ids: list[str],
     recipe_catalog: RecipeCatalog,
 ) -> list[str]:
-    tool_ids = list(retrieved_tool_ids)
-    seen = set(tool_ids)
+    tool_ids: list[str] = []
+    seen: set[str] = set()
+    for tool_id in retrieved_tool_ids:
+        if tool_id in seen:
+            continue
+        tool_ids.append(tool_id)
+        seen.add(tool_id)
+
     for recipe_id in retrieved_recipe_ids:
         try:
             recipe = recipe_catalog.get(recipe_id)

--- a/src/catalog/retrieval_eval.py
+++ b/src/catalog/retrieval_eval.py
@@ -147,6 +147,12 @@ def evaluate_retrieval_queries(
             "tool_recall_at_k": _mean(result["tool_recall"] for result in tool_results),
             "tool_mrr": _mean(result["first_expected_tool_reciprocal_rank"] for result in tool_results),
             "role_coverage": _mean(result["role_coverage"] for result in role_results),
+            "planner_context_tool_recall": _mean(
+                result["planner_context_tool_recall"] for result in tool_results
+            ),
+            "planner_context_role_coverage": _mean(
+                result["planner_context_role_coverage"] for result in role_results
+            ),
             "fallback_rate": _rate(len(fallback_query_ids), len(per_query)),
             "supported_fallback_rate": _rate(
                 len(supported_fallback_query_ids),
@@ -181,10 +187,19 @@ def _evaluate_one_query(
     )
     retrieved_recipe_ids = [str(recipe["id"]) for recipe in retrieval.get("recipes", [])]
     retrieved_tool_ids = [str(tool["id"]) for tool in retrieval.get("tools", [])]
+    planner_context_tool_ids = _planner_context_tool_ids(
+        retrieved_recipe_ids,
+        retrieved_tool_ids,
+        recipe_catalog,
+    )
 
     expected_recipe_rank = _rank_of(query.expected_recipe, retrieved_recipe_ids)
     expected_tool_ranks = {
         tool_id: _rank_of(tool_id, retrieved_tool_ids)
+        for tool_id in query.expected_tools
+    }
+    planner_context_tool_ranks = {
+        tool_id: _rank_of(tool_id, planner_context_tool_ids)
         for tool_id in query.expected_tools
     }
     recalled_tools = [
@@ -193,7 +208,21 @@ def _evaluate_one_query(
     missed_tools = [
         tool_id for tool_id, rank in expected_tool_ranks.items() if rank is None
     ]
+    planner_context_recalled_tools = [
+        tool_id
+        for tool_id, rank in planner_context_tool_ranks.items()
+        if rank is not None
+    ]
+    planner_context_missed_tools = [
+        tool_id
+        for tool_id, rank in planner_context_tool_ranks.items()
+        if rank is None
+    ]
     role_coverage = _role_coverage(query.expected_roles, retrieved_tool_ids)
+    planner_context_role_coverage = _role_coverage(
+        query.expected_roles,
+        planner_context_tool_ids,
+    )
 
     return {
         "id": query.id,
@@ -204,6 +233,7 @@ def _evaluate_one_query(
         "expected_roles": query.expected_roles,
         "retrieved_recipes": retrieved_recipe_ids,
         "retrieved_tools": retrieved_tool_ids,
+        "planner_context_tools": planner_context_tool_ids,
         "expected_recipe_recalled": expected_recipe_rank is not None,
         "expected_recipe_rank": expected_recipe_rank,
         "expected_recipe_reciprocal_rank": _reciprocal_rank(expected_recipe_rank),
@@ -214,14 +244,44 @@ def _evaluate_one_query(
         "missed_expected_tools": missed_tools,
         "tool_recall": _rate(len(recalled_tools), len(query.expected_tools)),
         "first_expected_tool_reciprocal_rank": _first_reciprocal_rank(expected_tool_ranks.values()),
+        "planner_context_recalled_expected_tools": planner_context_recalled_tools,
+        "planner_context_missed_expected_tools": planner_context_missed_tools,
+        "planner_context_tool_recall": _rate(
+            len(planner_context_recalled_tools),
+            len(query.expected_tools),
+        ),
         "covered_roles": role_coverage["covered_roles"],
         "missed_roles": role_coverage["missed_roles"],
         "role_coverage": role_coverage["coverage"],
+        "planner_context_covered_roles": planner_context_role_coverage["covered_roles"],
+        "planner_context_missed_roles": planner_context_role_coverage["missed_roles"],
+        "planner_context_role_coverage": planner_context_role_coverage["coverage"],
         "fallback_used": bool(retrieval.get("fallback_used")),
         "fallback_reason": retrieval.get("fallback_reason"),
         "strategy": retrieval.get("strategy"),
         "notes": query.notes,
     }
+
+
+def _planner_context_tool_ids(
+    retrieved_recipe_ids: list[str],
+    retrieved_tool_ids: list[str],
+    recipe_catalog: RecipeCatalog,
+) -> list[str]:
+    tool_ids = list(retrieved_tool_ids)
+    seen = set(tool_ids)
+    for recipe_id in retrieved_recipe_ids:
+        try:
+            recipe = recipe_catalog.get(recipe_id)
+        except KeyError:
+            continue
+        for step in recipe.steps:
+            for tool_id in step.allowed_tools:
+                if tool_id in seen:
+                    continue
+                tool_ids.append(tool_id)
+                seen.add(tool_id)
+    return tool_ids
 
 
 def _role_coverage(

--- a/tests/fixtures/retrieval_queries.json
+++ b/tests/fixtures/retrieval_queries.json
@@ -4,15 +4,15 @@
     "query": "Run bulk RNA-seq differential expression from paired-end FASTQ files with QC, transcript quantification, gene-level counts, and a workflow summary report.",
     "supported": true,
     "expected_recipe": "rnaseq_differential_expression",
-    "expected_tools": ["fastp", "salmon", "tximport", "deseq2", "multiqc"],
+    "expected_tools": ["fastp", "salmon", "tximport", "multiqc"],
     "expected_roles": {
       "read_quality_control": ["fastp"],
       "expression_quantification": ["salmon"],
       "transcript_to_gene_count_summary": ["tximport"],
-      "differential_expression": ["deseq2"],
+      "differential_expression": ["deseq2", "edger", "limma_voom"],
       "quality_control_summary": ["multiqc"]
     },
-    "notes": "Basic supported RNA-seq DEG request without explicit tool names."
+    "notes": "Basic supported RNA-seq DEG request without explicit DE backend names."
   },
   {
     "id": "rnaseq_deg_explicit_tools_en",
@@ -27,7 +27,7 @@
       "differential_expression": ["deseq2"],
       "quality_control_summary": ["multiqc"]
     },
-    "notes": "Supported request with every approved RNA-seq tool named explicitly."
+    "notes": "Supported request with all requested pipeline tools named explicitly, including DESeq2."
   },
   {
     "id": "rnaseq_deg_cn_mixed_tools",
@@ -49,27 +49,27 @@
     "query": "Create a DEG workflow for bulk RNAseq paired-end reads, including adapter trimming, transcript quantification, transcript-to-gene summarization, and a QC report.",
     "supported": true,
     "expected_recipe": "rnaseq_differential_expression",
-    "expected_tools": ["fastp", "salmon", "tximport", "deseq2", "multiqc"],
+    "expected_tools": ["fastp", "salmon", "tximport", "multiqc"],
     "expected_roles": {
       "read_quality_control": ["fastp"],
       "expression_quantification": ["salmon"],
       "transcript_to_gene_count_summary": ["tximport"],
-      "differential_expression": ["deseq2"],
+      "differential_expression": ["deseq2", "edger", "limma_voom"],
       "quality_control_summary": ["multiqc"]
     },
-    "notes": "Uses DEG and RNAseq shorthand while describing all major roles."
+    "notes": "Uses DEG and RNAseq shorthand without naming a specific DE backend."
   },
   {
     "id": "rnaseq_deg_no_tool_names_en",
     "query": "Identify differentially expressed genes from RNA sequencing FASTQs and create a workflow-level quality-control summary.",
     "supported": true,
     "expected_recipe": "rnaseq_differential_expression",
-    "expected_tools": ["fastp", "salmon", "tximport", "deseq2", "multiqc"],
+    "expected_tools": ["fastp", "salmon", "tximport", "multiqc"],
     "expected_roles": {
       "read_quality_control": ["fastp"],
       "expression_quantification": ["salmon"],
       "transcript_to_gene_count_summary": ["tximport"],
-      "differential_expression": ["deseq2"],
+      "differential_expression": ["deseq2", "edger", "limma_voom"],
       "quality_control_summary": ["multiqc"]
     },
     "notes": "Supported natural-language request that does not name specific tools."
@@ -130,14 +130,14 @@
     "query": "Differential expression from sample metadata, a tx2gene mapping table, and a Salmon transcriptome index for paired-end RNA-seq.",
     "supported": true,
     "expected_recipe": "rnaseq_differential_expression",
-    "expected_tools": ["fastp", "salmon", "tximport", "deseq2"],
+    "expected_tools": ["fastp", "salmon", "tximport"],
     "expected_roles": {
       "read_quality_control": ["fastp"],
       "expression_quantification": ["salmon"],
       "transcript_to_gene_count_summary": ["tximport"],
-      "differential_expression": ["deseq2"]
+      "differential_expression": ["deseq2", "edger", "limma_voom"]
     },
-    "notes": "Supported request emphasizing recipe inputs instead of step names."
+    "notes": "Supported request emphasizing recipe inputs instead of step names; any approved DE backend is acceptable."
   },
   {
     "id": "rnaseq_gene_counts_cn_mixed",
@@ -164,6 +164,96 @@
       "quality_control_summary": ["multiqc"]
     },
     "notes": "Supported request focused on tagged QC outputs and workflow summary."
+  },
+  {
+    "id": "rnaseq_reference_prep_basic_en",
+    "query": "Prepare RNA-seq reference artifacts by building a Salmon transcriptome index from FASTA and extracting tx2gene from a GTF annotation.",
+    "supported": true,
+    "expected_recipe": "rnaseq_reference_preparation",
+    "expected_tools": ["salmon_index", "gtf_tx2gene"],
+    "expected_roles": {
+      "transcriptome_index_build": ["salmon_index"],
+      "transcript_to_gene_mapping": ["gtf_tx2gene"]
+    },
+    "notes": "Supported reference preparation request covering both new reference prep tools."
+  },
+  {
+    "id": "rnaseq_reference_prep_cn_mixed",
+    "query": "准备 RNA-seq reference：从 transcriptome FASTA 构建 Salmon index，并从 GTF 提取 tx2gene 映射表。",
+    "supported": true,
+    "expected_recipe": "rnaseq_reference_preparation",
+    "expected_tools": ["salmon_index", "gtf_tx2gene"],
+    "expected_roles": {
+      "transcriptome_index_build": ["salmon_index"],
+      "transcript_to_gene_mapping": ["gtf_tx2gene"]
+    },
+    "notes": "Chinese reference preparation request with English tool and artifact names."
+  },
+  {
+    "id": "rnaseq_salmon_index_only_en",
+    "query": "Build a Salmon index archive from a transcriptome FASTA for RNA-seq quantification.",
+    "supported": true,
+    "expected_recipe": "rnaseq_reference_preparation",
+    "expected_tools": ["salmon_index"],
+    "expected_roles": {
+      "transcriptome_index_build": ["salmon_index"]
+    },
+    "notes": "Partial reference preparation request focused on Salmon index construction."
+  },
+  {
+    "id": "rnaseq_gtf_tx2gene_only_en",
+    "query": "Extract a transcript-to-gene mapping table from a GTF annotation for tximport.",
+    "supported": true,
+    "expected_recipe": "rnaseq_reference_preparation",
+    "expected_tools": ["gtf_tx2gene"],
+    "expected_roles": {
+      "transcript_to_gene_mapping": ["gtf_tx2gene"]
+    },
+    "notes": "Partial reference preparation request focused on tx2gene extraction."
+  },
+  {
+    "id": "rnaseq_deg_edger_en",
+    "query": "Use edgeR quasi-likelihood testing for bulk RNA-seq differential expression from a gene count matrix.",
+    "supported": true,
+    "expected_recipe": "rnaseq_differential_expression",
+    "expected_tools": ["edger"],
+    "expected_roles": {
+      "differential_expression": ["edger"]
+    },
+    "notes": "Supported request naming edgeR as the differential expression backend."
+  },
+  {
+    "id": "rnaseq_deg_limma_voom_en",
+    "query": "Run limma voom differential expression for bulk RNA-seq gene counts and sample group metadata.",
+    "supported": true,
+    "expected_recipe": "rnaseq_differential_expression",
+    "expected_tools": ["limma_voom"],
+    "expected_roles": {
+      "differential_expression": ["limma_voom"]
+    },
+    "notes": "Supported request naming limma-voom as the differential expression backend."
+  },
+  {
+    "id": "rnaseq_deg_alternative_backends_en",
+    "query": "Evaluate bulk RNA-seq differential expression with edgeR or limma voom instead of DESeq2.",
+    "supported": true,
+    "expected_recipe": "rnaseq_differential_expression",
+    "expected_tools": ["edger", "limma_voom"],
+    "expected_roles": {
+      "differential_expression": ["edger", "limma_voom"]
+    },
+    "notes": "Supported request naming both newly approved DE alternatives."
+  },
+  {
+    "id": "rnaseq_deg_alternative_backends_cn",
+    "query": "bulk RNA-seq 差异表达不想用 DESeq2，想试 edgeR 或 limma voom。",
+    "supported": true,
+    "expected_recipe": "rnaseq_differential_expression",
+    "expected_tools": ["edger", "limma_voom"],
+    "expected_roles": {
+      "differential_expression": ["edger", "limma_voom"]
+    },
+    "notes": "Chinese request for alternative differential expression backends."
   },
   {
     "id": "unsupported_chipseq_peak_calling_en",

--- a/tests/test_retrieval_evaluation.py
+++ b/tests/test_retrieval_evaluation.py
@@ -57,11 +57,38 @@ class RetrievalEvaluationTests(unittest.TestCase):
     def test_loads_current_catalog_query_fixture(self):
         queries = load_retrieval_queries(FIXTURE_PATH)
 
-        self.assertEqual(len(queries), 16)
-        self.assertEqual(sum(1 for query in queries if query.supported), 12)
+        self.assertEqual(len(queries), 24)
+        self.assertEqual(sum(1 for query in queries if query.supported), 20)
         self.assertEqual(sum(1 for query in queries if not query.supported), 4)
         self.assertEqual(queries[0].id, "rnaseq_deg_basic_en")
         self.assertIn("fastp", queries[0].expected_tools)
+        self.assertIn(
+            "rnaseq_reference_prep_basic_en",
+            {query.id for query in queries},
+        )
+        self.assertIn(
+            "rnaseq_deg_alternative_backends_en",
+            {query.id for query in queries},
+        )
+        queries_by_id = {query.id: query for query in queries}
+        explicit_deseq2 = queries_by_id["rnaseq_deg_explicit_tools_en"]
+        self.assertIn("deseq2", explicit_deseq2.expected_tools)
+        self.assertEqual(
+            explicit_deseq2.expected_roles["differential_expression"],
+            ["deseq2"],
+        )
+        chinese_explicit_deseq2 = queries_by_id["rnaseq_deg_cn_mixed_tools"]
+        self.assertIn("deseq2", chinese_explicit_deseq2.expected_tools)
+        self.assertEqual(
+            chinese_explicit_deseq2.expected_roles["differential_expression"],
+            ["deseq2"],
+        )
+        generic_deg = queries_by_id["rnaseq_deg_abbrev_en"]
+        self.assertNotIn("deseq2", generic_deg.expected_tools)
+        self.assertEqual(
+            generic_deg.expected_roles["differential_expression"],
+            ["deseq2", "edger", "limma_voom"],
+        )
 
     def test_evaluates_current_catalog_baseline(self):
         queries = load_retrieval_queries(FIXTURE_PATH)
@@ -75,10 +102,10 @@ class RetrievalEvaluationTests(unittest.TestCase):
         self.assertEqual(result["strategy"], "lexical_v1")
         self.assertEqual(result["top_k_recipes"], 3)
         self.assertEqual(result["top_k_tools"], 8)
-        self.assertEqual(result["query_count"], 16)
-        self.assertEqual(result["supported_query_count"], 12)
+        self.assertEqual(result["query_count"], 24)
+        self.assertEqual(result["supported_query_count"], 20)
         self.assertEqual(result["unsupported_query_count"], 4)
-        self.assertEqual(len(result["queries"]), 16)
+        self.assertEqual(len(result["queries"]), 24)
         for metric in result["metrics"].values():
             self.assertGreaterEqual(metric, 0.0)
             self.assertLessEqual(metric, 1.0)
@@ -127,13 +154,20 @@ class RetrievalEvaluationTests(unittest.TestCase):
         self.assertEqual(result["metrics"]["tool_recall_at_k"], 0.25)
         self.assertEqual(result["metrics"]["tool_mrr"], 0.5)
         self.assertEqual(result["metrics"]["role_coverage"], 0.25)
+        self.assertEqual(result["metrics"]["planner_context_tool_recall"], 0.5)
+        self.assertEqual(result["metrics"]["planner_context_role_coverage"], 0.5)
         self.assertEqual(result["metrics"]["fallback_rate"], 0.3333)
         self.assertEqual(result["metrics"]["supported_fallback_rate"], 0.5)
         self.assertEqual(result["metrics"]["unsupported_fallback_rate"], 0.0)
         self.assertEqual(result["fallback_query_ids"], ["q2"])
         self.assertEqual(result["unsupported_direct_match_query_ids"], ["q3"])
+        self.assertIn("deseq2", result["queries"][0]["planner_context_tools"])
         self.assertEqual(result["queries"][1]["missed_expected_tools"], ["deseq2"])
         self.assertEqual(result["queries"][1]["missed_roles"], ["differential_expression"])
+        self.assertEqual(
+            result["queries"][1]["planner_context_missed_expected_tools"],
+            ["deseq2"],
+        )
 
     def test_rejects_unsupported_queries_with_expected_hits(self):
         with self.assertRaisesRegex(ValueError, "unsupported queries must not define expected hits"):

--- a/tests/test_retrieval_evaluation.py
+++ b/tests/test_retrieval_evaluation.py
@@ -49,6 +49,27 @@ def fake_retriever(
     }
 
 
+def multi_version_fake_retriever(
+    query: str,
+    _tool_catalog,
+    _recipe_catalog,
+    _top_k_recipes: int,
+    _top_k_tools: int,
+) -> dict[str, Any]:
+    return {
+        "query": query,
+        "strategy": "fake_multi_version_v1",
+        "recipes": [{"id": "rnaseq_differential_expression"}],
+        "tools": [
+            {"id": "salmon", "version": "1.9.0"},
+            {"id": "salmon", "version": "1.10.0"},
+            {"id": "fastp", "version": "1.3.3"},
+        ],
+        "fallback_used": False,
+        "fallback_reason": None,
+    }
+
+
 class RetrievalEvaluationTests(unittest.TestCase):
     def setUp(self):
         self.tool_catalog = load_tool_catalog()
@@ -168,6 +189,34 @@ class RetrievalEvaluationTests(unittest.TestCase):
             result["queries"][1]["planner_context_missed_expected_tools"],
             ["deseq2"],
         )
+
+    def test_deduplicates_planner_context_tool_ids_from_multiple_versions(self):
+        queries = [
+            RetrievalQuery(
+                id="multi-version",
+                query="multi-version tool results",
+                supported=True,
+                expected_recipe="rnaseq_differential_expression",
+                expected_tools=["salmon", "deseq2"],
+                expected_roles={
+                    "expression_quantification": ["salmon"],
+                    "differential_expression": ["deseq2"],
+                },
+            )
+        ]
+
+        result = evaluate_retrieval_queries(
+            queries,
+            self.tool_catalog,
+            self.recipe_catalog,
+            retriever=multi_version_fake_retriever,
+        )
+
+        planner_context_tools = result["queries"][0]["planner_context_tools"]
+        self.assertEqual(planner_context_tools[:2], ["salmon", "fastp"])
+        self.assertEqual(planner_context_tools.count("salmon"), 1)
+        self.assertEqual(result["metrics"]["planner_context_tool_recall"], 1.0)
+        self.assertEqual(result["metrics"]["planner_context_role_coverage"], 1.0)
 
     def test_rejects_unsupported_queries_with_expected_hits(self):
         with self.assertRaisesRegex(ValueError, "unsupported queries must not define expected hits"):


### PR DESCRIPTION
## Summary

- expand the R2 retrieval query set for RNA-seq reference preparation, edgeR, and limma-voom catalog coverage
- add Planner-context tool recall and role coverage metrics that include allowed tools from retrieved recipes
- distinguish explicit differential-expression tool requests from generic role-level alternatives
- update the CLI diagnostics, baseline documentation, and retrieval evaluation tests

## Why

The RNA-seq Catalog now includes reference-preparation tools and multiple differential-expression backends. The retrieval baseline needs to cover those additions while separating raw lexical tool misses from the candidate tool context actually provided to the Planner.

## Validation

- `.\.venv\Scripts\python.exe -m unittest tests.test_catalog_retriever tests.test_retrieval_evaluation -v`
- `.\.venv\Scripts\python.exe scripts\evaluate_retrieval.py`
- `git diff --check`

The updated baseline covers 24 queries. Recipe Recall@3 remains 1.0000, Planner Context Tool Recall and Planner Context Role Coverage are both 1.0000, and supported fallback rate remains 0.0000.