### PR TITLE
Make workflow steps the canonical DAG

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -62,7 +62,7 @@ AI-bioworkflow/
 
 1. **状态管理 (`state.py`)**：必须保持强类型。除了 LangGraph 原生的 `messages` 列表，还需要定义好接收前端传入的 `parsed_json`、标准化后的 `workflow_ir`、流转中的 `current_wdl`、`analysis_errors` 和 `validation_message`。
 2. **提示词隔离 (`prompts.py`)**：绝对不要将长篇大论的 System Prompt 硬编码在业务逻辑文件中。
-3. **IR 优先 (`schema.py`)**：workflow 的调用关系与 task 的定义必须分离。`workflow.steps` 表达 call/scatter DAG，`workflow.calls` 作为旧输入兼容，`tasks` 表达可复用 task 模板。
+3. **IR 优先 (`schema.py`)**：workflow 的调用关系与 task 的定义必须分离。`workflow.steps` 是唯一 canonical call/scatter DAG；`workflow.calls` 仅作为旧输入和序列化输出的只读扁平兼容视图；`tasks` 表达可复用 task 模板。
 4. **自然语言只到 Plan (`nl_planner.py`)**：LLM 的职责是把用户需求转成 Recipe Tool Plan，不直接生成 WDL。Planner 失败需要区分 JSON 解析、plan schema、recipe/catalog 校验三类错误，便于调试真实模型输出。
 5. **Catalog 先于自由生成 (`catalog/`, `recipes/`)**：常见生信工具、版本、参数、runtime 与配方步骤应沉淀为结构化目录，Planner 可以把 Recipe Tool Plan 解析成标准 IR。
 6. **静态分析先于渲染 (`analyzer.py`)**：在生成 WDL 前先检查 task 是否存在、输入是否齐全、上游输出引用是否有效、基础类型是否匹配。
@@ -263,7 +263,7 @@ Web 展示系统与 Agent 核心代码继续保留在同一仓库中，以便 Wo
 | 数据持久化 | SQLite（展示版）/ PostgreSQL（部署升级） | 保存 run 摘要、状态事件、结构化产物和错误记录 |
 | Frontend | Next.js + TypeScript | 承载介绍站、交互工作台、DAG 视图和历史详情页 |
 | UI 与样式 | Tailwind CSS + shadcn/ui | 建立一致、可扩展的产品界面组件 |
-| DAG 可视化 | React Flow | 展示 Workflow IR 中 steps/calls/scatter 的依赖图 |
+| DAG 可视化 | React Flow | 展示 Workflow IR 中 call/scatter steps 的依赖图 |
 | 结构化产物展示 | Monaco Editor 或轻量只读代码查看器 | 展示 JSON Plan、Workflow IR 和 WDL，并支持复制/对比 |
 
 第一阶段使用 SSE 而不是 WebSocket：当前主要需求是后端向前端单向推送执行阶段与中间产物，SSE 的实现和调试成本更低。当后续引入运行中人工批准、交互式修订或双向协作时，再评估 WebSocket。
@@ -338,7 +338,7 @@ AI-bioworkflow/
 | --- | --- | --- | --- |
 | 项目介绍页 | 问题背景、Agent/Compiler 架构、RNA-seq DEG 示例、技术栈与项目边界 | 快速说明生信经验如何转化为 Agent 产品能力 | 可跳转到预填充示例工作台、run 历史和 API 文档 |
 | Workflow 生成工作台 | 自然语言输入、执行阶段流、Plan / IR / WDL 标签页、校验、修复信息和失败摘要 | 展示端到端 Agent 工程链路与可解释输出 | 提交一个示例请求后可实时看到状态、最终校验结果，并进入历史详情 |
-| Workflow DAG 审阅 | calls、scatter、依赖边、输入输出、runtime docker 和结构状态 | 展示结构化建模、领域工作流理解和可视化能力 | 能在 run 详情中从 Workflow IR 渲染 RNA-seq 示例 DAG 并选中节点查看详情 |
+| Workflow DAG 审阅 | call/scatter steps、依赖边、输入输出、runtime docker 和结构状态 | 展示结构化建模、领域工作流理解和可视化能力 | 能在 run 详情中从 Workflow IR 渲染 RNA-seq 示例 DAG 并选中节点查看详情 |
 | Run 历史详情 | 原始请求、事件时间线、模型/编译步骤、修复动作、产物、诊断与失败回放 | 展示可观测性、审计能力和失败处理意识 | 刷新页面后仍可重看一次成功或失败 run 的关键产物 |
 
 第一版工作台重点呈现的阶段为：

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ $env:AI_BIOWORKFLOW_CORS_ORIGINS = "http://127.0.0.1:3001,http://localhost:3001"
 
 结构化输入用于开发、调试和集成测试，目前支持两类：
 
-1. **标准 Workflow IR**：直接提供 `workflow.steps` / `workflow.calls` 和 `tasks`，适合精确控制每个 task 的命令、输入、输出、scatter 和 runtime。
+1. **标准 Workflow IR**：提供 canonical `workflow.steps` 和 `tasks`，适合精确控制每个 task 的命令、输入、输出、scatter 和 runtime；旧版 calls-only 输入仍兼容，但 `workflow.calls` 只作为自动生成的扁平兼容视图。
 2. **Recipe Tool Plan**：提供 `workflow.recipe` 和 `workflow.tool_calls`，由内置 recipe/tool catalog 自动解析为 Workflow IR。
 
 Recipe Tool Plan 示例：

--- a/docs/test-cases.md
+++ b/docs/test-cases.md
@@ -1368,7 +1368,6 @@ OK (skipped=2)
 1. 调用 `resolve_tool_plan(...)`。
 2. 调用 `analyze_workflow_ir(...)`。
 3. 调用 `render_wdl(...)`。
-3. 调用 `render_wdl(...)`。
 
 期望输出：
 

--- a/docs/test-cases.md
+++ b/docs/test-cases.md
@@ -1368,6 +1368,7 @@ OK (skipped=2)
 1. 调用 `resolve_tool_plan(...)`。
 2. 调用 `analyze_workflow_ir(...)`。
 3. 调用 `render_wdl(...)`。
+3. 调用 `render_wdl(...)`。
 
 期望输出：
 
@@ -1547,6 +1548,29 @@ OK (skipped=2)
 覆盖点：
 
 - Tool call params 必须来自 Tool Catalog 声明。
+
+### `test_resolver_does_not_infer_missing_workflow_outputs`
+
+输入：
+
+- 复制 `sample_rnaseq_tool_plan()`。
+- 删除显式声明的 `workflow.outputs`。
+
+执行：
+
+1. 调用 `resolve_tool_plan(...)`。
+2. 调用 `analyze_workflow_ir(...)`。
+
+期望输出：
+
+- Analyzer 返回 `is_valid=True`。
+- `workflow.outputs` 保持为空字典。
+- 生成的 WDL workflow 区块不包含 `output` block。
+
+覆盖点：
+
+- Resolver 不按 `tool_calls` 或 canonical `steps` 的顺序猜测 workflow 默认输出。
+- 未显式声明 outputs 的 Plan 与直接构造的空 outputs Workflow IR 保持相同语义。
 
 ### `test_multiqc_report_files_can_be_auto_collected_from_output_tags`
 

