### PR TITLE
Add Reviewer node and provider boundary

### DIFF
--- a/docs/p2-reviewer-repair-plan.md
+++ b/docs/p2-reviewer-repair-plan.md
@@ -322,3 +322,21 @@ Windows PowerShell：
   不复用完整 Catalog Retriever payload，也不提供候选工具重选上下文。
 - Reviewer 尝试次数后续实现宜拆成 deterministic 与 Reviewer 计数，便于 run
   diagnostics 和前端展示区分两类修复来源。
+
+## 已确认的 P2.3 决策
+
+- Reviewer provider 默认禁用；只有调用方显式启用后才允许创建 provider 或调用
+  模型。显式启用但缺少 `DEEPSEEK_API_KEY` 时返回 no-op diagnostic，不把该情况
+  计为一次模型尝试。
+- Recipe Tool Plan 路径只向 Reviewer 传递当前 plan 实际使用并再次通过正式
+  Catalog 校验的 recipe、step 和 tool metadata。直接 Workflow IR 没有正式
+  Catalog provenance，因此使用空 `catalog_context`，不根据 task 名称、command
+  或 runtime 猜测工具。
+- Provider boundary 只返回经过 `ReviewerRepairResult` schema 校验的结果。raw
+  provider response 不进入 Compiler state；schema error 只保留不含原始值的字段
+  位置和校验消息。
+- Reviewer node 使用独立 `reviewer_attempt_count` 和结构化 request、patch、
+  rejection reason、diagnostics state。P2.3 不添加 Compiler Graph edge；
+  Analyzer failure routing 和 Checker failure routing 按后续 PR 分别接入。
+- Policy rejection 与 application failure 使用不同异常类别。前者表示越过 P2
+  allowlist，后者表示 policy 允许的 patch 无法安全应用到当前 Workflow IR。

--- a/docs/test-cases.md
+++ b/docs/test-cases.md
@@ -2451,7 +2451,7 @@ result 和 policy 边界。
 
 输入：
 
-- patch 尝试把 `/workflow/outputs/clean_r1` 替换为数组值。
+- patch 尝试把 `/workflow/outputs/clean_r1` 替换为包含敏感标记的数组值。
 
 执行：
 
@@ -2460,12 +2460,14 @@ result 和 policy 边界。
 期望输出：
 
 - 抛出 `ReviewerPatchApplicationError`，错误说明 candidate 不是合法 Workflow IR。
+- application error 不包含 Pydantic 原始输入或敏感标记。
 - 原始 workflow output 仍是字符串表达式。
 
 覆盖点：
 
 - patch 应用完成后仍必须重新通过 `WorkflowIR` schema validation。
 - schema-invalid candidate 不会被交给 graph re-entry。
+- schema re-validation failure 不会把 Workflow IR 字段值写入错误文本。
 
 ## `tests/test_reviewer_provider.py`
 
@@ -2698,6 +2700,25 @@ Graph edge；Analyzer 和 Checker routing 留给 P2.4。
 
 - `ReviewerPatchApplicationError` 与 `ReviewerPatchPolicyError` 是独立错误类别。
 - P2.4/P2.5 可以按真实失败阶段生成 diagnostics。
+
+### `test_reviewer_node_sanitizes_schema_application_failure`
+
+输入：
+
+- fake provider 返回 policy 允许但会产生 schema-invalid Workflow IR 的 patch。
+- 无效 workflow output 数组值包含敏感标记。
+
+期望输出：
+
+- status 为 `invalid_request`，并保存 parsed patch。
+- rejection reason 和 diagnostics 不包含敏感标记。
+- Workflow IR 不变，patch 未标记为 applied。
+
+覆盖点：
+
+- Pydantic `ValidationError` 的原始输入不会经 application error 进入 Reviewer
+  rejection state。
+- 保存 parsed patch 与错误信息脱敏是两个独立契约。
 
 ### `test_reviewer_node_builds_checker_request_without_routing_it`
 

--- a/docs/test-cases.md
+++ b/docs/test-cases.md
@@ -2484,6 +2484,7 @@ result 和 policy 边界。
 
 - Provider 返回合法 `ReviewerRepairResult`。
 - prompt 包含 failure stage 和当前 workflow approved tool。
+- prompt 明确 `patch` 和 `rejection_reason` 与 result status 的对应关系。
 - prompt 不包含未使用的 `fastp` metadata。
 
 覆盖点：
@@ -2643,6 +2644,26 @@ Graph edge；Analyzer 和 Checker routing 留给 P2.4。
 覆盖点：
 
 - 自定义 Provider 异常不能绕过 raw payload 不持久化边界。
+
+### `test_reviewer_node_sanitizes_request_construction_errors`
+
+输入：
+
+- 包含敏感标记的 invalid Workflow IR。
+- 包含敏感标记的 invalid Recipe Tool Plan。
+- 包含敏感标记且无法通过 Reviewer request schema 的 diagnostics。
+
+期望输出：
+
+- 三类 request 构造失败都返回 `invalid_request`，且不调用 provider。
+- Reviewer attempt count 保持为零。
+- rejection reason、diagnostics 和完整 node update 都不包含敏感标记。
+
+覆盖点：
+
+- Workflow IR、Recipe Tool Plan、planned tool call 和最终 request schema 的底层
+  异常文本不会进入 Reviewer state。
+- request 构造错误只保留固定上下文和异常类型。
 
 ### `test_reviewer_node_rejects_policy_violation_without_mutating_ir`
 

--- a/docs/test-cases.md
+++ b/docs/test-cases.md
@@ -2773,6 +2773,28 @@ Graph edge；Analyzer 和 Checker routing 留给 P2.4。
 - allowlist 内允许修复的 wiring、workflow outputs 和 task output values 不参与该
   immutable provenance 比较。
 
+### `test_recipe_plan_context_uses_canonical_scatter_steps`
+
+输入：
+
+- resolver 生成且 `steps`/`calls` 一致的 RNA-seq DEG scatter Workflow IR。
+- 保持兼容 `calls` 不变，但篡改 scatter body 中 canonical call wiring 的 Workflow
+  IR。
+
+期望输出：
+
+- 一致的 scatter Workflow IR 可以构建 approved context 并调用 provider。
+- 不一致的 Workflow IR 返回 `invalid_request`，Reviewer attempt count 保持为零，
+  且不调用 provider。
+
+覆盖点：
+
+- Reviewer provenance 递归从 canonical `workflow.steps` 提取普通及 scatter body
+  calls。
+- compatibility `workflow.calls` 必须与 canonical calls 的顺序、ID、task 和 inputs
+  完全一致。
+- approved Catalog context 不能由与 canonical DAG 脱节的旧版兼容视图授权。
+
 ## `tests/test_graph.py`
 
 该文件验证 Compiler Graph、Analyzer、Renderer 和 deterministic repairer 的交互。

--- a/docs/test-cases.md
+++ b/docs/test-cases.md
@@ -2467,6 +2467,270 @@ result 和 policy 边界。
 - patch 应用完成后仍必须重新通过 `WorkflowIR` schema validation。
 - schema-invalid candidate 不会被交给 graph re-entry。
 
