### PR TITLE
Document W6 architecture visuals

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,9 +269,49 @@ Recipe Tool Plan 示例：
 
 `tool_calls[].inputs` 的值既可以是单个表达式字符串，也可以是表达式数组。数组会被编译成 WDL `Array[...]` 输入；例如 MultiQC 的 `report_files` 可以写成 `["qc.html_report", "qc.json_report", "quantify.log_file"]`，scatter 内产生的多个 `Array[File]` 会在渲染时自动展开为 `flatten([...])`。Catalog output 也可以用 `tags: [multiqc_input]` 标记可汇总文件；MultiQC 未显式提供 `report_files` 时会自动收集前序带标签输出。
 
-## 🏗️ 架构与开发指南
+## 🏗️ 架构总览与开发指南
 
-对于希望了解本项目底层实现原理、LangGraph 状态图设计，或有志于参与二次开发的工程师，请务必阅读我们的开发文档：
+系统提供自然语言和结构化输入两条入口，但最终都进入同一条以 Workflow IR
+为核心的编译链。自然语言入口先生成结构化 Recipe Tool Plan；结构化入口可以直接
+提交 Recipe Tool Plan 或 Workflow IR，不依赖 Planner API key。
+
+```mermaid
+flowchart TD
+    NL["自然语言需求"] --> ORCH["Orchestration Graph<br/>Planner + Catalog Retrieval"]
+    ORCH --> PLAN["Recipe Tool Plan"]
+    STRUCT["结构化输入<br/>Recipe Tool Plan / Workflow IR"] --> NORMALIZER["IR Normalizer<br/>Schema + Catalog Validation"]
+    PLAN --> NORMALIZER
+    NORMALIZER --> IR["Workflow IR<br/>Canonical DAG Contract"]
+    IR --> ANALYZER["Analyzer"]
+    ANALYZER --> RENDERER["Deterministic<br/>WDL Renderer"]
+    ANALYZER -- "有界修复" --> REPAIRER["Deterministic Repairer"]
+    REPAIRER -- "重新分析" --> ANALYZER
+    RENDERER --> CHECKER["WDL Checker"]
+    CHECKER --> OUTPUTS["Run Events + Artifacts<br/>Plan / IR / WDL / Diagnostics"]
+    IR -. "结构审阅" .-> DAG["Workflow IR DAG"]
+```
+
+Web 层与编译器核心通过显式 API 和 application service 隔离：
+
+```mermaid
+flowchart LR
+    WEB["Next.js<br/>Demo / Workbench / History / DAG"] -- "创建与查询" --> API["FastAPI<br/>Run + Catalog API"]
+    API -- "Snapshot + SSE" --> WEB
+    API --> SERVICE["Python Application Service"]
+    CLI["CLI"] --> SERVICE
+    SERVICE --> CORE["Orchestration Graph<br/>Compiler Graph"]
+    CORE --> RECORDS["SQLite Run Records<br/>Events + Artifacts + Diagnostics"]
+    RECORDS --> API
+```
+
+关键边界：
+
+- 当前公开演示主路径中，LLM Planner 只把自然语言需求规划为 Recipe Tool Plan，不直接生成最终 WDL。
+- FastAPI 与 CLI 复用 Python application service；API 不通过 shell 调用 CLI。
+- Next.js 只提交请求并展示 API 返回的事件和产物，不生成或修复 Plan、Workflow IR 或 WDL。
+- DAG 从 Workflow IR 派生，用于审阅 step、scatter 和依赖关系，不表示真实 workflow call 的运行状态。
+
+对于希望了解底层实现、LangGraph 状态图设计或参与二次开发的工程师，请阅读：
 
 👉 **[查看 DEVELOPMENT.md 开发指南](./DEVELOPMENT.md)**
 
@@ -280,6 +320,8 @@ Workflow IR 的结构、表达式规则、scatter 语义和 WDL 后端映射详�
 👉 **[Workflow IR 规范与后端映射](./docs/workflow-ir.md)**
 
 Web 产品化拆解与当前 W6 收口计划详见：
+
+👉 **[W4 工作台工作拆解](./docs/w4-workbench-plan.md)**
 
 👉 **[W5 DAG 与历史详情工作拆解](./docs/w5-dag-history-plan.md)**
 

--- a/docs/w6-portfolio-launch-plan.md
+++ b/docs/w6-portfolio-launch-plan.md
@@ -153,6 +153,16 @@ README 应提供：
 4. **W6 deployment docs**：部署说明、环境变量、CORS 和公开 demo 注意事项。
 5. **W6 screenshots and final QA**：截图/录屏资产、README 导航和最终 lint/build/test。
 
+当前实施进度：
+
+| 阶段 | 状态 | 实施记录 |
+| --- | --- | --- |
+| W6 portfolio landing polish | 已完成 | 首页和导航已形成 demo hub，稳定入口覆盖 RNA-seq 示例、run history、Catalog 和 API 文档。 |
+| W6 demo readiness | 已完成 | 工作台、历史、详情和 Catalog 已统一恢复入口，并补充 API 不可达等可读失败状态。 |
+| W6 architecture visuals | 进行中 | README 架构图和系统边界叙事正在收口，重点说明确定性编译链、服务复用与 DAG 结构语义。 |
+| W6 deployment docs | 待开始 | 等待架构叙事合并后处理部署、环境变量、CORS 和公开 demo 数据边界。 |
+| W6 screenshots and final QA | 待开始 | 在部署说明稳定后统一制作展示资产并执行最终前端 QA。 |
+
 如果某个 PR 只改文档，可以不运行前端 build，但应至少检查 Markdown 链接和文案一致性。涉及前端代码的 PR 应运行前端验证。
 
 ## W6 不做


### PR DESCRIPTION
## Summary

- Add a README architecture overview for natural-language and structured inputs through Recipe Tool Plan, Workflow IR, analysis, repair, deterministic WDL rendering, validation, and observable artifacts.
- Add a Web boundary diagram and explicit responsibilities for Next.js, FastAPI, the shared Python application service, and Workflow IR DAG review semantics.
- Restore W4/W5/W6 documentation navigation and record current W6 implementation progress.

## Why

W6 portfolio polish needs a concise system narrative that lets readers understand the compiler boundary, service ownership, and demo semantics without reading the full development guide first.

## Impact

Documentation now distinguishes deterministic compilation from planning, clarifies that the Web layer only presents API artifacts, and prevents the Workflow IR DAG from being mistaken for call-level execution monitoring.

## Verification

- Validated local Markdown links in the changed documents.
- Confirmed both Mermaid code blocks are closed and contain graph edges.
- Ran `git diff --cached --check`.
- Frontend build not run because this PR changes documentation only.