--- a/docs/test-cases.md
+++ b/docs/test-cases.md
@@ -104,7 +104,7 @@ OK (skipped=2)
 
 - workflow 名称：`RNASeqPipeline`
 - workflow inputs：`raw_r1: File`、`raw_r2: File`、`reference: File`
-- calls：
+- canonical steps：
   - `qc` 调用 task `fastp`
   - `align` 调用 task `bwa_mem`，输入引用 `qc.clean_r1/qc.clean_r2`
 - outputs：`bam = align.bam`
@@ -116,7 +116,7 @@ OK (skipped=2)
 
 - Analyzer 认为 call 顺序正确时 IR 有效。
 - Renderer 生成 `workflow RNASeqPipeline`、`call fastp as qc`、`call bwa_mem as align` 和 `File bam = align.bam`。
-- 当 calls 反转时，Analyzer 能发现前向引用；Agent repairer 能在安全情况下重排。
+- 当 steps 反转时，Analyzer 能发现前向引用；Agent repairer 能在安全情况下重排。
 
 ## `tests/api/test_models.py`
 
@@ -884,7 +884,7 @@ OK (skipped=2)
 
 输入：
 
-- 从 `examples/rnaseq_workflow_ir.json` 读取 Workflow IR，并反转 calls 形成 forward reference。
+- 从 `examples/rnaseq_workflow_ir.json` 读取 Workflow IR，并反转 canonical steps 形成 forward reference。
 - `check=False`
 
 执行：
@@ -896,7 +896,7 @@ OK (skipped=2)
 
 - snapshot `status == "succeeded"`。
 - diagnostics 包含 repair actions。
-- snapshot Workflow IR calls 被修复为 `["qc", "align"]`。
+- snapshot Workflow IR steps 被修复为 `["qc", "align"]`。
 - `artifact.updated` workflow_ir 事件在 `repair.applied` 事件前出现。
 - `repair.applied` payload 包含结构化 `repair_actions`。
 
@@ -2365,7 +2365,7 @@ result 和 policy 边界。
 - `remove` 支持 allowlist 内的 object entry 删除。
 - 删除失败不会通过共享引用污染原始 IR。
 
-### `test_apply_reviewer_patch_moves_workflow_steps_and_syncs_calls`
+### `test_apply_reviewer_patch_moves_steps_and_regenerates_compatibility_calls`
 
 输入：
 
@@ -2420,7 +2420,7 @@ result 和 policy 边界。
 期望输出：
 
 - 抛出 `ReviewerPatchPolicyError`。
-- 原始 `workflow.steps` 和 `workflow.calls` wiring 都保持不变。
+- 原始 `workflow.steps` wiring 保持不变，且不会向原始 dict 写入 `workflow.calls`。
 
 覆盖点：
 
@@ -2795,6 +2795,69 @@ Graph edge；Analyzer 和 Checker routing 留给 P2.4。
   完全一致。
 - approved Catalog context 不能由与 canonical DAG 脱节的旧版兼容视图授权。
 
+## `tests/test_schema.py`
+
+该文件验证 `workflow.steps` 的 canonical 契约以及 `workflow.calls` 的旧版兼容
+边界。业务模块不得把 `calls` 当作第二份 DAG。
+
+### `test_calls_only_input_builds_canonical_steps`
+
+输入：只包含无 `kind` 的 `workflow.calls` 旧版 IR。
+
+期望输出：
+
+- `coerce_workflow_ir(...)` 将 call 转成 canonical `workflow.steps`。
+- 生成的 compatibility calls 与 steps 一致。
+
+覆盖点：calls-only 历史输入仍然受支持。
+
+### `test_steps_only_input_builds_flattened_compatibility_view`
+
+输入：只包含一个 scatter 及其 body call 的 canonical `workflow.steps`。
+
+期望输出：
+
+- schema 递归生成扁平 `workflow.calls`。
+- compatibility call 与 canonical step 是不同对象。
+
+覆盖点：`calls` 是从 steps 生成的深拷贝快照，不通过共享引用成为第二个写入口。
+
+### `test_coercion_rejects_mismatched_dual_views`
+
+输入：同时提供 `steps` 和 `calls`，但两者的 call input wiring 不一致。
+
+期望输出：`coerce_workflow_ir(...)` 抛出 `WorkflowCompatibilityError`。
+
+覆盖点：输入归一化不会静默选择任意一份冲突 DAG。
+
+### `test_coercion_accepts_equivalent_default_call_inputs`
+
+输入：canonical step 省略 `inputs`，compatibility call 显式提供空 `inputs`。
+
+期望输出：IR 归一化成功，两个视图保持一致。
+
+覆盖点：双视图校验在比较前补齐 CallSpec 默认值，不误拒绝语义等价输入。
+
+### `test_direct_model_validation_rejects_mismatched_dual_views`
+
+输入：与上一用例相同的冲突双视图 IR。
+
+期望输出：`WorkflowIR.model_validate(...)` 抛出 `ValidationError`。
+
+覆盖点：绕过 normalizer 的直接 schema 构造也保持双视图一致性约束。
+
+### `test_refresh_rebuilds_detached_compatibility_snapshot`
+
+输入：修改已解析 IR 中的 canonical call，使旧 compatibility snapshot 过期。
+
+期望输出：
+
+- `compatibility_calls_match_steps(...)` 先返回 `False`。
+- `refresh_compatibility_calls(...)` 后重新一致。
+- 刷新后的 compatibility call 仍不与 canonical call 共享对象。
+
+覆盖点：Repairer 等内部修改方通过共享 helper 单向刷新兼容视图。
+
 ## `tests/test_graph.py`
 
 该文件验证 Compiler Graph、Analyzer、Renderer 和 deterministic repairer 的交互。
@@ -2832,7 +2895,7 @@ Graph edge；Analyzer 和 Checker routing 留给 P2.4。
 输入：
 
 - `sample_multi_task_ir()`。
-- 将 `workflow.calls` 顺序反转，使 `align` 在 `qc` 之前出现。
+- 将 `workflow.steps` 顺序反转，使 `align` 在 `qc` 之前出现。
 
 执行：
 
@@ -2871,7 +2934,7 @@ Graph edge；Analyzer 和 Checker routing 留给 P2.4。
 输入：
 
 - `sample_multi_task_ir()`。
-- 将 `workflow.calls` 顺序反转。
+- 将 `workflow.steps` 顺序反转。
 - 通过 `initial_state(...)` 构造 LangGraph state。
 
 执行：
@@ -2881,7 +2944,7 @@ Graph edge；Analyzer 和 Checker routing 留给 P2.4。
 期望输出：
 
 - final state 中 `is_valid=True`。
-- 修复后的 `workflow_ir.workflow.calls` 顺序为 `["qc", "align"]`。
+- 修复后的 `workflow_ir.workflow.steps` 顺序为 `["qc", "align"]`。
 - `repair_actions` 非空。
 
 覆盖点：
@@ -2986,7 +3049,7 @@ files = flatten([qc.html_report, qc.json_report, [extra_report]])
 期望输出：
 
 - 标准 IR workflow 名称为 `SimpleQC`。
-- `workflow.calls[0].id == "fastp_qc"`。
+- `workflow.steps[0].id == "fastp_qc"`。
 - `workflow_ir.tasks["fastp_qc"].runtime.docker == "quay.io/biocontainers/fastp:1.3.3--h43da1c4_0"`。
 
 覆盖点：

