### PR TITLE
Document W6 deployment setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,10 @@ Web 产品化拆解与当前 W6 收口计划详见：
 
 👉 **[W6 部署与作品集打磨工作拆解](./docs/w6-portfolio-launch-plan.md)**
 
+部署拓扑、环境变量、CORS、SQLite 数据边界和回滚流程详见：
+
+👉 **[部署与运维手册](./docs/deployment.md)**
+
 ## 📅 未来路线图 (Roadmap)
 
 - [x] 搭建基础 LangGraph 状态机。

--- a/deploy/app/README.md
+++ b/deploy/app/README.md
@@ -51,7 +51,12 @@ uvicorn src.api.app:app --host 0.0.0.0 --port 8010
 AI_BIOWORKFLOW_DB_PATH=/data/ai-bioworkflow/ai-bioworkflow.sqlite3
 AI_BIOWORKFLOW_RUN_BACKEND=disabled
 WDL_VALIDATOR=miniwdl
-DEEPSEEK_API_KEY=<仅自然语言规划需要>
+
+# 仅当前后端跨 origin 部署时需要。
+# AI_BIOWORKFLOW_CORS_ORIGINS=https://portfolio.example.com
+
+# 仅自然语言规划需要；结构化示例不需要。
+# DEEPSEEK_API_KEY=<your-deepseek-api-key>
 ```
 
 如果需要在容器替换后保留 run 历史记录，应持久化挂载
@@ -120,7 +125,12 @@ AI_BIOWORKFLOW_WEB_IMAGE=registry.cn-hangzhou.aliyuncs.com/your-namespace/ai-bio
 ```text
 AI_BIOWORKFLOW_RUN_BACKEND=disabled
 WDL_VALIDATOR=miniwdl
-DEEPSEEK_API_KEY=<your-deepseek-api-key>
+
+# 仅当前后端跨 origin 部署时需要。
+# AI_BIOWORKFLOW_CORS_ORIGINS=https://portfolio.example.com
+
+# 仅自然语言规划需要；结构化示例不需要。
+# DEEPSEEK_API_KEY=<your-deepseek-api-key>
 ```
 
 启动或更新应用：

--- a/deploy/app/env.prod.example
+++ b/deploy/app/env.prod.example
@@ -4,6 +4,9 @@
 AI_BIOWORKFLOW_RUN_BACKEND=disabled
 WDL_VALIDATOR=miniwdl
 
+# Required only when Web and API are served from different browser origins.
+# AI_BIOWORKFLOW_CORS_ORIGINS=https://portfolio.example.com
+
 # Required only when natural-language planning is enabled.
 # DEEPSEEK_API_KEY=<your-deepseek-api-key>
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -50,7 +50,7 @@ powershell -ExecutionPolicy Bypass -File scripts\dev_local.ps1 `
 | `NEXT_PUBLIC_API_BASE_URL` | Web 镜像构建时 | 本地 `http://127.0.0.1:8010` | 浏览器可访问的 API 根地址。值会进入客户端 bundle，不能包含 secret；修改后必须重新构建 Web 镜像。 |
 | `AI_BIOWORKFLOW_API_HOST` | `src.api.server` 本地启动时 | `127.0.0.1` | 控制开发服务器监听地址。生产 API 镜像直接以 `0.0.0.0:8010` 启动，不读取该变量。 |
 | `AI_BIOWORKFLOW_API_PORT` | `src.api.server` 本地启动时 | `8010` | 控制开发服务器端口，允许 `1-65535`。生产容器端口固定为 `8010`。 |