+## `tests/test_reviewer_provider.py`
+
+该文件验证 P2.3 Reviewer provider boundary。Provider 负责把结构化
+`ReviewerRepairRequest` 渲染为 JSON-only prompt，并把响应解析为
+`ReviewerRepairResult`；raw response 不进入返回契约。
+
+### `test_llm_provider_renders_structured_request_and_parses_fenced_result`
+
+输入：
+
+- 包含 Workflow IR、Analyzer diagnostics 和单个 approved tool 的 Reviewer request。
+- fake LLM 返回 fenced JSON `no_action` result。
+
+期望输出：
+
+- Provider 返回合法 `ReviewerRepairResult`。
+- prompt 包含 failure stage 和当前 workflow approved tool。
+- prompt 不包含未使用的 `fastp` metadata。
+
+覆盖点：
+
+- Provider prompt 只使用结构化 request。
+- fenced JSON 可以解析，但 raw response 不作为结果字段返回。
+
+### `test_parse_reviewer_response_rejects_non_json_without_echoing_raw_text`
+
+输入：
+
+- 不包含 JSON object、且带有敏感标记的 provider 文本。
+
+期望输出：
+
+- 抛出 `ReviewerProviderResponseError`。
+- error message 不回显敏感标记。
+
+覆盖点：
+
+- 非 JSON provider 输出不会作为 diagnostic 原样持久化。
+
+### `test_parse_reviewer_response_rejects_invalid_schema_without_echoing_values`
+
+输入：
+
+- JSON object 使用 `patch_proposed`，但 patch 缺少必填字段并包含敏感值。
+
+期望输出：
+
+- 抛出 schema-classified `ReviewerProviderResponseError`。
+- error message 只包含字段位置和校验消息，不包含原始值。
+
+覆盖点：
+
+- Provider response schema failure 保留可诊断性，同时避免 raw payload 泄漏。
+
+### `test_default_reviewer_provider_requires_api_key`
+
+输入：
+
+- 显式创建默认 Reviewer provider。
+- `DEEPSEEK_API_KEY` 为空。
+
+期望输出：
+
+- 抛出 `ReviewerProviderUnavailableError`。
+
+覆盖点：
+
+- Reviewer 只有显式启用并具备凭证时才创建真实模型客户端。
+- 确定性结构化编译路径不因 P2.3 自动依赖 API key。
+
+## `tests/test_reviewer_node.py`
+
+该文件验证 P2.3 `reviewer_repair` compiler node 的独立行为。Node 已具备
+Provider 注入、request 构造、patch 校验和应用能力，但本阶段不添加 Compiler
+Graph edge；Analyzer 和 Checker routing 留给 P2.4。
+
+### `test_default_reviewer_node_is_callable_and_disabled`
+
+输入：
+
+- 默认禁用的 Reviewer node。
+- 一个调用即失败的 fake provider。
+
+期望输出：
+
+- 返回 `no_action` 和禁用 diagnostic。
+- attempt count 保持为零。
+- provider 没有被调用，Workflow IR update 不存在。
+
+覆盖点：
+
+- Reviewer 必须显式启用。
+- 默认结构化编译路径不会隐式触发模型调用。
+
+### `test_reviewer_node_returns_no_action_when_provider_is_unavailable`
+
+输入：
+
+- Reviewer 已启用。
+- provider factory 抛出 `ReviewerProviderUnavailableError`。
+
+期望输出：
+
+- 返回 `no_action` 和 unavailable diagnostic。
+- attempt count 保持为零，Workflow IR 不变。
+
+覆盖点：
+
+- 缺少 API key 或 provider 时安全降级，不把 provider setup 当作一次模型尝试。
+
+### `test_reviewer_node_applies_valid_patch_with_minimal_approved_context`
+
+输入：
+
+- 已解析的 RNA-seq reference preparation Recipe Tool Plan 和 Workflow IR。
+- fake provider 返回增加 workflow output 的合法 patch。
+- patch 只引用当前 plan 使用的 `salmon_index:1.9.0`。
+
+期望输出：
+
+- patch 应用到新的 Workflow IR candidate，原 state IR 不变。
+- Reviewer attempt count 增加到 1。
+- request 只包含当前 recipe，以及 `salmon_index`、`gtf_tx2gene` metadata。
+- Analyzer diagnostics 和旧 WDL state 为 graph re-entry 清空。
+
+覆盖点：
+
+- Node 串联 request、provider、result schema、policy 和 patch application。
+- 不复用完整 Catalog Retriever payload，也不暴露 raw provider response。
+
+### `test_reviewer_node_rejects_invalid_provider_output_without_raw_payload`
+
+输入：
+
+- fake provider 返回缺少 patch 必填字段、且包含敏感标记的 dict。
+
+期望输出：
+
+- status 为 `model_error`。
+- 不返回 Workflow IR update。
+- diagnostics 和完整 node update 都不包含敏感标记。
+
+覆盖点：
+
+- Node 会再次校验 provider boundary，即使 fake/custom provider 未遵守 Protocol。
+
+### `test_reviewer_node_records_provider_failure_as_model_error`
+
+输入：
+
+- fake provider 抛出 transport exception。
+
+期望输出：
+
+- status 为 `model_error`，attempt count 为 1。
+- diagnostics 记录 provider failure。
+- Workflow IR 不变。
+
+覆盖点：
+
+- 已发生的模型调用失败与 disabled/unavailable no-op 分开记录。
+
+### `test_reviewer_node_does_not_persist_typed_provider_error_payload`
+
+输入：
+
+- fake provider 抛出包含敏感标记的 `ReviewerProviderError`。
+
+期望输出：
+
+- status 为 `model_error`。
+- diagnostics 只记录异常类型，不记录异常原文或敏感标记。
+
+覆盖点：
+
+- 自定义 Provider 异常不能绕过 raw payload 不持久化边界。
+
+### `test_reviewer_node_rejects_policy_violation_without_mutating_ir`
+
+输入：
+
+- fake provider 提议替换 task runtime Docker image。
+
+期望输出：
+
+- status 为 `policy_rejected`。
+- 保存 parsed patch 和 rejection reason。
+- 不返回 Workflow IR update，原 runtime image 不变。
+
+覆盖点：
+
+- Provider 不能绕过 P2.1 policy。
+- 被拒绝 patch 仍以脱敏 parsed data 形式保留用于后续 observability。
+
+### `test_reviewer_node_classifies_application_failure_separately_from_policy`
+
+输入：
+
+- policy 允许但尝试 `replace` 不存在 workflow output 的 patch。
+
+期望输出：
+
+- status 为 `invalid_request`，而不是 `policy_rejected`。
+- rejection reason 说明 target 不存在。
+- Workflow IR 不变。
+
+覆盖点：
+
+- `ReviewerPatchApplicationError` 与 `ReviewerPatchPolicyError` 是独立错误类别。
+- P2.4/P2.5 可以按真实失败阶段生成 diagnostics。
+
+### `test_reviewer_node_builds_checker_request_without_routing_it`
+
+输入：
+
+- `failure_stage = checker`。
+- state 包含 WOMtool validation message。
+- fake provider 返回 `no_action`。
+
+期望输出：
+
+- Provider 收到 Checker request 和完整 validation message。
+- Node 不应用 patch。
+
+覆盖点：
+
+- P2.3 同时设计 Analyzer/Checker request contract。
+- Checker graph routing 仍明确留在后续 PR。
+
+### `test_direct_workflow_ir_request_uses_empty_catalog_context`
+
+输入：
+
+- 直接 Workflow IR，而不是 Recipe Tool Plan。
+
+期望输出：
+
+- request 的 approved recipes 和 tools 都为空。
+
+覆盖点：
+
+- 没有正式 plan provenance 时不从 task 名称、command 或 runtime 猜测 Catalog
+  metadata。
+- Reviewer 不能借由直接 IR 获得候选工具重选上下文。
+
+### `test_recipe_plan_context_rejects_modified_catalog_controlled_task`
+
+输入：
+
+- 合法 Recipe Tool Plan 对应的 Workflow IR。
+- 当前 IR 中的 task command 已偏离正式 Catalog resolver 结果。
+
+期望输出：
+
+- request 构造返回 `invalid_request`，且不调用 provider。
+- Reviewer attempt count 保持为零。
+
+覆盖点：
+
+- approved context 只有在当前 IR 的 workflow identity、task mapping、command、
+  input/output schema 和 runtime 仍具有正式 plan provenance 时才会提供。
+- allowlist 内允许修复的 wiring、workflow outputs 和 task output values 不参与该
+  immutable provenance 比较。
+
 ## `tests/test_graph.py`
 
 该文件验证 Compiler Graph、Analyzer、Renderer 和 deterministic repairer 的交互。

--- a/src/nodes/reviewer_repair.py
+++ b/src/nodes/reviewer_repair.py
@@ -21,7 +21,10 @@ from src.reviewer_provider import (
     coerce_reviewer_repair_result,
     make_default_reviewer_provider,
 )