--- a/docs/w5-dag-history-plan.md
+++ b/docs/w5-dag-history-plan.md
@@ -6,7 +6,7 @@
 
 `W5` 的目标是把 `W4` 工作台产生的一次 workflow run，从“可实时生成”推进到“可结构化理解、可回放、可审计”。
 
-当前访问者已经能从工作台创建 RNA-seq 示例 run，在历史列表中再次找到它，进入详情页回放事件、产物和诊断信息，并通过 DAG 图理解 Workflow IR 中的 calls、scatter、依赖边、输入输出和结构状态。
+当前访问者已经能从工作台创建 RNA-seq 示例 run，在历史列表中再次找到它，进入详情页回放事件、产物和诊断信息，并通过 DAG 图理解 Workflow IR 中的 call/scatter steps、依赖边、输入输出和结构状态。
 
 `W5` 是 run 历史与 Workflow IR 可视化阶段，不改变 Compiler Graph 的职责，不让前端生成或修复 Plan、IR、WDL，也不引入新的 Agent 节点或真实 WDL 执行后端。
 
@@ -36,7 +36,7 @@
   - `/runs/[runId]` 历史详情、事件回放、artifact tabs、失败摘要和 Workflow IR DAG。
   - `workflow-graph` 纯数据模型、React Flow 展示组件和 graph 测试。
   - `RunEvent`、`WorkflowArtifacts`、`DiagnosticReport` 和 `WorkflowRunSnapshotResponse` 类型。
-- Workflow IR 已以 `workflow.steps` 作为 canonical DAG 表示，`workflow.calls` 仅用于兼容旧输入和调试输出。
+- Workflow IR 已以 `workflow.steps` 作为 canonical DAG 表示，`workflow.calls` 仅用于兼容旧输入和序列化输出。
 
 ## 产品行为
 

--- a/docs/workflow-ir.md
+++ b/docs/workflow-ir.md
@@ -157,13 +157,19 @@ T?
 ]
 ```
 
-Analyzer 和 Renderer 都以 `workflow.steps` 为准。
+Analyzer、Repairer、Reviewer 和 Renderer 都只以 `workflow.steps` 为 DAG 数据源。
 
 ### `workflow.calls`
 
-`calls` 是旧输入兼容字段。旧 IR 只提供 `workflow.calls` 时，normalizer 会把每个 call 转成 `steps` 中的 `kind: "call"`。
+`calls` 是旧输入和序列化输出的兼容字段，不是第二份 DAG。旧 IR 只提供
+`workflow.calls` 时，normalizer 会把每个 call 转成 `steps` 中的
+`kind: "call"`。新输入应只提供 `workflow.steps`；schema 会从 canonical steps
+递归生成一个扁平、深拷贝的 `calls` 快照。
 
-当前输出 IR 仍会保留扁平化的 `calls`，用于兼容旧测试、旧工具和调试输出。但新功能不应只更新 `calls` 而忽略 `steps`。
+如果输入同时提供 `steps` 和 `calls`，两者的 call 顺序、ID、task 和 inputs 必须
+完全一致，否则 schema 会拒绝该 IR。内部逻辑修改 `steps` 后必须通过共享 schema
+helper 单向刷新 `calls`，不得读取或单独 patch `calls`。由于扁平视图不保留 scatter
+边界，新功能不得依赖它表达 DAG 语义。
 
 ### `workflow.outputs`
 
@@ -579,7 +585,7 @@ Resolver 的主要职责：
 5. 把 tool params 转成 task inputs 和 WDL 字面量。
 6. 根据 recipe scatter metadata 生成 `workflow.steps` 中的 scatter block。
 7. 在 scatter 中自动把 workflow array input 索引为单元素输入。
-8. 保留扁平化 `workflow.calls` 作为兼容字段。
+8. 从 canonical steps 生成扁平化 `workflow.calls` 兼容快照。
 9. 收集 catalog output tags，用于自动连接某些通用汇总工具。
 
 ### MultiQC 自动收集

--- a/docs/workflow-ir.md
+++ b/docs/workflow-ir.md
@@ -190,6 +190,10 @@ output {
 }
 ```
 
+Recipe Tool Plan 未显式声明 `workflow.outputs` 时，Resolver 保留空字典，不根据
+`tool_calls` 或 canonical `steps` 的排列顺序推断默认输出。若 recipe 需要提供默认
+输出，应由 recipe metadata 显式声明，而不是依赖 DAG 的序列化顺序。
+
 ## TaskSpec
 
 `tasks` 中每个条目对应一个 `TaskSpec`。
@@ -585,8 +589,9 @@ Resolver 的主要职责：
 5. 把 tool params 转成 task inputs 和 WDL 字面量。
 6. 根据 recipe scatter metadata 生成 `workflow.steps` 中的 scatter block。
 7. 在 scatter 中自动把 workflow array input 索引为单元素输入。
-8. 从 canonical steps 生成扁平化 `workflow.calls` 兼容快照。
-9. 收集 catalog output tags，用于自动连接某些通用汇总工具。
+8. 仅复制 Plan 显式声明的 `workflow.outputs`，不根据 step 顺序推断默认输出。
+9. 从 canonical steps 生成扁平化 `workflow.calls` 兼容快照。
+10. 收集 catalog output tags，用于自动连接某些通用汇总工具。
 
 ### MultiQC 自动收集
 

--- a/examples/rnaseq_workflow_ir.json
+++ b/examples/rnaseq_workflow_ir.json
@@ -6,8 +6,9 @@
       "raw_r2": "File",
       "reference": "File"
     },