-| `AI_BIOWORKFLOW_CORS_ORIGINS` | API 运行时 | 本地允许 `127.0.0.1:3000` 和 `localhost:3000` | 逗号分隔的浏览器 origin。仅在 Web 与 API 跨 origin 时需要显式设置。 |
+| `AI_BIOWORKFLOW_CORS_ORIGINS` | API 运行时 | 本地允许 `http://127.0.0.1:3000` 和 `http://localhost:3000` | 逗号分隔的浏览器 origin。仅在 Web 与 API 跨 origin 时需要显式设置。 |
 | `AI_BIOWORKFLOW_DB_PATH` | API 运行时 | 本地 `.cache/ai-bioworkflow.sqlite3`；容器 `/data/ai-bioworkflow/ai-bioworkflow.sqlite3` | SQLite 文件路径。生产路径位于 Compose `api_data` volume。 |
 | `DEEPSEEK_API_KEY` | Planner 运行时 | 未设置 | 仅自然语言规划需要；结构化编译必须在无 key 时正常工作。只放在服务端 `.env.prod` 或 secret store。 |
 | `WDL_VALIDATOR` | 编译运行时 | 本地 `auto`；生产 `miniwdl` | 可选值为 `auto`、`womtool`、`miniwdl`。生产镜像已安装 miniwdl。 |

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,6 +1,6 @@
-# 生产部署与运维手册
+# 部署与运维手册
 
-本文档记录 AI-bioworkflow 作品集 demo 当前的生产部署方案。目标是让部署流程可以重复执行、可以审计、可以回滚，而不是依赖一次性的手工命令。
+本文档记录 AI-bioworkflow 作品集 demo 的本地与公开部署边界，以及当前生产部署方案。目标是让部署流程可以重复执行、可以审计、可以回滚，而不是依赖一次性的手工命令。
 
 当前生产形态是单台阿里云 ECS 上运行 Docker Compose：
 