-from src.reviewer_request import build_reviewer_repair_request
+from src.reviewer_request import (
+    ReviewerRequestBuildError,
+    build_reviewer_repair_request,
+)
 from src.reviewer_repair import (
     ReviewerFailureStage,
     ReviewerIRPatch,
@@ -92,13 +95,25 @@ def make_reviewer_repair_node(
                 tool_catalog=tool_catalog,
                 recipe_catalog=recipe_catalog,
             )
-        except Exception as exc:
+        except ReviewerRequestBuildError as exc:
             return _reviewer_update(
                 state,
                 status=ReviewerRepairStatus.INVALID_REQUEST,
                 rejection_reason=str(exc),
                 diagnostics=[f"Reviewer request could not be constructed: {exc}"],
                 message="Reviewer request construction failed.",
+            )
+        except Exception as exc:
+            safe_error = (
+                "Reviewer request construction failed with "
+                f"{exc.__class__.__name__}."
+            )
+            return _reviewer_update(
+                state,
+                status=ReviewerRepairStatus.INVALID_REQUEST,
+                rejection_reason=safe_error,
+                diagnostics=[safe_error],
+                message="Reviewer request construction failed unexpectedly.",
             )
 
         attempt_count = current_attempt_count + 1

--- a/src/nodes/reviewer_repair.py
+++ b/src/nodes/reviewer_repair.py
@@ -1,0 +1,255 @@
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from typing import Any
+
+from langchain_core.messages import AIMessage
+
+from src.catalog.loader import ToolCatalog
+from src.recipes.loader import RecipeCatalog
+from src.reviewer_patcher import (
+    ReviewerPatchApplicationError,
+    apply_reviewer_patch,
+)
+from src.reviewer_provider import (
+    DEFAULT_REVIEWER_MODEL,
+    ReviewerProviderError,
+    ReviewerProviderResponseError,
+    ReviewerProviderUnavailableError,
+    ReviewerRepairProvider,
+    coerce_reviewer_repair_result,
+    make_default_reviewer_provider,
+)
+from src.reviewer_request import build_reviewer_repair_request
+from src.reviewer_repair import (
+    ReviewerFailureStage,
+    ReviewerIRPatch,
+    ReviewerPatchPolicyError,
+    ReviewerRepairRequest,
+    ReviewerRepairStatus,
+)
+from src.state import WorkflowState
+
+
+ReviewerNode = Callable[[WorkflowState], dict[str, Any]]
+ReviewerProviderFactory = Callable[[str], ReviewerRepairProvider]
+logger = logging.getLogger(__name__)
+
+
+def reviewer_repair_node(state: WorkflowState) -> dict[str, Any]:
+    """Default-disabled Reviewer node retained for later Compiler Graph routing."""
+    return make_reviewer_repair_node()(state)
+
+
+def make_reviewer_repair_node(
+    *,
+    enabled: bool = False,
+    failure_stage: ReviewerFailureStage = ReviewerFailureStage.ANALYZER,
+    model: str = DEFAULT_REVIEWER_MODEL,
+    provider: ReviewerRepairProvider | None = None,
+    provider_factory: ReviewerProviderFactory = make_default_reviewer_provider,
+    tool_catalog: ToolCatalog | None = None,
+    recipe_catalog: RecipeCatalog | None = None,
+) -> ReviewerNode:
+    """Create a Reviewer node with injectable provider and Catalog dependencies."""
+
+    def node(state: WorkflowState) -> dict[str, Any]:
+        current_attempt_count = state.get("reviewer_attempt_count", 0)
+        if not enabled:
+            return _reviewer_update(
+                state,
+                status=ReviewerRepairStatus.NO_ACTION,
+                diagnostics=["Reviewer repair is disabled."],
+                message="Reviewer repair is disabled; no model call was made.",
+            )
+
+        try:
+            resolved_provider = (
+                provider if provider is not None else provider_factory(model)
+            )
+        except ReviewerProviderUnavailableError as exc:
+            return _reviewer_update(
+                state,
+                status=ReviewerRepairStatus.NO_ACTION,
+                diagnostics=[str(exc)],
+                message="Reviewer repair is unavailable; no model call was made.",
+            )
+        except Exception as exc:
+            return _reviewer_update(
+                state,
+                status=ReviewerRepairStatus.MODEL_ERROR,
+                diagnostics=[
+                    f"Reviewer provider setup failed with {exc.__class__.__name__}."
+                ],
+                message="Reviewer provider setup failed.",
+            )
+
+        try:
+            request = build_reviewer_repair_request(
+                state,
+                failure_stage=failure_stage,
+                tool_catalog=tool_catalog,
+                recipe_catalog=recipe_catalog,
+            )
+        except Exception as exc:
+            return _reviewer_update(
+                state,
+                status=ReviewerRepairStatus.INVALID_REQUEST,
+                rejection_reason=str(exc),
+                diagnostics=[f"Reviewer request could not be constructed: {exc}"],
+                message="Reviewer request construction failed.",
+            )
+
+        attempt_count = current_attempt_count + 1
+        try:
+            raw_result = resolved_provider.repair(request)
+            result = coerce_reviewer_repair_result(raw_result)
+        except ReviewerProviderResponseError as exc:
+            return _reviewer_update(
+                state,
+                status=ReviewerRepairStatus.MODEL_ERROR,
+                request=request,
+                attempt_count=attempt_count,
+                rejection_reason=str(exc),
+                diagnostics=[str(exc)],
+                message="Reviewer returned an invalid structured response.",
+            )
+        except ReviewerProviderError as exc:
+            safe_error = (
+                f"Reviewer provider failed with {exc.__class__.__name__}."
+            )
+            return _reviewer_update(
+                state,
+                status=ReviewerRepairStatus.MODEL_ERROR,
+                request=request,
+                attempt_count=attempt_count,
+                rejection_reason=safe_error,
+                diagnostics=[safe_error],
+                message="Reviewer provider failed.",
+            )
+        except Exception as exc:
+            return _reviewer_update(
+                state,
+                status=ReviewerRepairStatus.MODEL_ERROR,
+                request=request,
+                attempt_count=attempt_count,
+                rejection_reason=(
+                    f"Reviewer provider failed with {exc.__class__.__name__}."
+                ),
+                diagnostics=[
+                    f"Reviewer provider failed with {exc.__class__.__name__}."
+                ],
+                message="Reviewer provider failed unexpectedly.",
+            )
+
+        if result.status != ReviewerRepairStatus.PATCH_PROPOSED:
+            diagnostics = result.diagnostics or [
+                f"Reviewer returned {result.status.value} without additional diagnostics."
+            ]
+            return _reviewer_update(
+                state,
+                status=result.status,
+                request=request,
+                attempt_count=attempt_count,
+                rejection_reason=result.rejection_reason,
+                diagnostics=diagnostics,
+                message=f"Reviewer returned {result.status.value}.",
+            )
+
+        patch = result.patch
+        if patch is None:
+            return _reviewer_update(
+                state,
+                status=ReviewerRepairStatus.MODEL_ERROR,
+                request=request,
+                attempt_count=attempt_count,
+                diagnostics=["Reviewer patch_proposed result did not include a patch."],
+                message="Reviewer returned an invalid patch result.",
+            )
+
+        try:
+            patched_ir = apply_reviewer_patch(
+                request.workflow_ir,
+                patch,
+                catalog_context=request.catalog_context,
+            )
+        except ReviewerPatchPolicyError as exc:
+            return _reviewer_update(
+                state,
+                status=ReviewerRepairStatus.POLICY_REJECTED,
+                request=request,
+                patch=patch,
+                attempt_count=attempt_count,
+                rejection_reason=str(exc),
+                diagnostics=[*result.diagnostics, str(exc)],
+                message="Reviewer patch was rejected by policy.",
+            )
+        except ReviewerPatchApplicationError as exc:
+            return _reviewer_update(
+                state,
+                status=ReviewerRepairStatus.INVALID_REQUEST,
+                request=request,
+                patch=patch,
+                attempt_count=attempt_count,
+                rejection_reason=str(exc),
+                diagnostics=[*result.diagnostics, str(exc)],
+                message="Reviewer patch could not be applied to the current Workflow IR.",
+            )
+
+        logger.info("Reviewer patch was applied to a Workflow IR candidate.")
+        return {
+            **_reviewer_update(
+                state,
+                status=ReviewerRepairStatus.PATCH_PROPOSED,
+                request=request,
+                patch=patch,
+                attempt_count=attempt_count,
+                diagnostics=[
+                    *result.diagnostics,
+                    "Reviewer patch applied to Workflow IR candidate.",
+                ],
+                patch_applied=True,
+                message="Reviewer patch was applied to a Workflow IR candidate.",
+            ),
+            "workflow_ir": patched_ir.model_dump(mode="json"),
+            "analysis_errors": [],
+            "analysis_warnings": [],
+            "current_wdl": "",
+            "validation_message": "",
+            "is_valid": False,
+        }
+
+    return node
+
+
+def _reviewer_update(
+    state: WorkflowState,
+    *,
+    status: ReviewerRepairStatus,
+    diagnostics: list[str],
+    message: str,
+    request: ReviewerRepairRequest | None = None,
+    patch: ReviewerIRPatch | None = None,
+    rejection_reason: str | None = None,
+    attempt_count: int | None = None,
+    patch_applied: bool = False,
+) -> dict[str, Any]:
+    return {
+        "reviewer_attempt_count": (
+            state.get("reviewer_attempt_count", 0)
+            if attempt_count is None
+            else attempt_count
+        ),
+        "reviewer_repair_status": status.value,
+        "reviewer_repair_request": (
+            request.model_dump(mode="json") if request is not None else None
+        ),
+        "reviewer_ir_patch": (
+            patch.model_dump(mode="json") if patch is not None else None
+        ),
+        "reviewer_rejection_reason": rejection_reason,
+        "reviewer_diagnostics": diagnostics,
+        "reviewer_patch_applied": patch_applied,
+        "messages": [AIMessage(content=message)],
+    }

--- a/src/prompts.py
+++ b/src/prompts.py
@@ -46,3 +46,45 @@ def render_natural_language_planner_prompt(
         "User request:\n"
         f"{request.strip()}\n"
     )
+
+
+def render_reviewer_repair_prompt(request_payload: dict[str, Any]) -> str:
+    """Render a bounded Workflow IR repair request for the Reviewer provider."""
+    return (
+        "You are a constrained reviewer for a deterministic bioinformatics workflow compiler.\n\n"
+        "Rules:\n"
+        "- Return one JSON object only. Do not include markdown or prose outside JSON.\n"
+        "- Propose only Workflow IR patch actions allowed by the request constraints.\n"
+        "- Never generate or edit final WDL text.\n"
+        "- Never change tool or recipe catalogs, task commands, runtime settings, container "
+        "images, trust fields, or resource sizing.\n"
+        "- Use only recipe and tool references present in catalog_context.\n"
+        "- Treat workflow.steps as canonical. workflow.calls is compatibility-only and must "
+        "not be patched.\n"
+        "- For add/replace include a non-null value and omit from_path.\n"
+        "- For remove omit both value and from_path.\n"
+        "- For move include from_path and omit value.\n"
+        "- status must be one of patch_proposed, no_action, invalid_request, "
+        "policy_rejected, or model_error.\n"
+        "- If no safe patch is available, return status no_action with diagnostics.\n"
+        "- Do not echo secrets, credentials, or unrelated request data.\n\n"
+        "Output shape:\n"
+        "{\n"
+        '  "status": "patch_proposed",\n'
+        '  "patch": {\n'
+        '    "summary": "short repair summary",\n'
+        '    "actions": [\n'
+        '      {"operation": "add", "path": "/workflow/outputs/example", '
+        '"value": "call.output", '
+        '"reason": "why this repairs a referenced diagnostic"}\n'
+        "    ],\n"
+        '    "diagnostic_references": [],\n'
+        '    "catalog_references": [],\n'
+        '    "confidence": 0.0\n'
+        "  },\n"
+        '  "rejection_reason": null,\n'
+        '  "diagnostics": []\n'
+        "}\n\n"
+        "Structured Reviewer request:\n"
+        f"{json.dumps(request_payload, indent=2, ensure_ascii=False)}\n"
+    )

--- a/src/prompts.py
+++ b/src/prompts.py
@@ -66,9 +66,13 @@ def render_reviewer_repair_prompt(request_payload: dict[str, Any]) -> str:
         "- For move include from_path and omit value.\n"
         "- status must be one of patch_proposed, no_action, invalid_request, "
         "policy_rejected, or model_error.\n"
+        "- Set patch to an object only when status is patch_proposed; otherwise set patch "
+        "to null.\n"
+        "- Set rejection_reason to a non-empty string only when status is policy_rejected; "
+        "otherwise set rejection_reason to null.\n"
         "- If no safe patch is available, return status no_action with diagnostics.\n"
         "- Do not echo secrets, credentials, or unrelated request data.\n\n"
-        "Output shape:\n"
+        "patch_proposed example:\n"
         "{\n"
         '  "status": "patch_proposed",\n'
         '  "patch": {\n'

--- a/src/reviewer_patcher.py
+++ b/src/reviewer_patcher.py
@@ -16,7 +16,7 @@ from src.reviewer_repair import (
 from src.schema import WorkflowIR, coerce_workflow_ir
 
 
-class ReviewerPatchApplicationError(ReviewerPatchPolicyError):
+class ReviewerPatchApplicationError(ValueError):
     """Raised when a policy-allowed Reviewer patch cannot be applied safely."""
 
 

--- a/src/reviewer_patcher.py
+++ b/src/reviewer_patcher.py
@@ -42,7 +42,7 @@ def apply_reviewer_patch(
         return WorkflowIR.model_validate(candidate)
     except ValidationError as exc:
         raise ReviewerPatchApplicationError(
-            f"applied Reviewer patch produced invalid Workflow IR: {exc}"
+            "applied Reviewer patch produced invalid Workflow IR."
         ) from exc
 
 

--- a/src/reviewer_provider.py
+++ b/src/reviewer_provider.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import json
+import os
+import re
+from typing import Any, Protocol
+
+from langchain_deepseek import ChatDeepSeek
+from pydantic import SecretStr, ValidationError
+
+from src.prompts import render_reviewer_repair_prompt
+from src.reviewer_repair import ReviewerRepairRequest, ReviewerRepairResult
+
+
+DEFAULT_REVIEWER_MODEL = "deepseek-v4-pro"
+JSON_FENCE_PATTERN = re.compile(r"```(?:json)?\s*(.*?)\s*```", re.DOTALL | re.IGNORECASE)
+
+
+class ReviewerProviderError(ValueError):
+    """Base error for the Reviewer provider boundary."""
+
+
+class ReviewerProviderUnavailableError(ReviewerProviderError):
+    """Raised when Reviewer repair was enabled without an available provider."""
+
+
+class ReviewerProviderResponseError(ReviewerProviderError):
+    """Raised when a provider response cannot be parsed into the result contract."""
+
+
+class ReviewerLlm(Protocol):
+    def invoke(self, input: Any, *args: Any, **kwargs: Any) -> Any:
+        ...
+
+
+class ReviewerRepairProvider(Protocol):
+    def repair(self, request: ReviewerRepairRequest) -> ReviewerRepairResult:
+        ...
+
+
+class LlmReviewerRepairProvider:
+    """Invoke an LLM and return only a parsed Reviewer repair result."""
+
+    def __init__(self, llm: ReviewerLlm):
+        self._llm = llm
+
+    def repair(self, request: ReviewerRepairRequest) -> ReviewerRepairResult:
+        prompt = render_reviewer_repair_prompt(request.model_dump(mode="json"))
+        response = self._llm.invoke(prompt)
+        raw_content = str(getattr(response, "content", response))
+        return parse_reviewer_repair_response(raw_content)
+
+
+def make_default_reviewer_provider(
+    model: str = DEFAULT_REVIEWER_MODEL,
+) -> ReviewerRepairProvider:
+    """Create the default provider only when Reviewer repair is explicitly enabled."""
+    api_key_raw = os.environ.get("DEEPSEEK_API_KEY")
+    if not api_key_raw:
+        raise ReviewerProviderUnavailableError(
+            "Reviewer repair is enabled but DEEPSEEK_API_KEY is not configured."
+        )
+
+    return LlmReviewerRepairProvider(
+        ChatDeepSeek(
+            model=model,
+            api_key=SecretStr(api_key_raw),
+            base_url="https://api.deepseek.com",
+            temperature=0,
+        )
+    )
+
+
+def parse_reviewer_repair_response(text: str) -> ReviewerRepairResult:
+    """Parse a JSON-only provider response without retaining the raw text."""
+    candidate = _extract_json_candidate(text)
+    try:
+        payload = json.loads(candidate)
+    except json.JSONDecodeError as exc:
+        raise ReviewerProviderResponseError("Reviewer response is not valid JSON.") from exc
+    return coerce_reviewer_repair_result(payload)
+
+
+def coerce_reviewer_repair_result(value: Any) -> ReviewerRepairResult:
+    """Validate provider output while excluding raw values from error messages."""
+    try:
+        return ReviewerRepairResult.model_validate(value)
+    except ValidationError as exc:
+        details = "; ".join(
+            f"{_format_location(error['loc'])}: {error['msg']}"
+            for error in exc.errors(include_input=False, include_url=False)
+        )
+        raise ReviewerProviderResponseError(
+            f"Reviewer response does not match the result schema: {details}"
+        ) from exc
+
+
+def _extract_json_candidate(text: str) -> str:
+    stripped = text.strip()
+    fenced = JSON_FENCE_PATTERN.search(stripped)
+    if fenced:
+        return fenced.group(1).strip()
+
+    start = stripped.find("{")
+    end = stripped.rfind("}")
+    if start == -1 or end == -1 or end < start:
+        raise ReviewerProviderResponseError(
+            "Reviewer response does not contain a JSON object."
+        )
+    return stripped[start : end + 1]
+
+
+def _format_location(location: tuple[Any, ...]) -> str:
+    if not location:
+        return "result"
+    return ".".join(str(part) for part in location)

--- a/src/reviewer_request.py
+++ b/src/reviewer_request.py
@@ -1,0 +1,226 @@
+from __future__ import annotations
+
+from typing import Any
+
+from src.catalog.loader import ToolCatalog, load_tool_catalog
+from src.catalog.resolver import ToolCallPlan, resolve_tool_plan, validate_recipe_plan
+from src.recipes.loader import RecipeCatalog, load_recipe_catalog
+from src.reviewer_repair import (
+    ApprovedCatalogContext,
+    ApprovedRecipeMetadata,
+    ApprovedToolMetadata,
+    ReviewerFailureStage,
+    ReviewerRepairRequest,
+)
+from src.schema import WorkflowIR, coerce_workflow_ir
+from src.state import WorkflowState
+
+
+class ReviewerRequestBuildError(ValueError):
+    """Raised when a safe structured Reviewer request cannot be constructed."""
+
+
+def build_reviewer_repair_request(
+    state: WorkflowState,
+    *,
+    failure_stage: ReviewerFailureStage,
+    tool_catalog: ToolCatalog | None = None,
+    recipe_catalog: RecipeCatalog | None = None,
+) -> ReviewerRepairRequest:
+    """Build a structured request with only current-workflow approved metadata."""
+    try:
+        workflow_ir = coerce_workflow_ir(state.get("workflow_ir", {}))
+    except Exception as exc:
+        raise ReviewerRequestBuildError(f"Workflow IR is unavailable or invalid: {exc}") from exc
+
+    catalog_context = build_approved_catalog_context(
+        state.get("parsed_json", {}),
+        workflow_ir,
+        tool_catalog=tool_catalog,
+        recipe_catalog=recipe_catalog,
+    )
+    return ReviewerRepairRequest(
+        workflow_ir=workflow_ir,
+        failure_stage=failure_stage,
+        analysis_errors=list(state.get("analysis_errors", [])),
+        analysis_warnings=list(state.get("analysis_warnings", [])),
+        validation_message=state.get("validation_message", ""),
+        repair_history=_repair_history(state),
+        catalog_context=catalog_context,
+        attempt_index=state.get("reviewer_attempt_count", 0) + 1,
+    )
+
+
+def build_approved_catalog_context(
+    parsed_json: dict[str, Any],
+    workflow_ir: WorkflowIR,
+    *,
+    tool_catalog: ToolCatalog | None = None,
+    recipe_catalog: RecipeCatalog | None = None,
+) -> ApprovedCatalogContext:
+    """Select approved metadata only for recipe/tool calls proven by the current plan."""
+    if not _looks_like_tool_call_plan(parsed_json):
+        return ApprovedCatalogContext()
+
+    try:
+        plan = ToolCallPlan.model_validate(parsed_json)
+        resolved_tool_catalog = tool_catalog or load_tool_catalog()
+        resolved_recipe_catalog = recipe_catalog or load_recipe_catalog(
+            tool_catalog=resolved_tool_catalog
+        )
+        recipe = resolved_recipe_catalog.get(plan.workflow.recipe)
+        validate_recipe_plan(plan, recipe)
+        expected_workflow_ir = resolve_tool_plan(
+            plan,
+            resolved_recipe_catalog,
+            resolved_tool_catalog,
+        )
+    except Exception as exc:
+        raise ReviewerRequestBuildError(
+            f"Recipe Tool Plan cannot provide approved Reviewer context: {exc}"
+        ) from exc
+
+    workflow_calls = {call.id: call for call in workflow_ir.workflow.calls}
+    if len(workflow_calls) != len(workflow_ir.workflow.calls):
+        raise ReviewerRequestBuildError(
+            "Current Workflow IR contains duplicate compatibility call IDs."
+        )
+    planned_call_ids = {tool_call.id for tool_call in plan.workflow.tool_calls}
+    if set(workflow_calls) != planned_call_ids:
+        raise ReviewerRequestBuildError(
+            "Recipe Tool Plan calls do not match the current Workflow IR calls."
+        )
+    _validate_catalog_provenance(workflow_ir, expected_workflow_ir)
+
+    step_ids: list[str] = []
+    tool_ids: list[str] = []
+    tool_metadata: list[ApprovedToolMetadata] = []
+    seen_tools: set[tuple[str, str]] = set()
+
+    for tool_call in plan.workflow.tool_calls:
+        try:
+            step = recipe.step_by_id(tool_call.step)
+            if tool_call.tool not in step.allowed_tools:
+                raise ValueError(
+                    f"tool '{tool_call.tool}' is not approved for recipe step '{step.id}'"
+                )
+            tool = resolved_tool_catalog.get(tool_call.tool, tool_call.version)
+            workflow_call = workflow_calls[tool_call.id]
+            workflow_task = workflow_ir.tasks[workflow_call.task]
+        except Exception as exc:
+            raise ReviewerRequestBuildError(
+                f"Tool call '{tool_call.id}' cannot provide approved Reviewer context: {exc}"
+            ) from exc
+
+        if workflow_task.runtime.docker != tool.runtime.docker:
+            raise ReviewerRequestBuildError(
+                f"Tool call '{tool_call.id}' runtime does not match its approved Catalog entry."
+            )
+
+        if tool_call.step not in step_ids:
+            step_ids.append(tool_call.step)
+        if tool_call.tool not in tool_ids:
+            tool_ids.append(tool_call.tool)
+
+        tool_key = (tool.id, tool.version)
+        if tool_key in seen_tools:
+            continue
+        seen_tools.add(tool_key)
+        tool_metadata.append(
+            ApprovedToolMetadata(
+                tool_id=tool.id,
+                version=tool.version,
+                inputs=sorted(tool.inputs),
+                outputs=sorted(tool.outputs),
+                trust_status="catalog-approved",
+                runtime_docker=tool.runtime.docker,
+            )
+        )
+
+    return ApprovedCatalogContext(
+        recipes=[
+            ApprovedRecipeMetadata(
+                recipe_id=recipe.id,
+                step_ids=step_ids,
+                tool_ids=tool_ids,
+            )
+        ],
+        tools=tool_metadata,
+    )
+
+
+def _repair_history(state: WorkflowState) -> list[str]:
+    history = list(state.get("repair_actions", []))
+    previous_patch = state.get("reviewer_ir_patch")
+    if isinstance(previous_patch, dict) and previous_patch.get("summary"):
+        history.append(f"Reviewer patch: {previous_patch['summary']}")
+    previous_rejection = state.get("reviewer_rejection_reason")
+    if previous_rejection:
+        history.append(f"Reviewer rejection: {previous_rejection}")
+    return history
+
+
+def _validate_catalog_provenance(
+    workflow_ir: WorkflowIR,
+    expected_workflow_ir: WorkflowIR,
+) -> None:
+    """Verify fields outside the patch allowlist still match formal plan resolution."""
+    if (
+        workflow_ir.version != expected_workflow_ir.version
+        or workflow_ir.workflow.name != expected_workflow_ir.workflow.name
+        or workflow_ir.workflow.inputs != expected_workflow_ir.workflow.inputs
+    ):
+        raise ReviewerRequestBuildError(
+            "Current Workflow IR does not match Recipe Tool Plan provenance."
+        )
+
+    if set(workflow_ir.tasks) != set(expected_workflow_ir.tasks):
+        raise ReviewerRequestBuildError(
+            "Current Workflow IR tasks do not match Recipe Tool Plan provenance."
+        )
+
+    current_calls = {call.id: call for call in workflow_ir.workflow.calls}
+    expected_calls = {
+        call.id: call for call in expected_workflow_ir.workflow.calls
+    }
+    for call_id, expected_call in expected_calls.items():
+        if current_calls[call_id].task != expected_call.task:
+            raise ReviewerRequestBuildError(
+                f"Tool call '{call_id}' task does not match Recipe Tool Plan provenance."
+            )
+
+    for task_name, expected_task in expected_workflow_ir.tasks.items():
+        current_task = workflow_ir.tasks[task_name]
+        if _catalog_controlled_task_data(current_task) != _catalog_controlled_task_data(
+            expected_task
+        ):
+            raise ReviewerRequestBuildError(
+                f"Task '{task_name}' Catalog-controlled fields do not match "
+                "Recipe Tool Plan provenance."
+            )
+
+
+def _catalog_controlled_task_data(task: Any) -> dict[str, Any]:
+    return {
+        "inputs": task.inputs,
+        "command": task.command,
+        "outputs": {
+            output_name: {
+                "type": output.type,
+                "tags": output.tags,
+            }
+            for output_name, output in task.outputs.items()
+        },
+        "runtime": task.runtime.model_dump(mode="json"),
+    }
+
+
+def _looks_like_tool_call_plan(value: dict[str, Any]) -> bool:
+    if not isinstance(value, dict):
+        return False
+    workflow = value.get("workflow")
+    return (
+        isinstance(workflow, dict)
+        and "recipe" in workflow
+        and "tool_calls" in workflow
+    )

--- a/src/reviewer_request.py
+++ b/src/reviewer_request.py
@@ -12,7 +12,7 @@ from src.reviewer_repair import (
     ReviewerFailureStage,
     ReviewerRepairRequest,
 )
-from src.schema import WorkflowIR, coerce_workflow_ir
+from src.schema import CallSpec, ScatterSpec, WorkflowIR, coerce_workflow_ir
 from src.state import WorkflowState
 
 
@@ -83,17 +83,22 @@ def build_approved_catalog_context(
             f"({exc.__class__.__name__})."
         ) from exc
 
-    workflow_calls = {call.id: call for call in workflow_ir.workflow.calls}
-    if len(workflow_calls) != len(workflow_ir.workflow.calls):
-        raise ReviewerRequestBuildError(
-            "Current Workflow IR contains duplicate compatibility call IDs."
-        )
+    workflow_calls = _canonical_call_map(workflow_ir, label="Current")
+    expected_workflow_calls = _canonical_call_map(
+        expected_workflow_ir,
+        label="Resolved",
+    )
     planned_call_ids = {tool_call.id for tool_call in plan.workflow.tool_calls}
     if set(workflow_calls) != planned_call_ids:
         raise ReviewerRequestBuildError(
-            "Recipe Tool Plan calls do not match the current Workflow IR calls."
+            "Recipe Tool Plan calls do not match the current canonical Workflow IR steps."
         )
-    _validate_catalog_provenance(workflow_ir, expected_workflow_ir)
+    _validate_catalog_provenance(
+        workflow_ir,
+        expected_workflow_ir,
+        workflow_calls=workflow_calls,
+        expected_workflow_calls=expected_workflow_calls,
+    )
 
     step_ids: list[str] = []
     tool_ids: list[str] = []
@@ -167,6 +172,9 @@ def _repair_history(state: WorkflowState) -> list[str]:
 def _validate_catalog_provenance(
     workflow_ir: WorkflowIR,
     expected_workflow_ir: WorkflowIR,
+    *,
+    workflow_calls: dict[str, CallSpec],
+    expected_workflow_calls: dict[str, CallSpec],
 ) -> None:
     """Verify fields outside the patch allowlist still match formal plan resolution."""
     if (
@@ -183,12 +191,8 @@ def _validate_catalog_provenance(
             "Current Workflow IR tasks do not match Recipe Tool Plan provenance."
         )
 
-    current_calls = {call.id: call for call in workflow_ir.workflow.calls}
-    expected_calls = {
-        call.id: call for call in expected_workflow_ir.workflow.calls
-    }
-    for call_id, expected_call in expected_calls.items():
-        if current_calls[call_id].task != expected_call.task:
+    for call_id, expected_call in expected_workflow_calls.items():
+        if workflow_calls[call_id].task != expected_call.task:
             raise ReviewerRequestBuildError(
                 f"Tool call '{call_id}' task does not match Recipe Tool Plan provenance."
             )
@@ -202,6 +206,37 @@ def _validate_catalog_provenance(
                 f"Task '{task_name}' Catalog-controlled fields do not match "
                 "Recipe Tool Plan provenance."
             )
+
+
+def _canonical_call_map(
+    workflow_ir: WorkflowIR,
+    *,
+    label: str,
+) -> dict[str, CallSpec]:
+    canonical_calls = _flatten_canonical_calls(workflow_ir.workflow.steps)
+    call_map = {call.id: call for call in canonical_calls}
+    if len(call_map) != len(canonical_calls):
+        raise ReviewerRequestBuildError(
+            f"{label} Workflow IR contains duplicate canonical call IDs."
+        )
+
+    if workflow_ir.workflow.calls != canonical_calls:
+        raise ReviewerRequestBuildError(
+            f"{label} Workflow IR compatibility calls do not match canonical workflow steps."
+        )
+    return call_map
+
+
+def _flatten_canonical_calls(
+    steps: list[CallSpec | ScatterSpec],
+) -> list[CallSpec]:
+    calls: list[CallSpec] = []
+    for step in steps:
+        if isinstance(step, CallSpec):
+            calls.append(step)
+        else:
+            calls.extend(_flatten_canonical_calls(step.body))
+    return calls
 
 
 def _catalog_controlled_task_data(task: Any) -> dict[str, Any]:

--- a/src/reviewer_request.py
+++ b/src/reviewer_request.py
@@ -31,7 +31,9 @@ def build_reviewer_repair_request(
     try:
         workflow_ir = coerce_workflow_ir(state.get("workflow_ir", {}))
     except Exception as exc:
-        raise ReviewerRequestBuildError(f"Workflow IR is unavailable or invalid: {exc}") from exc
+        raise ReviewerRequestBuildError(
+            f"Workflow IR is unavailable or invalid ({exc.__class__.__name__})."
+        ) from exc
 
     catalog_context = build_approved_catalog_context(
         state.get("parsed_json", {}),
@@ -77,7 +79,8 @@ def build_approved_catalog_context(
         )
     except Exception as exc:
         raise ReviewerRequestBuildError(
-            f"Recipe Tool Plan cannot provide approved Reviewer context: {exc}"
+            "Recipe Tool Plan cannot provide approved Reviewer context "
+            f"({exc.__class__.__name__})."
         ) from exc
 
     workflow_calls = {call.id: call for call in workflow_ir.workflow.calls}
@@ -109,7 +112,8 @@ def build_approved_catalog_context(
             workflow_task = workflow_ir.tasks[workflow_call.task]
         except Exception as exc:
             raise ReviewerRequestBuildError(
-                f"Tool call '{tool_call.id}' cannot provide approved Reviewer context: {exc}"
+                "A planned tool call cannot provide approved Reviewer context "
+                f"({exc.__class__.__name__})."
             ) from exc
 
         if workflow_task.runtime.docker != tool.runtime.docker:

--- a/src/services/workflow_service.py
+++ b/src/services/workflow_service.py
@@ -160,6 +160,13 @@ def build_initial_state(
         "error_count": 0,
         "repair_count": 0,
         "repair_actions": [],
+        "reviewer_attempt_count": 0,
+        "reviewer_repair_status": None,
+        "reviewer_repair_request": None,
+        "reviewer_ir_patch": None,
+        "reviewer_rejection_reason": None,
+        "reviewer_diagnostics": [],
+        "reviewer_patch_applied": False,
         "is_valid": False,
     }
 
@@ -473,5 +480,19 @@ def _merge_state(state: WorkflowState, update: Mapping[str, Any]) -> None:
             state["repair_count"] = value
         elif key == "repair_actions":
             state["repair_actions"] = value
+        elif key == "reviewer_attempt_count":
+            state["reviewer_attempt_count"] = value
+        elif key == "reviewer_repair_status":
+            state["reviewer_repair_status"] = value
+        elif key == "reviewer_repair_request":
+            state["reviewer_repair_request"] = value
+        elif key == "reviewer_ir_patch":
+            state["reviewer_ir_patch"] = value
+        elif key == "reviewer_rejection_reason":
+            state["reviewer_rejection_reason"] = value
+        elif key == "reviewer_diagnostics":
+            state["reviewer_diagnostics"] = value
+        elif key == "reviewer_patch_applied":
+            state["reviewer_patch_applied"] = value
         elif key == "is_valid":
             state["is_valid"] = value

--- a/src/state.py
+++ b/src/state.py
@@ -34,6 +34,15 @@ class WorkflowState(TypedDict):
 
     # 记录最近一次 IR repairer 执行的具体修复动作
     repair_actions: list[str]
+
+    # Reviewer repair 使用独立计数和结构化结果，避免与 deterministic repair 混淆
+    reviewer_attempt_count: int
+    reviewer_repair_status: str | None
+    reviewer_repair_request: dict | None
+    reviewer_ir_patch: dict | None
+    reviewer_rejection_reason: str | None
+    reviewer_diagnostics: list[str]
+    reviewer_patch_applied: bool
     
     # 用一个明确的布尔值来记录校验状态，True 代表校验通过，False 代表校验失败
     is_valid: bool

--- a/tests/test_reviewer_node.py
+++ b/tests/test_reviewer_node.py
@@ -428,6 +428,56 @@ class ReviewerNodeTests(unittest.TestCase):
         self.assertIn("Catalog-controlled", update["reviewer_rejection_reason"])
         self.assertEqual(provider.requests, [])
 
+    def test_recipe_plan_context_uses_canonical_scatter_steps(self):
+        plan = json.loads(
+            (REPO_ROOT / "examples" / "rnaseq_deg_recipe_plan.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        workflow_ir = resolve_tool_plan(
+            plan,
+            self.recipe_catalog,
+            self.tool_catalog,
+        ).model_dump(mode="json")
+        self.assertEqual(workflow_ir["workflow"]["steps"][0]["kind"], "scatter")
+
+        valid_provider = RecordingReviewerProvider(
+            {
+                "status": "no_action",
+                "diagnostics": ["Canonical scatter steps are consistent."],
+            }
+        )
+        valid_state = build_initial_state(copy.deepcopy(plan))
+        valid_state["workflow_ir"] = copy.deepcopy(workflow_ir)
+
+        valid_update = self.make_node(valid_provider)(valid_state)
+
+        self.assertEqual(
+            valid_update["reviewer_repair_status"],
+            ReviewerRepairStatus.NO_ACTION.value,
+        )
+        self.assertEqual(len(valid_provider.requests), 1)
+
+        invalid_provider = RecordingReviewerProvider({"status": "no_action"})
+        invalid_state = build_initial_state(copy.deepcopy(plan))
+        invalid_state["workflow_ir"] = copy.deepcopy(workflow_ir)
+        invalid_state["workflow_ir"]["workflow"]["steps"][0]["body"][0][
+            "inputs"
+        ]["r1"] = "tampered_input"
+
+        invalid_update = self.make_node(invalid_provider)(invalid_state)
+
+        self.assertEqual(
+            invalid_update["reviewer_repair_status"],
+            ReviewerRepairStatus.INVALID_REQUEST.value,
+        )
+        self.assertEqual(invalid_update["reviewer_attempt_count"], 0)
+        self.assertIn(
+            "compatibility calls do not match canonical workflow steps",
+            invalid_update["reviewer_rejection_reason"],
+        )
+        self.assertEqual(invalid_provider.requests, [])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_reviewer_node.py
+++ b/tests/test_reviewer_node.py
@@ -330,6 +330,41 @@ class ReviewerNodeTests(unittest.TestCase):
         self.assertFalse(update["reviewer_patch_applied"])
         self.assertNotIn("workflow_ir", update)
 
+    def test_reviewer_node_sanitizes_schema_application_failure(self):
+        state = self.sample_state()
+        output_name = next(iter(state["workflow_ir"]["workflow"]["outputs"]))
+        provider = RecordingReviewerProvider(
+            {
+                "status": "patch_proposed",
+                "patch": {
+                    "summary": "Propose an invalid workflow output value type.",
+                    "actions": [
+                        {
+                            "operation": "replace",
+                            "path": f"/workflow/outputs/{output_name}",
+                            "value": ["TOP_SECRET"],
+                            "reason": "Exercise schema rejection diagnostics.",
+                        }
+                    ],
+                },
+            }
+        )
+
+        update = self.make_node(provider)(state)
+
+        self.assertEqual(
+            update["reviewer_repair_status"],
+            ReviewerRepairStatus.INVALID_REQUEST.value,
+        )
+        self.assertIsNotNone(update["reviewer_ir_patch"])
+        self.assertNotIn("TOP_SECRET", update["reviewer_rejection_reason"])
+        self.assertNotIn(
+            "TOP_SECRET",
+            json.dumps(update["reviewer_diagnostics"]),
+        )
+        self.assertFalse(update["reviewer_patch_applied"])
+        self.assertNotIn("workflow_ir", update)
+
     def test_reviewer_node_builds_checker_request_without_routing_it(self):
         provider = RecordingReviewerProvider(
             {

--- a/tests/test_reviewer_node.py
+++ b/tests/test_reviewer_node.py
@@ -1,0 +1,363 @@
+import copy
+import json
+import unittest
+from pathlib import Path
+
+from src.catalog.loader import load_tool_catalog
+from src.catalog.resolver import resolve_tool_plan
+from src.nodes.reviewer_repair import (
+    make_reviewer_repair_node,
+    reviewer_repair_node,
+)
+from src.recipes.loader import load_recipe_catalog
+from src.reviewer_provider import (
+    ReviewerProviderError,
+    ReviewerProviderUnavailableError,
+)
+from src.reviewer_request import build_reviewer_repair_request
+from src.reviewer_repair import ReviewerFailureStage, ReviewerRepairStatus
+from src.services.workflow_service import build_initial_state
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+class RecordingReviewerProvider:
+    def __init__(self, result):
+        self.result = result
+        self.requests = []
+
+    def repair(self, request):
+        self.requests.append(request)
+        return self.result
+
+
+class FailingReviewerProvider:
+    def __init__(self):
+        self.call_count = 0
+
+    def repair(self, request):
+        self.call_count += 1
+        raise AssertionError("disabled Reviewer provider must not be called")
+
+
+class RaisingReviewerProvider:
+    def repair(self, request):
+        raise RuntimeError("TOP_SECRET raw provider failure")
+
+
+class RaisingTypedReviewerProvider:
+    def repair(self, request):
+        raise ReviewerProviderError("TOP_SECRET provider failure")
+
+
+class ReviewerNodeTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.tool_catalog = load_tool_catalog()
+        cls.recipe_catalog = load_recipe_catalog(tool_catalog=cls.tool_catalog)
+        cls.plan = json.loads(
+            (
+                REPO_ROOT / "examples" / "rnaseq_reference_prep_recipe_plan.json"
+            ).read_text(encoding="utf-8")
+        )
+        cls.workflow_ir = resolve_tool_plan(
+            cls.plan,
+            cls.recipe_catalog,
+            cls.tool_catalog,
+        ).model_dump(mode="json")
+
+    def sample_state(self):
+        state = build_initial_state(copy.deepcopy(self.plan))
+        state["workflow_ir"] = copy.deepcopy(self.workflow_ir)
+        state["analysis_errors"] = ["workflow output is missing"]
+        state["analysis_warnings"] = ["review output wiring"]
+        return state
+
+    def make_node(self, provider, **kwargs):
+        return make_reviewer_repair_node(
+            enabled=True,
+            provider=provider,
+            tool_catalog=self.tool_catalog,
+            recipe_catalog=self.recipe_catalog,
+            **kwargs,
+        )
+
+    def test_default_reviewer_node_is_callable_and_disabled(self):
+        self.assertTrue(callable(reviewer_repair_node))
+        provider = FailingReviewerProvider()
+        state = self.sample_state()
+
+        update = make_reviewer_repair_node(
+            enabled=False,
+            provider=provider,
+        )(state)
+
+        self.assertEqual(
+            update["reviewer_repair_status"],
+            ReviewerRepairStatus.NO_ACTION.value,
+        )
+        self.assertEqual(update["reviewer_attempt_count"], 0)
+        self.assertIsNone(update["reviewer_repair_request"])
+        self.assertFalse(update["reviewer_patch_applied"])
+        self.assertNotIn("workflow_ir", update)
+        self.assertEqual(provider.call_count, 0)
+
+    def test_reviewer_node_returns_no_action_when_provider_is_unavailable(self):
+        def unavailable_provider_factory(model):
+            raise ReviewerProviderUnavailableError("Reviewer provider unavailable.")
+
+        state = self.sample_state()
+        update = make_reviewer_repair_node(
+            enabled=True,
+            provider_factory=unavailable_provider_factory,
+        )(state)
+
+        self.assertEqual(
+            update["reviewer_repair_status"],
+            ReviewerRepairStatus.NO_ACTION.value,
+        )
+        self.assertEqual(update["reviewer_attempt_count"], 0)
+        self.assertIn("unavailable", update["reviewer_diagnostics"][0])
+        self.assertNotIn("workflow_ir", update)
+
+    def test_reviewer_node_applies_valid_patch_with_minimal_approved_context(self):
+        provider = RecordingReviewerProvider(
+            {
+                "status": "patch_proposed",
+                "patch": {
+                    "summary": "Expose a validated index output alias.",
+                    "actions": [
+                        {
+                            "operation": "add",
+                            "path": "/workflow/outputs/index_copy",
+                            "value": "index.index_archive",
+                            "reason": "Use an existing call output.",
+                        }
+                    ],
+                    "diagnostic_references": ["workflow output is missing"],
+                    "catalog_references": ["salmon_index:1.9.0"],
+                    "confidence": 0.9,
+                },
+                "diagnostics": ["Patch uses only existing Workflow IR values."],
+            }
+        )
+        state = self.sample_state()
+
+        update = self.make_node(provider)(state)
+
+        self.assertTrue(update["reviewer_patch_applied"])
+        self.assertEqual(update["reviewer_attempt_count"], 1)
+        self.assertEqual(
+            update["reviewer_repair_status"],
+            ReviewerRepairStatus.PATCH_PROPOSED.value,
+        )
+        self.assertEqual(
+            update["workflow_ir"]["workflow"]["outputs"]["index_copy"],
+            "index.index_archive",
+        )
+        self.assertNotIn(
+            "index_copy",
+            state["workflow_ir"]["workflow"]["outputs"],
+        )
+        self.assertEqual(update["analysis_errors"], [])
+        self.assertEqual(len(provider.requests), 1)
+
+        request = provider.requests[0]
+        self.assertEqual(request.attempt_index, 1)
+        self.assertEqual(
+            [recipe.recipe_id for recipe in request.catalog_context.recipes],
+            ["rnaseq_reference_preparation"],
+        )
+        self.assertEqual(
+            {tool.tool_id for tool in request.catalog_context.tools},
+            {"salmon_index", "gtf_tx2gene"},
+        )
+        self.assertNotIn(
+            "fastp",
+            json.dumps(update["reviewer_repair_request"]),
+        )
+        self.assertNotIn("raw_response", update)
+
+    def test_reviewer_node_rejects_invalid_provider_output_without_raw_payload(self):
+        provider = RecordingReviewerProvider(
+            {
+                "status": "patch_proposed",
+                "patch": {
+                    "secret_marker": "TOP_SECRET",
+                },
+            }
+        )
+        state = self.sample_state()
+
+        update = self.make_node(provider)(state)
+
+        self.assertEqual(
+            update["reviewer_repair_status"],
+            ReviewerRepairStatus.MODEL_ERROR.value,
+        )
+        self.assertEqual(update["reviewer_attempt_count"], 1)
+        self.assertFalse(update["reviewer_patch_applied"])
+        self.assertNotIn("workflow_ir", update)
+        self.assertNotIn("TOP_SECRET", json.dumps(update, default=str))
+
+    def test_reviewer_node_records_provider_failure_as_model_error(self):
+        state = self.sample_state()
+
+        update = self.make_node(RaisingReviewerProvider())(state)
+
+        self.assertEqual(
+            update["reviewer_repair_status"],
+            ReviewerRepairStatus.MODEL_ERROR.value,
+        )
+        self.assertEqual(update["reviewer_attempt_count"], 1)
+        self.assertIn("RuntimeError", update["reviewer_diagnostics"][0])
+        self.assertNotIn("TOP_SECRET", json.dumps(update, default=str))
+        self.assertFalse(update["reviewer_patch_applied"])
+        self.assertNotIn("workflow_ir", update)
+
+    def test_reviewer_node_does_not_persist_typed_provider_error_payload(self):
+        state = self.sample_state()
+
+        update = self.make_node(RaisingTypedReviewerProvider())(state)
+
+        self.assertEqual(
+            update["reviewer_repair_status"],
+            ReviewerRepairStatus.MODEL_ERROR.value,
+        )
+        self.assertIn("ReviewerProviderError", update["reviewer_diagnostics"][0])
+        self.assertNotIn("TOP_SECRET", json.dumps(update, default=str))
+
+    def test_reviewer_node_rejects_policy_violation_without_mutating_ir(self):
+        provider = RecordingReviewerProvider(
+            {
+                "status": "patch_proposed",
+                "patch": {
+                    "summary": "Attempt a forbidden runtime edit.",
+                    "actions": [
+                        {
+                            "operation": "replace",
+                            "path": "/tasks/salmon_index_index/runtime/docker",
+                            "value": "ubuntu:22.04",
+                            "reason": "Reviewer must not change runtime images.",
+                        }
+                    ],
+                },
+            }
+        )
+        state = self.sample_state()
+
+        update = self.make_node(provider)(state)
+
+        self.assertEqual(
+            update["reviewer_repair_status"],
+            ReviewerRepairStatus.POLICY_REJECTED.value,
+        )
+        self.assertIsNotNone(update["reviewer_ir_patch"])
+        self.assertIn("forbidden", update["reviewer_rejection_reason"])
+        self.assertFalse(update["reviewer_patch_applied"])
+        self.assertNotIn("workflow_ir", update)
+        self.assertEqual(
+            state["workflow_ir"]["tasks"]["salmon_index_index"]["runtime"]["docker"],
+            self.tool_catalog.get("salmon_index", "1.9.0").runtime.docker,
+        )
+
+    def test_reviewer_node_classifies_application_failure_separately_from_policy(self):
+        provider = RecordingReviewerProvider(
+            {
+                "status": "patch_proposed",
+                "patch": {
+                    "summary": "Replace a missing workflow output.",
+                    "actions": [
+                        {
+                            "operation": "replace",
+                            "path": "/workflow/outputs/missing_output",
+                            "value": "index.index_archive",
+                            "reason": "The target must already exist for replace.",
+                        }
+                    ],
+                },
+            }
+        )
+        state = self.sample_state()
+
+        update = self.make_node(provider)(state)
+
+        self.assertEqual(
+            update["reviewer_repair_status"],
+            ReviewerRepairStatus.INVALID_REQUEST.value,
+        )
+        self.assertIn("does not exist", update["reviewer_rejection_reason"])
+        self.assertNotEqual(
+            update["reviewer_repair_status"],
+            ReviewerRepairStatus.POLICY_REJECTED.value,
+        )
+        self.assertFalse(update["reviewer_patch_applied"])
+        self.assertNotIn("workflow_ir", update)
+
+    def test_reviewer_node_builds_checker_request_without_routing_it(self):
+        provider = RecordingReviewerProvider(
+            {
+                "status": "no_action",
+                "diagnostics": ["Checker failure has no safe IR-only repair."],
+            }
+        )
+        state = self.sample_state()
+        state["validation_message"] = "WOMtool rejected the generated WDL."
+
+        update = self.make_node(
+            provider,
+            failure_stage=ReviewerFailureStage.CHECKER,
+        )(state)
+
+        self.assertEqual(
+            update["reviewer_repair_status"],
+            ReviewerRepairStatus.NO_ACTION.value,
+        )
+        self.assertFalse(update["reviewer_patch_applied"])
+        self.assertNotIn("workflow_ir", update)
+        request = provider.requests[0]
+        self.assertEqual(request.failure_stage, ReviewerFailureStage.CHECKER)
+        self.assertEqual(
+            request.validation_message,
+            "WOMtool rejected the generated WDL.",
+        )
+
+    def test_direct_workflow_ir_request_uses_empty_catalog_context(self):
+        state = self.sample_state()
+        state["parsed_json"] = copy.deepcopy(state["workflow_ir"])
+
+        request = build_reviewer_repair_request(
+            state,
+            failure_stage=ReviewerFailureStage.ANALYZER,
+            tool_catalog=self.tool_catalog,
+            recipe_catalog=self.recipe_catalog,
+        )
+
+        self.assertEqual(request.catalog_context.recipes, [])
+        self.assertEqual(request.catalog_context.tools, [])
+
+    def test_recipe_plan_context_rejects_modified_catalog_controlled_task(self):
+        provider = RecordingReviewerProvider(
+            {
+                "status": "no_action",
+                "diagnostics": ["No repair needed."],
+            }
+        )
+        state = self.sample_state()
+        task_name = state["workflow_ir"]["workflow"]["calls"][0]["task"]
+        state["workflow_ir"]["tasks"][task_name]["command"] = "echo tampered"
+
+        update = self.make_node(provider)(state)
+
+        self.assertEqual(
+            update["reviewer_repair_status"],
+            ReviewerRepairStatus.INVALID_REQUEST.value,
+        )
+        self.assertEqual(update["reviewer_attempt_count"], 0)
+        self.assertIn("Catalog-controlled", update["reviewer_rejection_reason"])
+        self.assertEqual(provider.requests, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_reviewer_node.py
+++ b/tests/test_reviewer_node.py
@@ -228,6 +228,41 @@ class ReviewerNodeTests(unittest.TestCase):
         self.assertIn("ReviewerProviderError", update["reviewer_diagnostics"][0])
         self.assertNotIn("TOP_SECRET", json.dumps(update, default=str))
 
+    def test_reviewer_node_sanitizes_request_construction_errors(self):
+        invalid_states = []
+
+        invalid_workflow_ir = self.sample_state()
+        invalid_workflow_ir["workflow_ir"] = {
+            "workflow": {"name": "TOP_SECRET"},
+        }
+        invalid_states.append(("workflow_ir", invalid_workflow_ir))
+
+        invalid_recipe_plan = self.sample_state()
+        invalid_recipe_plan["parsed_json"]["workflow"]["tool_calls"][0]["tool"] = {
+            "secret": "TOP_SECRET",
+        }
+        invalid_states.append(("recipe_plan", invalid_recipe_plan))
+
+        invalid_request_contract = self.sample_state()
+        invalid_request_contract["analysis_errors"] = [
+            {"secret": "TOP_SECRET"},
+        ]
+        invalid_states.append(("request_contract", invalid_request_contract))
+
+        for label, state in invalid_states:
+            with self.subTest(label=label):
+                provider = RecordingReviewerProvider({"status": "no_action"})
+
+                update = self.make_node(provider)(state)
+
+                self.assertEqual(
+                    update["reviewer_repair_status"],
+                    ReviewerRepairStatus.INVALID_REQUEST.value,
+                )
+                self.assertEqual(update["reviewer_attempt_count"], 0)
+                self.assertEqual(provider.requests, [])
+                self.assertNotIn("TOP_SECRET", json.dumps(update, default=str))
+
     def test_reviewer_node_rejects_policy_violation_without_mutating_ir(self):
         provider = RecordingReviewerProvider(
             {

--- a/tests/test_reviewer_patcher.py
+++ b/tests/test_reviewer_patcher.py
@@ -289,19 +289,21 @@ class ReviewerPatcherTests(unittest.TestCase):
             {
                 "summary": "Set workflow output to an invalid value type.",
                 "actions": [
-                    {
-                        "operation": "replace",
-                        "path": "/workflow/outputs/clean_r1",
-                        "value": ["qc.clean_r1"],
-                        "reason": "Workflow outputs must remain string expressions.",
-                    }
+                        {
+                            "operation": "replace",
+                            "path": "/workflow/outputs/clean_r1",
+                            "value": ["TOP_SECRET"],
+                            "reason": "Workflow outputs must remain string expressions.",
+                        }
                 ],
             }
         )
 
-        with self.assertRaisesRegex(ReviewerPatchApplicationError, "invalid Workflow IR"):
+        with self.assertRaises(ReviewerPatchApplicationError) as raised:
             apply_reviewer_patch(original, patch)
 
+        self.assertIn("invalid Workflow IR", str(raised.exception))
+        self.assertNotIn("TOP_SECRET", str(raised.exception))
         self.assertEqual(original["workflow"]["outputs"]["clean_r1"], "qc.clean_r1")
 
 

--- a/tests/test_reviewer_provider.py
+++ b/tests/test_reviewer_provider.py
@@ -112,6 +112,15 @@ class ReviewerProviderTests(unittest.TestCase):
         self.assertIn('"failure_stage": "analyzer"', prompt)
         self.assertIn('"tool_id": "salmon_index"', prompt)
         self.assertIn("workflow.steps as canonical", prompt)
+        self.assertIn(
+            "patch to an object only when status is patch_proposed",
+            prompt,
+        )
+        self.assertIn(
+            "rejection_reason to a non-empty string only when status is policy_rejected",
+            prompt,
+        )
+        self.assertIn("patch_proposed example", prompt)
         self.assertNotIn('"tool_id": "fastp"', prompt)
 
     def test_parse_reviewer_response_rejects_non_json_without_echoing_raw_text(self):

--- a/tests/test_reviewer_provider.py
+++ b/tests/test_reviewer_provider.py
@@ -1,0 +1,151 @@
+import json
+import os
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from src.reviewer_provider import (
+    LlmReviewerRepairProvider,
+    ReviewerProviderResponseError,
+    ReviewerProviderUnavailableError,
+    make_default_reviewer_provider,
+    parse_reviewer_repair_response,
+)
+from src.reviewer_repair import ReviewerRepairRequest, ReviewerRepairStatus
+
+
+def sample_reviewer_request() -> ReviewerRepairRequest:
+    return ReviewerRepairRequest.model_validate(
+        {
+            "workflow_ir": {
+                "workflow": {
+                    "name": "ReferencePrep",
+                    "inputs": {"transcriptome_fasta": "File"},
+                    "steps": [
+                        {
+                            "kind": "call",
+                            "id": "index",
+                            "task": "salmon_index",
+                            "inputs": {
+                                "transcriptome_fasta": "transcriptome_fasta",
+                            },
+                        }
+                    ],
+                    "outputs": {
+                        "transcriptome_index": "index.index_archive",
+                    },
+                },
+                "tasks": {
+                    "salmon_index": {
+                        "inputs": {"transcriptome_fasta": "File"},
+                        "command": "salmon index -t ~{transcriptome_fasta}",
+                        "outputs": {
+                            "index_archive": {
+                                "type": "File",
+                                "value": '"salmon_index.tar.gz"',
+                            }
+                        },
+                        "runtime": {
+                            "docker": "quay.io/biocontainers/salmon:1.9.0--h7e5ed60_1",
+                        },
+                    }
+                },
+            },
+            "failure_stage": "analyzer",
+            "analysis_errors": ["workflow output is missing"],
+            "catalog_context": {
+                "recipes": [
+                    {
+                        "recipe_id": "rnaseq_reference_preparation",
+                        "step_ids": ["build_salmon_index"],
+                        "tool_ids": ["salmon_index"],
+                    }
+                ],
+                "tools": [
+                    {
+                        "tool_id": "salmon_index",
+                        "version": "1.9.0",
+                        "inputs": ["transcriptome_fasta"],
+                        "outputs": ["index_archive"],
+                        "trust_status": "catalog-approved",
+                        "runtime_docker": (
+                            "quay.io/biocontainers/salmon:1.9.0--h7e5ed60_1"
+                        ),
+                    }
+                ],
+            },
+            "attempt_index": 1,
+        }
+    )
+
+
+class FakeReviewerLlm:
+    def __init__(self, response: str):
+        self.response = response
+        self.prompts: list[str] = []
+
+    def invoke(self, prompt: str):
+        self.prompts.append(prompt)
+        return SimpleNamespace(content=self.response)
+
+
+class ReviewerProviderTests(unittest.TestCase):
+    def test_llm_provider_renders_structured_request_and_parses_fenced_result(self):
+        response = {
+            "status": "no_action",
+            "diagnostics": ["No safe IR-only repair is available."],
+        }
+        fake_llm = FakeReviewerLlm(
+            f"```json\n{json.dumps(response)}\n```"
+        )
+        provider = LlmReviewerRepairProvider(fake_llm)
+
+        result = provider.repair(sample_reviewer_request())
+
+        self.assertEqual(result.status, ReviewerRepairStatus.NO_ACTION)
+        self.assertEqual(
+            result.diagnostics,
+            ["No safe IR-only repair is available."],
+        )
+        self.assertEqual(len(fake_llm.prompts), 1)
+        prompt = fake_llm.prompts[0]
+        self.assertIn('"failure_stage": "analyzer"', prompt)
+        self.assertIn('"tool_id": "salmon_index"', prompt)
+        self.assertIn("workflow.steps as canonical", prompt)
+        self.assertNotIn('"tool_id": "fastp"', prompt)
+
+    def test_parse_reviewer_response_rejects_non_json_without_echoing_raw_text(self):
+        raw_response = "TOP_SECRET provider prose without JSON"
+
+        with self.assertRaises(ReviewerProviderResponseError) as raised:
+            parse_reviewer_repair_response(raw_response)
+
+        self.assertNotIn("TOP_SECRET", str(raised.exception))
+
+    def test_parse_reviewer_response_rejects_invalid_schema_without_echoing_values(self):
+        raw_response = json.dumps(
+            {
+                "status": "patch_proposed",
+                "patch": {
+                    "secret_marker": "TOP_SECRET",
+                },
+            }
+        )
+
+        with self.assertRaises(ReviewerProviderResponseError) as raised:
+            parse_reviewer_repair_response(raw_response)
+
+        self.assertIn("does not match the result schema", str(raised.exception))
+        self.assertNotIn("TOP_SECRET", str(raised.exception))
+
+    def test_default_reviewer_provider_requires_api_key(self):
+        with patch.dict(os.environ, {"DEEPSEEK_API_KEY": ""}):
+            with self.assertRaisesRegex(
+                ReviewerProviderUnavailableError,
+                "DEEPSEEK_API_KEY",
+            ):
+                make_default_reviewer_provider()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a default-disabled Reviewer provider boundary and compiler node with injectable test doubles
- build structured repair requests using only current-workflow approved recipe/tool metadata, backed by formal plan and Catalog provenance checks
- validate provider output as `ReviewerRepairResult`, avoid persisting raw responses, and keep provider failures sanitized
- apply policy-approved Workflow IR patches while distinguishing policy rejection from application failure
- add independent Reviewer state fields, focused unit coverage, and P2.3 design/test documentation

## Scope

This PR implements P2.3 only. It does not add Compiler Graph routing. Analyzer failure routing remains the first P2.4 follow-up; Checker failure routing will follow separately.

## Validation

- `\.venv\Scripts\python.exe -m unittest tests.test_reviewer_repair tests.test_reviewer_patcher tests.test_reviewer_provider tests.test_reviewer_node tests.test_workflow_service tests.test_orchestration_state` - 55 tests passed
- `\.venv\Scripts\python.exe -m unittest discover` - 231 tests run; 3 existing graph tests fail because no WOMtool/miniwdl validator is installed, and 4 tests are skipped
- `git diff --cached --check` - passed