-    "calls": [
+    "steps": [
       {
+        "kind": "call",
         "id": "qc",
         "task": "fastp",
         "inputs": {
@@ -16,6 +17,7 @@
         }
       },
       {
+        "kind": "call",
         "id": "align",
         "task": "bwa_mem",
         "inputs": {

--- a/src/catalog/resolver.py
+++ b/src/catalog/resolver.py
@@ -96,7 +96,6 @@ def resolve_tool_plan(
     steps: list[dict[str, Any]] = []
     scatter_steps: dict[str, dict[str, Any]] = {}
     tagged_outputs: dict[str, list[str]] = {MULTIQC_INPUT_TAG: []}
-    last_call_step: dict[str, Any] | None = None
 
     for tool_call in plan.workflow.tool_calls:
         step = recipe.step_by_id(tool_call.step)
@@ -142,12 +141,7 @@ def resolve_tool_plan(
         }
         _append_workflow_step(steps, scatter_steps, call_step, step.scatter)
         _record_tagged_outputs(tagged_outputs, tool_call.id, tool)
-        last_call_step = call_step
 
-    workflow_outputs = plan.workflow.outputs or _default_workflow_outputs(
-        last_call_step,
-        task_defs,
-    )
     return WorkflowIR.model_validate(
         {
             "version": "1.0",
@@ -155,7 +149,7 @@ def resolve_tool_plan(
                 "name": plan.workflow.name,
                 "inputs": plan.workflow.inputs,
                 "steps": steps,
-                "outputs": workflow_outputs,
+                "outputs": plan.workflow.outputs,
             },
             "tasks": task_defs,
         }
@@ -392,20 +386,6 @@ def _join_shell_command_lines(lines: list[str]) -> str:
         for index, line in enumerate(lines)
     ]
     return "\n".join(continued_lines)
-
-
-def _default_workflow_outputs(
-    last_call: dict[str, Any] | None,
-    task_defs: dict[str, dict[str, Any]],
-) -> dict[str, str]:
-    if last_call is None:
-        return {}
-
-    last_task = task_defs[last_call["task"]]
-    return {
-        output_name: f"{last_call['id']}.{output_name}"
-        for output_name in last_task["outputs"]
-    }
 
 
 def _task_name_for_call(tool_call: PlannedToolCall) -> str:

--- a/src/catalog/resolver.py
+++ b/src/catalog/resolver.py
@@ -93,10 +93,10 @@ def resolve_tool_plan(
     validate_recipe_plan(plan, recipe)
 
     task_defs: dict[str, dict[str, Any]] = {}
-    calls: list[dict[str, Any]] = []
     steps: list[dict[str, Any]] = []
     scatter_steps: dict[str, dict[str, Any]] = {}
     tagged_outputs: dict[str, list[str]] = {MULTIQC_INPUT_TAG: []}
+    last_call_step: dict[str, Any] | None = None
 
     for tool_call in plan.workflow.tool_calls:
         step = recipe.step_by_id(tool_call.step)
@@ -140,18 +140,20 @@ def resolve_tool_plan(
                 },
             },
         }
-        calls.append(call_step)
         _append_workflow_step(steps, scatter_steps, call_step, step.scatter)
         _record_tagged_outputs(tagged_outputs, tool_call.id, tool)
+        last_call_step = call_step
 
-    workflow_outputs = plan.workflow.outputs or _default_workflow_outputs(calls, task_defs)
+    workflow_outputs = plan.workflow.outputs or _default_workflow_outputs(
+        last_call_step,
+        task_defs,
+    )
     return WorkflowIR.model_validate(
         {
             "version": "1.0",
             "workflow": {
                 "name": plan.workflow.name,
                 "inputs": plan.workflow.inputs,
-                "calls": calls,
                 "steps": steps,
                 "outputs": workflow_outputs,
             },
@@ -393,13 +395,12 @@ def _join_shell_command_lines(lines: list[str]) -> str:
 
 
 def _default_workflow_outputs(
-    calls: list[dict[str, Any]],
+    last_call: dict[str, Any] | None,
     task_defs: dict[str, dict[str, Any]],
 ) -> dict[str, str]:
-    if not calls:
+    if last_call is None:
         return {}
 
-    last_call = calls[-1]
     last_task = task_defs[last_call["task"]]
     return {
         output_name: f"{last_call['id']}.{output_name}"

--- a/src/nodes/analyzer.py
+++ b/src/nodes/analyzer.py
@@ -3,7 +3,7 @@ import logging
 from langchain_core.messages import HumanMessage
 
 from src.analyzer import analyze_workflow_ir
-from src.schema import WorkflowIR
+from src.schema import coerce_workflow_ir
 from src.state import WorkflowState
 
 
@@ -17,7 +17,7 @@ def analyzer_node(state: WorkflowState):
     logger.info("Analyzer node is checking Workflow IR.")
 
     try:
-        workflow_ir = WorkflowIR.model_validate(state.get("workflow_ir", {}))
+        workflow_ir = coerce_workflow_ir(state.get("workflow_ir", {}))
     except Exception as exc:
         message = f"Workflow IR 结构校验失败: {exc}"
         return {

--- a/src/repairer.py
+++ b/src/repairer.py
@@ -10,6 +10,7 @@ from src.schema import (
     ScatterSpec,
     WorkflowIR,
     coerce_workflow_ir,
+    refresh_compatibility_calls,
 )
 
 
@@ -44,7 +45,7 @@ def _repair_call_order(ir: WorkflowIR, actions: list[str]) -> None:
         return
 
     ir.workflow.steps = repaired_steps
-    ir.workflow.calls = _flatten_calls(repaired_steps)
+    refresh_compatibility_calls(ir.workflow)
     actions.append(
         "Reordered workflow steps to satisfy upstream output dependencies: "
         f"{' -> '.join(_step_labels(repaired_steps))}"
@@ -143,16 +144,6 @@ def _step_produced_calls(step: CallSpec | ScatterSpec) -> set[str]:
     for child in step.body:
         produced.update(_step_produced_calls(child))
     return produced
-
-
-def _flatten_calls(steps: list[CallSpec | ScatterSpec]) -> list[CallSpec]:
-    calls = []
-    for step in steps:
-        if isinstance(step, CallSpec):
-            calls.append(step)
-        else:
-            calls.extend(_flatten_calls(step.body))
-    return calls
 
 
 def _step_labels(steps: list[CallSpec | ScatterSpec]) -> list[str]:

--- a/src/reviewer_patcher.py
+++ b/src/reviewer_patcher.py
@@ -1,9 +1,6 @@
 from __future__ import annotations
 
-import copy
 from typing import Any
-
-from pydantic import ValidationError
 
 from src.reviewer_repair import (
     ApprovedCatalogContext,
@@ -38,9 +35,13 @@ def apply_reviewer_patch(
     for action in patch.actions:
         _apply_action(candidate, action)
 
+    workflow = candidate.get("workflow")
+    if isinstance(workflow, dict):
+        workflow.pop("calls", None)
+
     try:
-        return WorkflowIR.model_validate(candidate)
-    except ValidationError as exc:
+        return coerce_workflow_ir(candidate)
+    except (TypeError, ValueError) as exc:
         raise ReviewerPatchApplicationError(
             "applied Reviewer patch produced invalid Workflow IR."
         ) from exc
@@ -66,7 +67,6 @@ def _apply_add(candidate: dict[str, Any], path: str, value: Any) -> None:
     if key in parent:
         raise ReviewerPatchApplicationError(f"add target '{path}' already exists")
     parent[key] = value
-    _sync_calls_after_steps_patch(candidate, path)
 
 
 def _apply_replace(candidate: dict[str, Any], path: str, value: Any) -> None:
@@ -75,13 +75,11 @@ def _apply_replace(candidate: dict[str, Any], path: str, value: Any) -> None:
         if key not in parent:
             raise ReviewerPatchApplicationError(f"replace target '{path}' does not exist")
         parent[key] = value
-        _sync_calls_after_steps_patch(candidate, path)
         return
 
     if isinstance(parent, list):
         index = _parse_existing_index(key, parent, path)
         parent[index] = value
-        _sync_calls_after_steps_patch(candidate, path)
         return
 
     raise ReviewerPatchApplicationError(f"replace target parent for '{path}' is not editable")
@@ -93,13 +91,11 @@ def _apply_remove(candidate: dict[str, Any], path: str) -> None:
         if key not in parent:
             raise ReviewerPatchApplicationError(f"remove target '{path}' does not exist")
         del parent[key]
-        _sync_calls_after_steps_patch(candidate, path)
         return
 
     if isinstance(parent, list):
         index = _parse_existing_index(key, parent, path)
         parent.pop(index)
-        _sync_calls_after_steps_patch(candidate, path)
         return
 
     raise ReviewerPatchApplicationError(f"remove target parent for '{path}' is not editable")
@@ -120,7 +116,6 @@ def _apply_move(candidate: dict[str, Any], action: ReviewerPatchAction) -> None:
     item = source_parent.pop(source_index)
     target_index = _parse_insert_index(target_key, source_parent, action.path)
     source_parent.insert(target_index, item)
-    _sync_calls_after_steps_patch(candidate, action.path)
 
 
 def _resolve_parent(candidate: dict[str, Any], path: str) -> tuple[Any, str]:
@@ -168,33 +163,6 @@ def _parse_index(segment: str, path: str) -> int:
     if index < 0:
         raise ReviewerPatchApplicationError(f"patch path '{path}' contains a negative list index")
     return index
-
-
-def _sync_calls_after_steps_patch(candidate: dict[str, Any], path: str) -> None:
-    if not path.startswith("/workflow/steps/"):
-        return
-
-    workflow = candidate.get("workflow")
-    if not isinstance(workflow, dict):
-        return
-
-    steps = workflow.get("steps")
-    if isinstance(steps, list):
-        workflow["calls"] = _flatten_call_steps(steps)
-
-
-def _flatten_call_steps(steps: list[Any]) -> list[dict[str, Any]]:
-    calls: list[dict[str, Any]] = []
-    for step in steps:
-        if not isinstance(step, dict):
-            continue
-        if step.get("kind", "call") == "call":
-            calls.append(copy.deepcopy(step))
-        elif step.get("kind") == "scatter":
-            body = step.get("body", [])
-            if isinstance(body, list):
-                calls.extend(_flatten_call_steps(body))
-    return calls
 
 
 def _json_pointer_segments(path: str) -> list[str]:

--- a/src/reviewer_request.py
+++ b/src/reviewer_request.py
@@ -12,7 +12,14 @@ from src.reviewer_repair import (
     ReviewerFailureStage,
     ReviewerRepairRequest,
 )
-from src.schema import CallSpec, ScatterSpec, WorkflowIR, coerce_workflow_ir
+from src.schema import (
+    CallSpec,
+    WorkflowCompatibilityError,
+    WorkflowIR,
+    coerce_workflow_ir,
+    compatibility_calls_match_steps,
+    flatten_workflow_calls,
+)
 from src.state import WorkflowState
 
 
@@ -30,6 +37,8 @@ def build_reviewer_repair_request(
     """Build a structured request with only current-workflow approved metadata."""
     try:
         workflow_ir = coerce_workflow_ir(state.get("workflow_ir", {}))
+    except WorkflowCompatibilityError as exc:
+        raise ReviewerRequestBuildError(str(exc)) from exc
     except Exception as exc:
         raise ReviewerRequestBuildError(
             f"Workflow IR is unavailable or invalid ({exc.__class__.__name__})."
@@ -213,30 +222,18 @@ def _canonical_call_map(
     *,
     label: str,
 ) -> dict[str, CallSpec]:
-    canonical_calls = _flatten_canonical_calls(workflow_ir.workflow.steps)
+    canonical_calls = flatten_workflow_calls(workflow_ir.workflow.steps)
     call_map = {call.id: call for call in canonical_calls}
     if len(call_map) != len(canonical_calls):
         raise ReviewerRequestBuildError(
             f"{label} Workflow IR contains duplicate canonical call IDs."
         )
 
-    if workflow_ir.workflow.calls != canonical_calls:
+    if not compatibility_calls_match_steps(workflow_ir.workflow):
         raise ReviewerRequestBuildError(
             f"{label} Workflow IR compatibility calls do not match canonical workflow steps."
         )
     return call_map
-
-
-def _flatten_canonical_calls(
-    steps: list[CallSpec | ScatterSpec],
-) -> list[CallSpec]:
-    calls: list[CallSpec] = []
-    for step in steps:
-        if isinstance(step, CallSpec):
-            calls.append(step)
-        else:
-            calls.extend(_flatten_canonical_calls(step.body))
-    return calls
 
 
 def _catalog_controlled_task_data(task: Any) -> dict[str, Any]:

--- a/src/schema.py
+++ b/src/schema.py
@@ -4,7 +4,7 @@ import copy
 import re
 from typing import Annotated, Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 
 IDENTIFIER_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
@@ -100,6 +100,28 @@ class ScatterSpec(BaseModel):
 WorkflowStepSpec = Annotated[CallSpec | ScatterSpec, Field(discriminator="kind")]
 
 
+WORKFLOW_CALLS_MISMATCH_MESSAGE = (
+    "compatibility calls do not match canonical workflow steps"
+)
+
+
+class WorkflowCompatibilityError(ValueError):
+    """Raised when legacy workflow.calls diverges from canonical workflow.steps."""
+
+
+def flatten_workflow_calls(
+    steps: list[CallSpec | ScatterSpec],
+) -> list[CallSpec]:
+    """Return canonical calls in workflow step traversal order."""
+    calls: list[CallSpec] = []
+    for step in steps:
+        if isinstance(step, CallSpec):
+            calls.append(step)
+        else:
+            calls.extend(flatten_workflow_calls(step.body))
+    return calls
+
+
 class WorkflowSpec(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -127,6 +149,39 @@ class WorkflowSpec(BaseModel):
         _validate_mapping_keys(value, "workflow output")
         return value
 
+    @model_validator(mode="after")
+    def normalize_compatibility_calls(self):
+        calls_provided = "calls" in self.model_fields_set
+        steps_provided = "steps" in self.model_fields_set
+
+        if calls_provided and not steps_provided:
+            self.steps = [call.model_copy(deep=True) for call in self.calls]
+
+        canonical_calls = flatten_workflow_calls(self.steps)
+        if calls_provided and steps_provided and self.calls != canonical_calls:
+            raise WorkflowCompatibilityError(WORKFLOW_CALLS_MISMATCH_MESSAGE)
+
+        self.calls = [call.model_copy(deep=True) for call in canonical_calls]
+        return self
+
+
+def compatibility_calls_match_steps(workflow: WorkflowSpec) -> bool:
+    """Check that the legacy calls view is an exact snapshot of canonical steps."""
+    return workflow.calls == flatten_workflow_calls(workflow.steps)
+
+
+def ensure_compatibility_calls_match_steps(workflow: WorkflowSpec) -> None:
+    if not compatibility_calls_match_steps(workflow):
+        raise WorkflowCompatibilityError(WORKFLOW_CALLS_MISMATCH_MESSAGE)
+
+
+def refresh_compatibility_calls(workflow: WorkflowSpec) -> None:
+    """Regenerate the legacy calls view from canonical workflow steps."""
+    workflow.calls = [
+        call.model_copy(deep=True)
+        for call in flatten_workflow_calls(workflow.steps)
+    ]
+
 
 class WorkflowIR(BaseModel):
     model_config = ConfigDict(extra="forbid")
@@ -145,6 +200,7 @@ class WorkflowIR(BaseModel):
 def coerce_workflow_ir(data: WorkflowIR | dict[str, Any]) -> WorkflowIR:
     """Normalize supported user JSON shapes into the internal WorkflowIR."""
     if isinstance(data, WorkflowIR):
+        ensure_compatibility_calls_match_steps(data.workflow)
         return data
     if not isinstance(data, dict):
         raise TypeError("workflow input must be a dictionary")
@@ -187,6 +243,7 @@ def _normalize_ir_dict(data: dict[str, Any]) -> dict[str, Any]:
         }
 
     if isinstance(workflow, dict):
+        calls_provided = "calls" in workflow
         calls = workflow.get("calls", [])
         steps = workflow.get("steps")
 
@@ -195,8 +252,12 @@ def _normalize_ir_dict(data: dict[str, Any]) -> dict[str, Any]:
         else:
             workflow["steps"] = [_normalize_step_dict(step) for step in steps]
 
-        if "calls" not in workflow:
-            workflow["calls"] = _flatten_call_steps(workflow["steps"])
+        canonical_calls = _flatten_call_step_dicts(workflow["steps"])
+        if calls_provided:
+            normalized_calls = [_normalize_call_step(call) for call in calls]
+            if normalized_calls != canonical_calls:
+                raise WorkflowCompatibilityError(WORKFLOW_CALLS_MISMATCH_MESSAGE)
+        workflow["calls"] = canonical_calls
 
     return normalized
 
@@ -204,7 +265,7 @@ def _normalize_ir_dict(data: dict[str, Any]) -> dict[str, Any]:
 def _legacy_to_ir_dict(data: dict[str, Any]) -> dict[str, Any]:
     workflow_inputs = dict(data.get("inputs", {}))
     task_defs: dict[str, dict[str, Any]] = {}
-    calls: list[dict[str, Any]] = []
+    steps: list[dict[str, Any]] = []
     previous_task_outputs: dict[str, dict[str, str]] = {}
 
     for raw_task in data.get("tasks", []):
@@ -230,15 +291,22 @@ def _legacy_to_ir_dict(data: dict[str, Any]) -> dict[str, Any]:
             "outputs": outputs,
             "runtime": _normalize_runtime(raw_task),
         }
-        calls.append({"id": task_name, "task": task_name, "inputs": call_inputs})
+        steps.append(
+            {
+                "kind": "call",
+                "id": task_name,
+                "task": task_name,
+                "inputs": call_inputs,
+            }
+        )
         previous_task_outputs[task_name] = {
             output_name: output_spec["type"]
             for output_name, output_spec in outputs.items()
         }
 
     workflow_outputs = dict(data.get("outputs", {}))
-    if not workflow_outputs and calls:
-        last_call_id = calls[-1]["id"]
+    if not workflow_outputs and steps:
+        last_call_id = steps[-1]["id"]
         workflow_outputs = {
             output_name: f"{last_call_id}.{output_name}"
             for output_name in task_defs[last_call_id]["outputs"]
@@ -249,8 +317,7 @@ def _legacy_to_ir_dict(data: dict[str, Any]) -> dict[str, Any]:
         "workflow": {
             "name": data["workflow_name"],
             "inputs": workflow_inputs,
-            "calls": calls,
-            "steps": [_normalize_call_step(call) for call in calls],
+            "steps": steps,
             "outputs": workflow_outputs,
         },
         "tasks": task_defs,
@@ -290,6 +357,7 @@ def _normalize_runtime(task_data: dict[str, Any]) -> dict[str, Any]:
 def _normalize_call_step(call: dict[str, Any]) -> dict[str, Any]:
     normalized = copy.deepcopy(call)
     normalized.setdefault("kind", "call")
+    normalized.setdefault("inputs", {})
     return normalized
 
 
@@ -310,13 +378,13 @@ def _normalize_step_dict(step: dict[str, Any]) -> dict[str, Any]:
     return normalized
 
 
-def _flatten_call_steps(steps: list[dict[str, Any]]) -> list[dict[str, Any]]:
+def _flatten_call_step_dicts(steps: list[dict[str, Any]]) -> list[dict[str, Any]]:
     calls = []
     for step in steps:
         if step.get("kind", "call") == "call":
             calls.append(_normalize_call_step(step))
         elif step.get("kind") == "scatter":
-            calls.extend(_flatten_call_steps(step.get("body", [])))
+            calls.extend(_flatten_call_step_dicts(step.get("body", [])))
     return calls
 
 

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -10,6 +10,7 @@ from src.catalog import load_tool_catalog, resolve_tool_plan
 from src.catalog.schema import ToolSpec
 from src.recipes import load_recipe_catalog
 from src.renderers import render_wdl
+from src.schema import flatten_workflow_calls
 
 
 CATALOG_TOOLS_DIR = Path(__file__).resolve().parents[1] / "src" / "catalog" / "tools"
@@ -361,7 +362,7 @@ class CatalogResolutionTests(unittest.TestCase):
 
         self.assertTrue(report.is_valid, report.errors)
         self.assertEqual(
-            workflow_ir.workflow.calls[-1].inputs["report_files"],
+            flatten_workflow_calls(workflow_ir.workflow.steps)[-1].inputs["report_files"],
             ["qc.html_report", "qc.json_report", "quantify.log_file"],
         )
         self.assertIn("report_files = flatten([qc.html_report, qc.json_report, quantify.log_file])", wdl)

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -347,6 +347,22 @@ class CatalogResolutionTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "unknown param 'magic'"):
             resolve_tool_plan(plan, self.recipe_catalog, self.tool_catalog)
 
+    def test_resolver_does_not_infer_missing_workflow_outputs(self):
+        plan = copy.deepcopy(sample_rnaseq_tool_plan())
+        plan["workflow"].pop("outputs")
+
+        workflow_ir = resolve_tool_plan(
+            plan,
+            self.recipe_catalog,
+            self.tool_catalog,
+        )
+        report = analyze_workflow_ir(workflow_ir)
+        workflow_wdl = render_wdl(workflow_ir).split("\ntask ", maxsplit=1)[0]
+
+        self.assertTrue(report.is_valid, report.errors)
+        self.assertEqual(workflow_ir.workflow.outputs, {})
+        self.assertNotIn("\n  output {", workflow_wdl)
+
     def test_multiqc_report_files_can_be_auto_collected_from_output_tags(self):
         plan = copy.deepcopy(sample_rnaseq_tool_plan())
         report_call = plan["workflow"]["tool_calls"][-1]

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -17,8 +17,9 @@ def sample_multi_task_ir() -> dict[str, Any]:
                 "raw_r2": "File",
                 "reference": "File",
             },
-            "calls": [
+            "steps": [
                 {
+                    "kind": "call",
                     "id": "qc",
                     "task": "fastp",
                     "inputs": {
@@ -27,6 +28,7 @@ def sample_multi_task_ir() -> dict[str, Any]:
                     },
                 },
                 {
+                    "kind": "call",
                     "id": "align",
                     "task": "bwa_mem",
                     "inputs": {
@@ -213,7 +215,7 @@ class WorkflowCompilationTests(unittest.TestCase):
 
     def test_analyzer_rejects_forward_output_reference(self):
         raw_ir = sample_multi_task_ir()
-        raw_ir["workflow"]["calls"].reverse()
+        raw_ir["workflow"]["steps"].reverse()
 
         workflow_ir = coerce_workflow_ir(raw_ir)
         report = analyze_workflow_ir(workflow_ir)
@@ -223,13 +225,13 @@ class WorkflowCompilationTests(unittest.TestCase):
 
     def test_compiler_graph_repairs_forward_output_reference_order(self):
         raw_ir = sample_multi_task_ir()
-        raw_ir["workflow"]["calls"].reverse()
+        raw_ir["workflow"]["steps"].reverse()
 
         final_state = compiler_graph.invoke(initial_state(raw_ir))
 
         self.assertTrue(final_state["is_valid"], final_state["validation_message"])
         self.assertEqual(
-            [call["id"] for call in final_state["workflow_ir"]["workflow"]["calls"]],
+            [step["id"] for step in final_state["workflow_ir"]["workflow"]["steps"]],
             ["qc", "align"],
         )
         self.assertTrue(final_state["repair_actions"])
@@ -237,7 +239,7 @@ class WorkflowCompilationTests(unittest.TestCase):
     def test_analyzer_allows_omitted_optional_call_inputs(self):
         raw_ir = sample_multi_task_ir()
         raw_ir["tasks"]["fastp"]["inputs"]["r2"] = "File?"
-        raw_ir["workflow"]["calls"][0]["inputs"].pop("r2")
+        raw_ir["workflow"]["steps"][0]["inputs"].pop("r2")
 
         workflow_ir = coerce_workflow_ir(raw_ir)
         report = analyze_workflow_ir(workflow_ir)
@@ -405,7 +407,7 @@ class WorkflowCompilationTests(unittest.TestCase):
         workflow_ir = coerce_workflow_ir(legacy_json)
 
         self.assertEqual(workflow_ir.workflow.name, "SimpleQC")
-        self.assertEqual(workflow_ir.workflow.calls[0].id, "fastp_qc")
+        self.assertEqual(workflow_ir.workflow.steps[0].id, "fastp_qc")
         self.assertEqual(
             workflow_ir.tasks["fastp_qc"].runtime.docker,
             "quay.io/biocontainers/fastp:1.3.3--h43da1c4_0",
@@ -425,7 +427,7 @@ class WorkflowCompilationTests(unittest.TestCase):
 
     def test_compiler_graph_stops_when_repairer_has_no_safe_action(self):
         raw_ir = sample_multi_task_ir()
-        raw_ir["workflow"]["calls"][0]["inputs"]["r1"] = "missing_input"
+        raw_ir["workflow"]["steps"][0]["inputs"]["r1"] = "missing_input"
 
         final_state = compiler_graph.invoke(initial_state(raw_ir))
 

--- a/tests/test_reviewer_node.py
+++ b/tests/test_reviewer_node.py
@@ -415,7 +415,7 @@ class ReviewerNodeTests(unittest.TestCase):
             }
         )
         state = self.sample_state()
-        task_name = state["workflow_ir"]["workflow"]["calls"][0]["task"]
+        task_name = state["workflow_ir"]["workflow"]["steps"][0]["task"]
         state["workflow_ir"]["tasks"][task_name]["command"] = "echo tampered"
 
         update = self.make_node(provider)(state)

--- a/tests/test_reviewer_patcher.py
+++ b/tests/test_reviewer_patcher.py
@@ -30,16 +30,6 @@ def sample_workflow_ir():
                     },
                 }
             ],
-            "calls": [
-                {
-                    "kind": "call",
-                    "id": "qc",
-                    "task": "fastp",
-                    "inputs": {
-                        "r1": "raw_r1",
-                    },
-                }
-            ],
             "outputs": {
                 "clean_r1": "qc.clean_r1",
                 "legacy_report": "qc.clean_r1",
@@ -80,17 +70,6 @@ def sample_ordering_ir():
             },
         },
         workflow_ir["workflow"]["steps"][0],
-    ]
-    workflow_ir["workflow"]["calls"] = [
-        {
-            "kind": "call",
-            "id": "align",
-            "task": "bwa_mem",
-            "inputs": {
-                "r1": "qc.clean_r1",
-            },
-        },
-        workflow_ir["workflow"]["calls"][0],
     ]
     workflow_ir["tasks"]["bwa_mem"] = {
         "inputs": {
@@ -172,7 +151,7 @@ class ReviewerPatcherTests(unittest.TestCase):
         self.assertEqual(patched.workflow.outputs["clean_r1"], "qc.clean_r1")
         self.assertEqual(patched.tasks["fastp"].outputs["clean_r1"].value, "\"clean_R1.fq.gz\"")
         self.assertNotIn("r2", original["workflow"]["steps"][0]["inputs"])
-        self.assertNotIn("r2", original["workflow"]["calls"][0]["inputs"])
+        self.assertNotIn("calls", original["workflow"])
 
     def test_apply_reviewer_patch_removes_workflow_output_without_mutating_original(self):
         original = sample_workflow_ir()
@@ -194,7 +173,7 @@ class ReviewerPatcherTests(unittest.TestCase):
         self.assertNotIn("legacy_report", patched.workflow.outputs)
         self.assertIn("legacy_report", original["workflow"]["outputs"])
 
-    def test_apply_reviewer_patch_moves_workflow_steps_and_syncs_calls(self):
+    def test_apply_reviewer_patch_moves_steps_and_regenerates_compatibility_calls(self):
         original = sample_ordering_ir()
         patch = ReviewerIRPatch.model_validate(
             {
@@ -260,7 +239,7 @@ class ReviewerPatcherTests(unittest.TestCase):
             apply_reviewer_patch(original, patch)
 
         self.assertEqual(original["workflow"]["steps"][0]["inputs"]["r1"], "raw_r1")
-        self.assertEqual(original["workflow"]["calls"][0]["inputs"]["r1"], "raw_r1")
+        self.assertNotIn("calls", original["workflow"])
 
     def test_apply_reviewer_patch_rejects_missing_replace_target_without_mutating_original(self):
         original = sample_workflow_ir()

--- a/tests/test_run_repository.py
+++ b/tests/test_run_repository.py
@@ -462,7 +462,7 @@ class RunRepositoryTests(unittest.TestCase):
                 DiagnosticReport(
                     analysis_errors=["missing input"],
                     analysis_warnings=["unused output"],
-                    repair_actions=["reordered calls"],
+                    repair_actions=["reordered steps"],
                     validation_message="missing input",
                     is_valid=False,
                     succeeded=False,

--- a/tests/test_run_service.py
+++ b/tests/test_run_service.py
@@ -55,7 +55,7 @@ def natural_language_result(
 
 def repairable_forward_reference_ir() -> dict:
     workflow_ir = load_example("rnaseq_workflow_ir.json")
-    workflow_ir["workflow"]["calls"].reverse()
+    workflow_ir["workflow"]["steps"].reverse()
     return workflow_ir
 
 
@@ -122,7 +122,7 @@ class RunServiceTests(unittest.TestCase):
             self.assertEqual(snapshot.status, RunStatus.SUCCEEDED)
             self.assertTrue(snapshot.diagnostics.repair_actions)
             self.assertEqual(
-                [call["id"] for call in snapshot.artifacts.workflow_ir["workflow"]["calls"]],
+                [step["id"] for step in snapshot.artifacts.workflow_ir["workflow"]["steps"]],
                 ["qc", "align"],
             )
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,0 +1,129 @@
+import unittest
+
+from pydantic import ValidationError
+
+from src.schema import (
+    WorkflowCompatibilityError,
+    WorkflowIR,
+    coerce_workflow_ir,
+    compatibility_calls_match_steps,
+    flatten_workflow_calls,
+    refresh_compatibility_calls,
+)
+
+
+def call_step(call_id: str = "qc", input_value: str = "raw_fastq") -> dict:
+    return {
+        "kind": "call",
+        "id": call_id,
+        "task": "fastp",
+        "inputs": {"fastq": input_value},
+    }
+
+
+def workflow_ir(workflow: dict) -> dict:
+    return {
+        "workflow": {
+            "name": "CompatibilityDemo",
+            "inputs": {"raw_fastq": "File"},
+            "outputs": {},
+            **workflow,
+        },
+        "tasks": {},
+    }
+
+
+class WorkflowSchemaCompatibilityTests(unittest.TestCase):
+    def test_calls_only_input_builds_canonical_steps(self):
+        legacy_call = call_step()
+        legacy_call.pop("kind")
+
+        parsed = coerce_workflow_ir(workflow_ir({"calls": [legacy_call]}))
+
+        self.assertEqual([step.id for step in parsed.workflow.steps], ["qc"])
+        self.assertTrue(compatibility_calls_match_steps(parsed.workflow))
+
+    def test_steps_only_input_builds_flattened_compatibility_view(self):
+        parsed = coerce_workflow_ir(
+            workflow_ir(
+                {
+                    "steps": [
+                        {
+                            "kind": "scatter",
+                            "id": "per_sample",
+                            "item": "i",
+                            "over": "range(1)",
+                            "body": [call_step()],
+                        }
+                    ]
+                }
+            )
+        )
+
+        self.assertEqual([call.id for call in parsed.workflow.calls], ["qc"])
+        self.assertIsNot(
+            parsed.workflow.calls[0],
+            flatten_workflow_calls(parsed.workflow.steps)[0],
+        )
+
+    def test_coercion_rejects_mismatched_dual_views(self):
+        data = workflow_ir(
+            {
+                "steps": [call_step()],
+                "calls": [call_step(input_value="tampered_input")],
+            }
+        )
+
+        with self.assertRaisesRegex(
+            WorkflowCompatibilityError,
+            "compatibility calls do not match canonical workflow steps",
+        ):
+            coerce_workflow_ir(data)
+
+    def test_coercion_accepts_equivalent_default_call_inputs(self):
+        canonical_call = call_step()
+        canonical_call.pop("inputs")
+        compatibility_call = call_step()
+        compatibility_call["inputs"] = {}
+
+        parsed = coerce_workflow_ir(
+            workflow_ir(
+                {
+                    "steps": [canonical_call],
+                    "calls": [compatibility_call],
+                }
+            )
+        )
+
+        self.assertTrue(compatibility_calls_match_steps(parsed.workflow))
+
+    def test_direct_model_validation_rejects_mismatched_dual_views(self):
+        data = workflow_ir(
+            {
+                "steps": [call_step()],
+                "calls": [call_step(input_value="tampered_input")],
+            }
+        )
+
+        with self.assertRaisesRegex(
+            ValidationError,
+            "compatibility calls do not match canonical workflow steps",
+        ):
+            WorkflowIR.model_validate(data)
+
+    def test_refresh_rebuilds_detached_compatibility_snapshot(self):
+        parsed = coerce_workflow_ir(workflow_ir({"steps": [call_step()]}))
+        canonical_call = flatten_workflow_calls(parsed.workflow.steps)[0]
+        canonical_call.inputs["fastq"] = "updated_fastq"
+
+        self.assertFalse(compatibility_calls_match_steps(parsed.workflow))
+
+        refresh_compatibility_calls(parsed.workflow)
+
+        self.assertTrue(compatibility_calls_match_steps(parsed.workflow))
+        self.assertIsNot(parsed.workflow.calls[0], canonical_call)
+        self.assertEqual(parsed.workflow.calls[0].inputs["fastq"], "updated_fastq")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_workflow_service.py
+++ b/tests/test_workflow_service.py
@@ -41,8 +41,9 @@ def repairable_forward_reference_ir() -> dict:
                 "raw_r2": "File",
                 "reference": "File",
             },
-            "calls": [
+            "steps": [
                 {
+                    "kind": "call",
                     "id": "align",
                     "task": "bwa_mem",
                     "inputs": {
@@ -52,6 +53,7 @@ def repairable_forward_reference_ir() -> dict:
                     },
                 },
                 {
+                    "kind": "call",
                     "id": "qc",
                     "task": "fastp",
                     "inputs": {
@@ -182,7 +184,7 @@ class WorkflowServiceTests(unittest.TestCase):
         self.assertEqual(events[artifact_index]["node"], "repairer")
         self.assertEqual(events[artifact_index]["payload"], {"artifact": "workflow_ir"})
         self.assertEqual(
-            [call["id"] for call in events[artifact_index]["workflow_ir"]["workflow"]["calls"]],
+            [step["id"] for step in events[artifact_index]["workflow_ir"]["workflow"]["steps"]],
             ["qc", "align"],
         )
 
@@ -204,7 +206,7 @@ class WorkflowServiceTests(unittest.TestCase):
             )
 
         repaired_ir = repairable_forward_reference_ir()
-        repaired_ir["workflow"]["calls"].reverse()
+        repaired_ir["workflow"]["steps"].reverse()
         with (
             patch(
                 "src.services.workflow_service.checker_node",
@@ -238,7 +240,7 @@ class WorkflowServiceTests(unittest.TestCase):
         self.assertEqual(events[artifact_index]["node"], "repairer")
         self.assertEqual(events[artifact_index]["payload"], {"artifact": "workflow_ir"})
         self.assertEqual(
-            [call["id"] for call in events[artifact_index]["workflow_ir"]["workflow"]["calls"]],
+            [step["id"] for step in events[artifact_index]["workflow_ir"]["workflow"]["steps"]],
             ["qc", "align"],
         )
 

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -33,7 +33,7 @@ const pipelineStages = [
   },
   {
     label: "Workflow IR",
-    detail: "编译契约记录 steps、calls、scatter 和 workflow outputs。",
+    detail: "编译契约记录 call/scatter steps 和 workflow outputs。",
   },
   {
     label: "Analyzer / Repairer",
@@ -102,7 +102,7 @@ const systemSurfaces: Array<{
   },
   {
     title: "DAG",
-    description: "查看 Workflow IR 的 calls、scatter、依赖边和结构状态。",
+    description: "查看 Workflow IR 的 call/scatter steps、依赖边和结构状态。",
     icon: Network,
   },
 ];


### PR DESCRIPTION
## Summary

- make `workflow.steps` the sole canonical DAG representation
- preserve calls-only legacy input while generating `workflow.calls` as a detached compatibility snapshot
- reject inconsistent dual-view inputs instead of silently accepting drift
- migrate the resolver, analyzer, repairer, Reviewer flow, examples, tests, and documentation to canonical steps

## Why

`workflow.calls` and `workflow.steps` could previously be maintained independently, which allowed the two views to drift and left duplicate flattening and synchronization logic across business modules. This change centralizes compatibility handling in the Workflow IR schema and keeps internal decisions on one DAG source.

## Impact

The compatibility field is not removed. Existing calls-only structured inputs remain supported, and serialized Workflow IR still includes flattened calls for older consumers. New and internal code uses `workflow.steps`; conflicting steps/calls payloads are rejected explicitly.

## Validation

- focused schema, Catalog, Reviewer, workflow service, run service, and repository tests passed
- representative WDL generated successfully from `examples/rnaseq_workflow_ir.json` with `--no-check`
- full Python suite: 240 tests, 233 passed, 4 skipped, 3 blocked by the unavailable local WOMtool/miniwdl validator
- `git diff --check` passed
- frontend graph test could not start because workspace Node dependencies are not installed (`tsx` unavailable)