@@ -13,6 +13,89 @@ GitHub main push
   -> Docker Compose pulls images and starts services
   -> Caddy terminates HTTPS and reverse proxies traffic
 ```
+
+## 运行模式与最短路径
+
+当前仓库覆盖三种运行方式，公开作品集使用第二种：
+
+| 模式 | 入口 | 数据位置 | 适用范围 |
+| --- | --- | --- | --- |
+| 本地联合开发 | `scripts/dev_local.ps1` 启动 FastAPI 与 Next.js | `.cache/ai-bioworkflow.sqlite3` | 开发、演示和跨页面回放 |
+| 单机公开 demo | Caddy + API + Web 的 Docker Compose | `api_data` Docker volume | 当前 ECS 作品集部署 |
+| 前后端分离 | 独立 Web 域名通过 HTTPS 调用 API 域名 | 由 API 部署决定 | 可选拓扑，需要显式配置 API base URL 与 CORS |
+
+本地启动前可以先执行 dry run，检查 Python、Web 依赖和端口可用性，但不启动服务：
+
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts\dev_local.ps1 -DryRun
+powershell -ExecutionPolicy Bypass -File scripts\dev_local.ps1
+```
+
+默认地址是 FastAPI `127.0.0.1:8010` 和 Next.js `127.0.0.1:3000`。需要更换端口时，
+联合启动脚本会同步生成 API base URL 和 CORS origins：
+
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts\dev_local.ps1 `
+  -ApiPort 8020 `
+  -WebPort 3001
+```
+
+结构化 RNA-seq 示例调用 `POST /api/compile`，不需要 `DEEPSEEK_API_KEY`。只有自然语言
+入口 `POST /api/runs` 需要 Planner key。
+
+## 环境变量边界
+
+| 变量 | 生效阶段 | 默认值或当前生产值 | 用途与约束 |
+| --- | --- | --- | --- |
+| `NEXT_PUBLIC_API_BASE_URL` | Web 镜像构建时 | 本地 `http://127.0.0.1:8010` | 浏览器可访问的 API 根地址。值会进入客户端 bundle，不能包含 secret；修改后必须重新构建 Web 镜像。 |
+| `AI_BIOWORKFLOW_API_HOST` | `src.api.server` 本地启动时 | `127.0.0.1` | 控制开发服务器监听地址。生产 API 镜像直接以 `0.0.0.0:8010` 启动，不读取该变量。 |
+| `AI_BIOWORKFLOW_API_PORT` | `src.api.server` 本地启动时 | `8010` | 控制开发服务器端口，允许 `1-65535`。生产容器端口固定为 `8010`。 |
+| `AI_BIOWORKFLOW_CORS_ORIGINS` | API 运行时 | 本地允许 `127.0.0.1:3000` 和 `localhost:3000` | 逗号分隔的浏览器 origin。仅在 Web 与 API 跨 origin 时需要显式设置。 |
+| `AI_BIOWORKFLOW_DB_PATH` | API 运行时 | 本地 `.cache/ai-bioworkflow.sqlite3`；容器 `/data/ai-bioworkflow/ai-bioworkflow.sqlite3` | SQLite 文件路径。生产路径位于 Compose `api_data` volume。 |
+| `DEEPSEEK_API_KEY` | Planner 运行时 | 未设置 | 仅自然语言规划需要；结构化编译必须在无 key 时正常工作。只放在服务端 `.env.prod` 或 secret store。 |
+| `WDL_VALIDATOR` | 编译运行时 | 本地 `auto`；生产 `miniwdl` | 可选值为 `auto`、`womtool`、`miniwdl`。生产镜像已安装 miniwdl。 |
+| `AI_BIOWORKFLOW_RUN_BACKEND` | API 运行时 | `disabled` | 控制真实 WDL execution backend。作品集 demo 保持禁用，不把编译 timeline 表述为真实 call 执行状态。 |
+
+`NEXT_PUBLIC_API_BASE_URL` 是构建时公开配置，`.env.prod` 是 API 容器运行时私有配置。
+两者不能互相替代，也不要把 API key、token 或私有网络地址写入任何 `NEXT_PUBLIC_*`
+变量。
+
+## 同源、CORS 与反向代理
+
+当前 ECS 方案使用单一 HTTPS 域名。浏览器请求同一域名的 `/api/*`，Caddy 再转发到
+Docker 网络内的 `api:8010`，因此不产生跨 origin 请求，也不需要为生产域名额外放宽
+CORS。
+
+只有 Web 与 API 使用不同的 scheme、hostname 或 port 时，才需要同时配置：
+
+1. 构建 Web 镜像时，将 `NEXT_PUBLIC_API_BASE_URL` 设置为公开 API 的 HTTPS 根地址。
+2. 在 API `.env.prod` 中，将 `AI_BIOWORKFLOW_CORS_ORIGINS` 设置为实际 Web origins。
+
+```text
+NEXT_PUBLIC_API_BASE_URL=https://api.example.com
+AI_BIOWORKFLOW_CORS_ORIGINS=https://portfolio.example.com,https://preview.example.com
+```
+
+origin 只写 scheme、hostname 和可选 port，不包含 path。CORS 只控制浏览器跨域访问，
+不是认证或限流机制，不应使用它保护匿名公开 API。
+
+## SQLite 与公开 demo 数据边界
+
+SQLite 当前保存 run、event、artifact 和 diagnostic，连接启用 WAL、busy timeout 和
+foreign keys，适合单机、单 API 服务的作品集流量。生产 Compose 的 `api_data` volume
+可以跨容器重建保留数据，但它不是备份，也不能替代主机或云盘级恢复策略。
+
+公开 demo 应遵守以下边界：
+
+- 保持单个 API replica，不让多个主机共享同一个 SQLite 文件。
+- 只使用可公开的示例请求，不保存真实受试者信息、凭证或私有数据路径。
+- 明确保留策略：选择周期性重置匿名 run history，或定期备份 `api_data` volume。
+- 执行数据重置前先停止 API 并备份数据库，避免在写入期间复制或替换 SQLite 文件。
+- 需要多副本、较高并发或长期可靠保存时，再实现并验证 PostgreSQL repository；当前仓库尚未提供可直接切换的 PostgreSQL adapter。
+
+当前 demo 没有登录、多租户、配额或 API rate limit。若在公开 API 中配置
+`DEEPSEEK_API_KEY`，匿名访问者也可能触发模型调用并产生费用；广泛公开前应在反向代理
+或应用层增加访问策略。仅展示确定性编译路径时，可以不配置该 key。
 
 ## 服务边界
 
@@ -170,6 +253,9 @@ AI_BIOWORKFLOW_CADDY_IMAGE=registry.cn-hangzhou.aliyuncs.com/your-namespace/cadd
 AI_BIOWORKFLOW_RUN_BACKEND=disabled
 WDL_VALIDATOR=miniwdl
 
+# Required only when Web and API are served from different browser origins.
+# AI_BIOWORKFLOW_CORS_ORIGINS=https://portfolio.example.com
+
 # Required only when natural-language planning is enabled.
 # DEEPSEEK_API_KEY=<your-deepseek-api-key>
 ```
@@ -219,7 +305,7 @@ ECS 还需要允许出站 HTTPS，用于拉取 ACR 镜像、访问 Docker regist
 {$AI_BIOWORKFLOW_SITE_ADDRESS} {
 	encode zstd gzip
 
-	@api path /api /api/* /docs /docs/* /redoc /redoc/* /openapi.json /health
+	@api path /api /api/* /docs /docs/* /redoc /redoc/* /openapi.json /health /version
 	reverse_proxy @api api:8010
 
 	reverse_proxy web:3000

--- a/docs/w6-portfolio-launch-plan.md
+++ b/docs/w6-portfolio-launch-plan.md
@@ -93,6 +93,8 @@ Natural Language / Structured Payload
 
 目标：让本地和公开部署的运行边界清晰可复现。
 
+实施入口：[部署与运维手册](./deployment.md)。
+
 需要完成：
 
 - 更新或补充部署文档，覆盖 FastAPI、Next.js、SQLite 展示库和 CORS。
@@ -159,8 +161,8 @@ README 应提供：
 | --- | --- | --- |
 | W6 portfolio landing polish | 已完成 | 首页和导航已形成 demo hub，稳定入口覆盖 RNA-seq 示例、run history、Catalog 和 API 文档。 |
 | W6 demo readiness | 已完成 | 工作台、历史、详情和 Catalog 已统一恢复入口，并补充 API 不可达等可读失败状态。 |
-| W6 architecture visuals | 进行中 | README 架构图和系统边界叙事正在收口，重点说明确定性编译链、服务复用与 DAG 结构语义。 |
-| W6 deployment docs | 待开始 | 等待架构叙事合并后处理部署、环境变量、CORS 和公开 demo 数据边界。 |
+| W6 architecture visuals | 已完成 | README 已补充确定性编译链、Web/service 边界和 DAG 结构语义。 |
+| W6 deployment docs | 进行中 | 部署手册正在收口本地/公开拓扑、环境变量、CORS、SQLite 持久化和匿名 demo 安全边界。 |
 | W6 screenshots and final QA | 待开始 | 在部署说明稳定后统一制作展示资产并执行最终前端 QA。 |
 
 如果某个 PR 只改文档，可以不运行前端 build，但应至少检查 Markdown 链接和文案一致性。涉及前端代码的 PR 应运行前端验证。


### PR DESCRIPTION
## Summary

- Add a deployment-mode overview for local development, the current single-host ECS demo, and optional split Web/API hosting.
- Consolidate build-time and runtime environment variable boundaries, including API binding, CORS, SQLite, Planner credentials, WDL validation, and execution backend settings.
- Document same-origin proxy behavior, SQLite persistence limits, anonymous demo retention, security, and model-cost considerations.
- Align deployment examples and README navigation, correct the documented Caddy `/version` route, and update W6 progress.

## Why

W6 portfolio polish needs one reproducible deployment reference that explains both how the current public demo is assembled and where its operational limits begin. The existing ECS runbook covered image publishing and rollback well, but local versus public topology, configuration phases, CORS, and SQLite ownership were spread across several files.

## Impact

Maintainers can now distinguish build-time public values from server-side secrets, deploy same-origin or split-origin setups without ambiguous CORS guidance, and evaluate the current SQLite demo without treating it as a multi-replica production datastore. Runtime behavior is unchanged.

## Verification

- Ran `scripts/dev_local.ps1 -DryRun -ApiPort 18010 -WebPort 13000`.
- Validated local Markdown links in README, the deployment guide, the W6 plan, and the deploy/app guide.
- Confirmed the documented Caddy API route matches `deploy/app/Caddyfile`.
- Ran `git diff --cached --check`.
- Frontend build not run because this PR changes documentation and commented environment examples only.