### PR TITLE
Route analyzer failures through bounded Reviewer repair

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -136,11 +136,19 @@ checker_node     # WDL syntax validation
   ↓
 END
 
-analyzer_node 或 checker_node 发现错误时，如果 repairer 还有重试预算，会进入：
+Analyzer failure recovery：
 
-repairer_node    # 可确定修复时更新 IR
+analyzer_node
   ↓
-analyzer_node    # 修复后重新分析、渲染、校验
+repairer_node       # 始终先尝试确定性修复
+  ├─ 有安全动作 -> analyzer_node -> renderer_node -> checker_node
+  └─ 无安全动作 -> reviewer_repair
+                      ├─ patch 已应用 -> analyzer_node -> renderer_node -> checker_node
+                      └─ disabled / rejected / error / budget exhausted -> END
+
+`reviewer_repair` 默认禁用，独立预算默认为一次；禁用或缺少 provider 时不会调用
+模型。Checker failure 当前仍只走 deterministic repairer，Reviewer routing 留给后续
+独立 PR。
 ```
 
 ## 已完成的容器管理边界

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -141,8 +141,9 @@ Analyzer failure recovery：
 analyzer_node
   ↓
 repairer_node       # 始终先尝试确定性修复
+  ├─ 内部失败 -> END，并保留 repairer diagnostic
   ├─ 有安全动作 -> analyzer_node -> renderer_node -> checker_node
-  └─ 无安全动作 -> reviewer_repair
+  └─ 正常完成但无安全动作 -> reviewer_repair
                       ├─ patch 已应用 -> analyzer_node -> renderer_node -> checker_node
                       └─ disabled / rejected / error / budget exhausted -> END
 

--- a/docs/p2-reviewer-repair-plan.md
+++ b/docs/p2-reviewer-repair-plan.md
@@ -250,6 +250,8 @@ artifacts，避免前端和 API 消费方解析文本 summary。
 
 - 第一部分只接入 Analyzer failure routing。deterministic repairer 有安全动作时不
   调用 Reviewer；无安全动作时才进入 Reviewer branch。
+- deterministic repairer 内部失败使用独立状态终止当前分支并保留 diagnostic，
+  不得被解释为正常的 `no_action`，也不得触发 Reviewer model call。
 - Reviewer 使用独立 `reviewer_attempt_count`，默认最多调用 provider 一次。禁用、
   provider 不可用、拒绝、model error 或预算耗尽都终止该分支并保留 diagnostics。
 - 已应用 patch 重新进入 Analyzer、Renderer 和 Checker。

--- a/docs/p2-reviewer-repair-plan.md
+++ b/docs/p2-reviewer-repair-plan.md
@@ -246,6 +246,16 @@ artifacts，避免前端和 API 消费方解析文本 summary。
 - deterministic repair 放弃且 policy 允许时调用 Reviewer。
 - 修复次数耗尽时返回 failed diagnostic report。
 
+当前拆分：
+
+- 第一部分只接入 Analyzer failure routing。deterministic repairer 有安全动作时不
+  调用 Reviewer；无安全动作时才进入 Reviewer branch。
+- Reviewer 使用独立 `reviewer_attempt_count`，默认最多调用 provider 一次。禁用、
+  provider 不可用、拒绝、model error 或预算耗尽都终止该分支并保留 diagnostics。
+- 已应用 patch 重新进入 Analyzer、Renderer 和 Checker。
+- Checker failure routing 不在第一部分启用，继续使用现有 deterministic repair
+  行为，后续独立 PR 再接入 Reviewer。
+
 ### P2.5 Run Service 与 API Observability
 
 交付：
@@ -340,3 +350,16 @@ Windows PowerShell：
   Analyzer failure routing 和 Checker failure routing 按后续 PR 分别接入。
 - Policy rejection 与 application failure 使用不同异常类别。前者表示越过 P2
   allowlist，后者表示 policy 允许的 patch 无法安全应用到当前 Workflow IR。
+
+## 已确认的 P2.4 Analyzer Routing 决策
+
+- `build_compiler_graph(...)` 通过显式注入 Reviewer node 启用模型路径；默认导出的
+  `compiler_graph` 使用 disabled Reviewer，不依赖 API key。
+- Analyzer failure 始终先尝试 deterministic repair。只有没有安全动作，或
+  deterministic budget 已耗尽时，才进入 Analyzer Reviewer branch。
+- Reviewer provider 默认最多调用一次，预算与 `repair_count` 分离。预算耗尽时不
+  再创建或调用 provider，并保留已有 parsed patch、rejection reason 和 diagnostics。
+- 只有 `reviewer_patch_applied=True` 才重新进入 Analyzer；其他 Reviewer 状态全部
+  结束当前 Compiler Graph 分支。
+- Checker failure 通过 `analysis_errors` 为空与 Analyzer branch 隔离，本 PR 不改变
+  Checker routing。

--- a/docs/test-cases.md
+++ b/docs/test-cases.md
@@ -2997,6 +2997,29 @@ Analyzer Reviewer branch 的交互。
 
 - Reviewer 不抢占可以确定性修复的 Analyzer failure。
 
+### `test_repairer_failure_stops_before_reviewer`
+
+输入：
+
+- 使用 `missing_input` 触发 Analyzer failure。
+- 注入 enabled Reviewer provider。
+- mock deterministic repair implementation 抛出异常。
+
+执行：
+
+- 调用注入 Reviewer node 的 Compiler Graph。
+
+期望输出：
+
+- `repairer_failed == True`，且 deterministic `repair_count == 1`。
+- repairer diagnostic 保留在 state messages 中。
+- Reviewer provider 调用次数为零，Reviewer status 保持为空。
+
+覆盖点：
+
+- deterministic repairer 内部失败与正常完成后的 `no_action` 是不同状态。
+- 内部异常会明确终止，不会被 Reviewer routing 掩盖或触发模型调用。
+
 ### `test_analyzer_allows_omitted_optional_call_inputs`
 
 输入：
@@ -3744,6 +3767,29 @@ Agent 占位逻辑。
 
 - service 不吞掉 resolver/catalog 诊断。
 - 无效 plan 不会产生 WDL。
+
+### `test_analyzer_repair_failure_emits_failed_event`
+
+输入：
+
+- 使用可触发 Analyzer repair 的 forward-reference Workflow IR。
+- mock deterministic repair implementation 抛出异常。
+- 注入 event callback。
+
+执行：
+
+- 调用 `compile_structured_workflow(..., check=False, event_callback=...)`。
+
+期望输出：
+
+- 编译失败，`repairer_failed == True` 且 `repair_count == 1`。
+- repairer 事件序列为 `node.started`、`node.failed`。
+- failed event payload 明确包含 `repairer_failed: true`。
+
+覆盖点：
+
+- workflow service 保留 deterministic repairer 的显式失败状态。
+- repairer 异常不会被错误记录为“正常完成但无安全修复动作”。
 
 ### `test_plan_and_compile_workflow_plans_then_compiles`
 

--- a/docs/test-cases.md
+++ b/docs/test-cases.md
@@ -2565,9 +2565,10 @@ result 和 policy 边界。
 
 ## `tests/test_reviewer_node.py`
 
-该文件验证 P2.3 `reviewer_repair` compiler node 的独立行为。Node 已具备
-Provider 注入、request 构造、patch 校验和应用能力，但本阶段不添加 Compiler
-Graph edge；Analyzer 和 Checker routing 留给 P2.4。
+该文件验证 P2.3 `reviewer_repair` compiler node 的独立行为。Node 具备 Provider
+注入、request 构造、patch 校验、应用和 attempt budget 能力。P2.4 Analyzer
+routing 通过 `build_compiler_graph(...)` 使用该 node；Checker request contract 已
+保留，但 Checker routing 仍留给后续 PR。
 
 ### `test_default_reviewer_node_is_callable_and_disabled`
 
@@ -2883,7 +2884,8 @@ Graph edge；Analyzer 和 Checker routing 留给 P2.4。
 
 ## `tests/test_graph.py`
 
-该文件验证 Compiler Graph、Analyzer、Renderer 和 deterministic repairer 的交互。
+该文件验证 Compiler Graph、Analyzer、Renderer、deterministic repairer 和有界
+Analyzer Reviewer branch 的交互。
 
 ### `test_multi_task_ir_analyzes_and_renders`
 
@@ -2973,6 +2975,27 @@ Graph edge；Analyzer 和 Checker routing 留给 P2.4。
 覆盖点：
 
 - Deterministic repairer 能修复可由依赖关系确定的 call 顺序问题。
+
+### `test_deterministic_repair_does_not_call_reviewer`
+
+输入：
+
+- 将 `sample_multi_task_ir()` 的 canonical steps 顺序反转。
+- 注入一个记录调用次数的 enabled Reviewer provider。
+
+执行：
+
+- 调用 `build_compiler_graph(...)` 构造测试图并执行。
+
+期望输出：
+
+- deterministic repairer 恢复 `qc -> align` 顺序。
+- `repair_actions` 非空。
+- Reviewer provider 调用次数为零，`reviewer_attempt_count == 0`。
+
+覆盖点：
+
+- Reviewer 不抢占可以确定性修复的 Analyzer failure。
 
 ### `test_analyzer_allows_omitted_optional_call_inputs`
 
@@ -3104,7 +3127,7 @@ files = flatten([qc.html_report, qc.json_report, [extra_report]])
 
 - Deterministic repairer 能修复 File/String output 字面量缺少引号的问题。
 
-### `test_compiler_graph_stops_when_repairer_has_no_safe_action`
+### `test_compiler_graph_stops_after_disabled_reviewer_has_no_safe_action`
 
 输入：
 
@@ -3120,10 +3143,103 @@ files = flatten([qc.html_report, qc.json_report, [extra_report]])
 - final state 中 `is_valid=False`。
 - `analysis_errors` 包含 `references unknown value 'missing_input'`。
 - `repair_actions == []`。
+- `reviewer_repair_status == "no_action"`，attempt count 保持零。
+- diagnostics 说明 Reviewer disabled。
 
 覆盖点：
 
 - Repairer 对无法安全推断的问题不做自由修复。
+- 默认 Compiler Graph 不启用模型，也不依赖 API key。
+
+### `test_analyzer_failure_routes_to_reviewer_after_no_safe_repair`
+
+输入：
+
+- 使用相同的 `missing_input` Analyzer failure。
+- 注入返回 `no_action` 的 enabled Reviewer provider。
+
+执行：
+
+- 调用注入 Reviewer node 的 Compiler Graph。
+
+期望输出：
+
+- deterministic `repair_count == 1` 且没有 repair actions。
+- Provider 只调用一次，请求的 failure stage 为 `analyzer`。
+- Reviewer attempt count 为一，status 为 `no_action`。
+- 原始 Analyzer diagnostics 保留，图明确结束。
+
+覆盖点：
+
+- Analyzer Reviewer 只在 deterministic repairer 放弃后触发。
+- Reviewer no-op 不会重新进入 Analyzer 或形成循环。
+
+### `test_analyzer_reviewer_patch_reenters_compiler_pipeline`
+
+输入：
+
+- 使用 `missing_input` Analyzer failure。
+- Reviewer patch 把 `/workflow/steps/0/inputs/r1` 替换为已声明的 `raw_r1`。
+
+执行：
+
+- 调用注入 Reviewer node 的 Compiler Graph。
+
+期望输出：
+
+- Provider 调用一次，patch status 为 `patch_proposed`。
+- patched canonical step 使用 `r1 = raw_r1`。
+- Analyzer errors 清空，Renderer 生成包含该 wiring 的 WDL。
+
+覆盖点：
+
+- 只有已应用的 Reviewer patch 才回到 Analyzer，并继续 Renderer/Checker 流程。
+- Reviewer 只修改 Workflow IR，不直接修改 WDL。
+
+### `test_analyzer_reviewer_attempt_budget_stops_second_model_call`
+
+输入：
+
+- 使用 `missing_input` Analyzer failure。
+- 初始 `reviewer_attempt_count == 1`，并带有上一轮 parsed patch、rejection reason
+  和 diagnostics。
+
+执行：
+
+- 调用默认 Reviewer budget 为一次的测试图。
+
+期望输出：
+
+- Provider 调用次数为零，attempt count 不增加。
+- diagnostics 追加 budget exhausted 说明。
+- 上一轮 parsed patch 和 rejection reason 保留。
+
+覆盖点：
+
+- Reviewer budget 在 provider 创建或调用前强制执行。
+- 次数耗尽会显式结束，不丢失已有审计数据。
+
+### `test_checker_failure_does_not_route_to_analyzer_reviewer`
+
+输入：
+
+- 有效的 `sample_multi_task_ir()`。
+- Checker 返回合成 validation failure。
+- 注入一个记录调用次数的 enabled Analyzer Reviewer provider。
+
+执行：
+
+- 调用 Compiler Graph。
+
+期望输出：
+
+- Checker failure 仍先进入 deterministic repairer，且没有安全动作。
+- Analyzer Reviewer provider 调用次数为零。
+- validation message 保留，Reviewer status 仍为空。
+
+覆盖点：
+
+- P2.4 第一部分没有提前启用 Checker Reviewer routing。
 
 ### `test_compiler_graph_compiles_recipe_tool_plan`
 

--- a/src/graph.py
+++ b/src/graph.py
@@ -45,6 +45,8 @@ def route_after_checker(state: WorkflowState):
 
 
 def route_after_repairer(state: WorkflowState):
+    if state.get("repairer_failed"):
+        return END
     if state.get("repair_actions"):
         return "analyzer"
     if state.get("analysis_errors") and state.get("workflow_ir"):

--- a/src/graph.py
+++ b/src/graph.py
@@ -7,6 +7,10 @@ from src.nodes.checker import checker_node
 from src.nodes.ir_normalizer import ir_normalizer_node
 from src.nodes.renderer import renderer_node
 from src.nodes.repairer import repairer_node
+from src.nodes.reviewer_repair import (
+    ReviewerNode,
+    reviewer_repair_node as default_reviewer_repair_node,
+)
 from src.state import WorkflowState
 from src.tools.validator import VALIDATOR_MISSING_MARKER
 
@@ -24,6 +28,8 @@ def route_after_analyzer(state: WorkflowState):
     if state.get("analysis_errors"):
         if _can_attempt_repair(state):
             return "repairer"
+        if state.get("workflow_ir"):
+            return "reviewer_repair"
         return END
     return "renderer"
 
@@ -41,6 +47,14 @@ def route_after_checker(state: WorkflowState):
 def route_after_repairer(state: WorkflowState):
     if state.get("repair_actions"):
         return "analyzer"
+    if state.get("analysis_errors") and state.get("workflow_ir"):
+        return "reviewer_repair"
+    return END
+
+
+def route_after_reviewer(state: WorkflowState):
+    if state.get("reviewer_patch_applied"):
+        return "analyzer"
     return END
 
 
@@ -52,28 +66,32 @@ def _missing_local_validator(state: WorkflowState) -> bool:
     return VALIDATOR_MISSING_MARKER in state.get("validation_message", "")
 
 
-# 1. 实例化状态图，传入我们的 WorkflowState 笔记本
-builder = StateGraph(WorkflowState)
+def build_compiler_graph(*, reviewer_node: ReviewerNode | None = None):
+    """Build the compiler graph with an explicitly injected Reviewer node."""
+    resolved_reviewer_node = (
+        reviewer_node
+        if reviewer_node is not None
+        else default_reviewer_repair_node
+    )
+    builder = StateGraph(WorkflowState)
+    builder.add_node("ir_normalizer", ir_normalizer_node)
+    builder.add_node("analyzer", analyzer_node)
+    builder.add_node("renderer", renderer_node)
+    builder.add_node("checker", checker_node)
+    builder.add_node("repairer", repairer_node)
+    builder.add_node("reviewer_repair", resolved_reviewer_node)
 
-# 2. 添加工作节点
-# 第一个参数是节点的内部名称（随便起），第二个参数是我们刚才写的处理函数
-builder.add_node("ir_normalizer", ir_normalizer_node)
-builder.add_node("analyzer", analyzer_node)
-builder.add_node("renderer", renderer_node)
-builder.add_node("checker", checker_node)
-builder.add_node("repairer", repairer_node)
+    builder.add_edge(START, "ir_normalizer")
+    builder.add_conditional_edges("ir_normalizer", route_after_ir_normalizer)
+    builder.add_conditional_edges("analyzer", route_after_analyzer)
+    builder.add_edge("renderer", "checker")
+    builder.add_conditional_edges("checker", route_after_checker)
+    builder.add_conditional_edges("repairer", route_after_repairer)
+    builder.add_conditional_edges("reviewer_repair", route_after_reviewer)
+    return builder.compile()
 
-# 3. 规划工作流向 (连线)
-# START -> ir_normalizer -> analyzer -> renderer -> checker -> END
-# analyzer/checker can branch to repairer, then repairer returns to analyzer.
-builder.add_edge(START, "ir_normalizer")
-builder.add_conditional_edges("ir_normalizer", route_after_ir_normalizer)
-builder.add_conditional_edges("analyzer", route_after_analyzer)
-builder.add_edge("renderer", "checker")
-builder.add_conditional_edges("checker", route_after_checker)
-builder.add_conditional_edges("repairer", route_after_repairer)
-# 4. 编译打包成结构化 Workflow IR -> WDL 编译子图
-compiler_graph = builder.compile()
+
+compiler_graph = build_compiler_graph()
 
 # Backward-compatible alias for older imports. New code should use
 # compiler_graph to make the graph boundary explicit.

--- a/src/nodes/repairer.py
+++ b/src/nodes/repairer.py
@@ -14,6 +14,7 @@ def repairer_node(state: WorkflowState):
     Deterministically repair WorkflowIR when the analyzer/checker finds a safe fix.
     """
     logger.info("Repairer node is attempting to repair Workflow IR.")
+    repair_count = state.get("repair_count", 0) + 1
 
     try:
         report = repair_workflow_ir(state.get("workflow_ir", {}))
@@ -21,14 +22,16 @@ def repairer_node(state: WorkflowState):
         message = f"Workflow IR 修复失败: {exc}"
         return {
             "repair_actions": [],
+            "repair_count": repair_count,
+            "repairer_failed": True,
             "messages": [AIMessage(content=message)],
         }
 
-    repair_count = state.get("repair_count", 0) + 1
     if not report.changed:
         return {
             "repair_actions": [],
             "repair_count": repair_count,
+            "repairer_failed": False,
             "messages": [AIMessage(content="Repairer 未找到可安全自动修复的 IR 问题。")],
         }
 
@@ -41,5 +44,6 @@ def repairer_node(state: WorkflowState):
         "is_valid": False,
         "repair_actions": report.actions,
         "repair_count": repair_count,
+        "repairer_failed": False,
         "messages": [AIMessage(content=f"Workflow IR 已修复：\n{action_summary}")],
     }

--- a/src/nodes/reviewer_repair.py
+++ b/src/nodes/reviewer_repair.py
@@ -37,11 +37,12 @@ from src.state import WorkflowState
 
 ReviewerNode = Callable[[WorkflowState], dict[str, Any]]
 ReviewerProviderFactory = Callable[[str], ReviewerRepairProvider]
+DEFAULT_MAX_REVIEWER_ATTEMPTS = 1
 logger = logging.getLogger(__name__)
 
 
 def reviewer_repair_node(state: WorkflowState) -> dict[str, Any]:
-    """Default-disabled Reviewer node retained for later Compiler Graph routing."""
+    """Run the default-disabled Reviewer branch used by the Compiler Graph."""
     return make_reviewer_repair_node()(state)
 
 
@@ -54,11 +55,28 @@ def make_reviewer_repair_node(
     provider_factory: ReviewerProviderFactory = make_default_reviewer_provider,
     tool_catalog: ToolCatalog | None = None,
     recipe_catalog: RecipeCatalog | None = None,
+    max_attempts: int = DEFAULT_MAX_REVIEWER_ATTEMPTS,
 ) -> ReviewerNode:
     """Create a Reviewer node with injectable provider and Catalog dependencies."""
+    if max_attempts < 1:
+        raise ValueError("Reviewer max_attempts must be at least 1.")
 
     def node(state: WorkflowState) -> dict[str, Any]:
         current_attempt_count = state.get("reviewer_attempt_count", 0)
+        if current_attempt_count >= max_attempts:
+            return _reviewer_update(
+                state,
+                status=ReviewerRepairStatus.NO_ACTION,
+                diagnostics=[
+                    f"Reviewer repair attempt budget exhausted ({max_attempts})."
+                ],
+                message=(
+                    "Reviewer repair attempt budget is exhausted; "
+                    "no model call was made."
+                ),
+                preserve_existing=True,
+            )
+
         if not enabled:
             return _reviewer_update(
                 state,
@@ -249,7 +267,26 @@ def _reviewer_update(
     rejection_reason: str | None = None,
     attempt_count: int | None = None,
     patch_applied: bool = False,
+    preserve_existing: bool = False,
 ) -> dict[str, Any]:
+    request_payload = (
+        request.model_dump(mode="json") if request is not None else None
+    )
+    patch_payload = patch.model_dump(mode="json") if patch is not None else None
+    resolved_rejection_reason = rejection_reason
+    resolved_diagnostics = diagnostics
+    if preserve_existing:
+        if request_payload is None:
+            request_payload = state.get("reviewer_repair_request")
+        if patch_payload is None:
+            patch_payload = state.get("reviewer_ir_patch")
+        if resolved_rejection_reason is None:
+            resolved_rejection_reason = state.get("reviewer_rejection_reason")
+        resolved_diagnostics = [
+            *list(state.get("reviewer_diagnostics") or []),
+            *diagnostics,
+        ]
+
     return {
         "reviewer_attempt_count": (
             state.get("reviewer_attempt_count", 0)
@@ -257,14 +294,10 @@ def _reviewer_update(
             else attempt_count
         ),
         "reviewer_repair_status": status.value,
-        "reviewer_repair_request": (
-            request.model_dump(mode="json") if request is not None else None
-        ),
-        "reviewer_ir_patch": (
-            patch.model_dump(mode="json") if patch is not None else None
-        ),
-        "reviewer_rejection_reason": rejection_reason,
-        "reviewer_diagnostics": diagnostics,
+        "reviewer_repair_request": request_payload,
+        "reviewer_ir_patch": patch_payload,
+        "reviewer_rejection_reason": resolved_rejection_reason,
+        "reviewer_diagnostics": resolved_diagnostics,
         "reviewer_patch_applied": patch_applied,
         "messages": [AIMessage(content=message)],
     }

--- a/src/services/workflow_service.py
+++ b/src/services/workflow_service.py
@@ -160,6 +160,7 @@ def build_initial_state(
         "error_count": 0,
         "repair_count": 0,
         "repair_actions": [],
+        "repairer_failed": False,
         "reviewer_attempt_count": 0,
         "reviewer_repair_status": None,
         "reviewer_repair_request": None,
@@ -344,6 +345,16 @@ def _analyze_with_repair(
 
         _emit_compiler_event(event_callback, "node.started", "repairer", "Repairer started.", state)
         _merge_state(state, repairer_node(state))
+        if state["repairer_failed"]:
+            _emit_compiler_event(
+                event_callback,
+                "node.failed",
+                "repairer",
+                "Repairer failed.",
+                state,
+                {"repairer_failed": True},
+            )
+            return
         if not state["repair_actions"]:
             _emit_compiler_event(
                 event_callback,
@@ -389,6 +400,16 @@ def _validate_with_repair(
 
         _emit_compiler_event(event_callback, "node.started", "repairer", "Repairer started.", state)
         _merge_state(state, repairer_node(state))
+        if state["repairer_failed"]:
+            _emit_compiler_event(
+                event_callback,
+                "node.failed",
+                "repairer",
+                "Repairer failed.",
+                state,
+                {"repairer_failed": True},
+            )
+            return
         if not state["repair_actions"]:
             _emit_compiler_event(
                 event_callback,
@@ -480,6 +501,8 @@ def _merge_state(state: WorkflowState, update: Mapping[str, Any]) -> None:
             state["repair_count"] = value
         elif key == "repair_actions":
             state["repair_actions"] = value
+        elif key == "repairer_failed":
+            state["repairer_failed"] = value
         elif key == "reviewer_attempt_count":
             state["reviewer_attempt_count"] = value
         elif key == "reviewer_repair_status":

--- a/src/state.py
+++ b/src/state.py
@@ -35,6 +35,9 @@ class WorkflowState(TypedDict):
     # 记录最近一次 IR repairer 执行的具体修复动作
     repair_actions: list[str]
 
+    # 区分 repairer 内部失败与正常完成但没有安全修复动作
+    repairer_failed: bool
+
     # Reviewer repair 使用独立计数和结构化结果，避免与 deterministic repair 混淆
     reviewer_attempt_count: int
     reviewer_repair_status: str | None

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -211,6 +211,7 @@ def initial_state(parsed_json: dict[str, Any]) -> WorkflowState:
         "error_count": 0,
         "repair_count": 0,
         "repair_actions": [],
+        "repairer_failed": False,
         "reviewer_attempt_count": 0,
         "reviewer_repair_status": None,
         "reviewer_repair_request": None,
@@ -289,6 +290,29 @@ class WorkflowCompilationTests(unittest.TestCase):
         )
         self.assertTrue(final_state["repair_actions"])
         self.assertEqual(final_state["reviewer_attempt_count"], 0)
+
+    def test_repairer_failure_stops_before_reviewer(self):
+        raw_ir = sample_multi_task_ir()
+        raw_ir["workflow"]["steps"][0]["inputs"]["r1"] = "missing_input"
+        provider = UnexpectedGraphReviewerProvider()
+
+        with patch(
+            "src.nodes.repairer.repair_workflow_ir",
+            side_effect=RuntimeError("Synthetic repairer failure."),
+        ):
+            final_state = self.make_graph_with_reviewer(provider).invoke(
+                initial_state(raw_ir)
+            )
+
+        self.assertEqual(provider.call_count, 0)
+        self.assertTrue(final_state["repairer_failed"])
+        self.assertEqual(final_state["repair_count"], 1)
+        self.assertEqual(final_state["repair_actions"], [])
+        self.assertIsNone(final_state["reviewer_repair_status"])
+        self.assertIn(
+            "Synthetic repairer failure.",
+            final_state["messages"][-1].content,
+        )
 
     def test_analyzer_allows_omitted_optional_call_inputs(self):
         raw_ir = sample_multi_task_ir()

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,9 +1,12 @@
 import unittest
 from typing import Any
+from unittest.mock import patch
 
 from src.analyzer import analyze_workflow_ir
-from src.graph import agent, compiler_graph
+from src.graph import agent, build_compiler_graph, compiler_graph
+from src.nodes.reviewer_repair import make_reviewer_repair_node
 from src.renderers import render_wdl
+from src.reviewer_repair import ReviewerFailureStage, ReviewerRepairStatus
 from src.schema import coerce_workflow_ir
 from src.state import WorkflowState
 
@@ -177,6 +180,25 @@ def sample_rnaseq_tool_plan() -> dict[str, Any]:
     }
 
 
+class RecordingGraphReviewerProvider:
+    def __init__(self, result):
+        self.result = result
+        self.requests = []
+
+    def repair(self, request):
+        self.requests.append(request)
+        return self.result
+
+
+class UnexpectedGraphReviewerProvider:
+    def __init__(self):
+        self.call_count = 0
+
+    def repair(self, request):
+        self.call_count += 1
+        return {"status": "no_action"}
+
+
 def initial_state(parsed_json: dict[str, Any]) -> WorkflowState:
     state: WorkflowState = {
         "parsed_json": parsed_json,
@@ -189,12 +211,27 @@ def initial_state(parsed_json: dict[str, Any]) -> WorkflowState:
         "error_count": 0,
         "repair_count": 0,
         "repair_actions": [],
+        "reviewer_attempt_count": 0,
+        "reviewer_repair_status": None,
+        "reviewer_repair_request": None,
+        "reviewer_ir_patch": None,
+        "reviewer_rejection_reason": None,
+        "reviewer_diagnostics": [],
+        "reviewer_patch_applied": False,
         "is_valid": False,
     }
     return state
 
 
 class WorkflowCompilationTests(unittest.TestCase):
+    def make_graph_with_reviewer(self, provider):
+        return build_compiler_graph(
+            reviewer_node=make_reviewer_repair_node(
+                enabled=True,
+                provider=provider,
+            )
+        )
+
     def test_agent_alias_points_to_compiler_graph(self):
         self.assertIs(agent, compiler_graph)
 
@@ -235,6 +272,23 @@ class WorkflowCompilationTests(unittest.TestCase):
             ["qc", "align"],
         )
         self.assertTrue(final_state["repair_actions"])
+
+    def test_deterministic_repair_does_not_call_reviewer(self):
+        raw_ir = sample_multi_task_ir()
+        raw_ir["workflow"]["steps"].reverse()
+        provider = UnexpectedGraphReviewerProvider()
+
+        final_state = self.make_graph_with_reviewer(provider).invoke(
+            initial_state(raw_ir)
+        )
+
+        self.assertEqual(provider.call_count, 0)
+        self.assertEqual(
+            [step["id"] for step in final_state["workflow_ir"]["workflow"]["steps"]],
+            ["qc", "align"],
+        )
+        self.assertTrue(final_state["repair_actions"])
+        self.assertEqual(final_state["reviewer_attempt_count"], 0)
 
     def test_analyzer_allows_omitted_optional_call_inputs(self):
         raw_ir = sample_multi_task_ir()
@@ -425,7 +479,7 @@ class WorkflowCompilationTests(unittest.TestCase):
         self.assertIn('File clean_r2 = "clean_R2.fq.gz"', final_state["current_wdl"])
         self.assertTrue(final_state["repair_actions"])
 
-    def test_compiler_graph_stops_when_repairer_has_no_safe_action(self):
+    def test_compiler_graph_stops_after_disabled_reviewer_has_no_safe_action(self):
         raw_ir = sample_multi_task_ir()
         raw_ir["workflow"]["steps"][0]["inputs"]["r1"] = "missing_input"
 
@@ -434,6 +488,133 @@ class WorkflowCompilationTests(unittest.TestCase):
         self.assertFalse(final_state["is_valid"])
         self.assertIn("references unknown value 'missing_input'", "\n".join(final_state["analysis_errors"]))
         self.assertEqual(final_state["repair_actions"], [])
+        self.assertEqual(
+            final_state["reviewer_repair_status"],
+            ReviewerRepairStatus.NO_ACTION.value,
+        )
+        self.assertEqual(final_state["reviewer_attempt_count"], 0)
+        self.assertIn("disabled", final_state["reviewer_diagnostics"][0])
+
+    def test_analyzer_failure_routes_to_reviewer_after_no_safe_repair(self):
+        raw_ir = sample_multi_task_ir()
+        raw_ir["workflow"]["steps"][0]["inputs"]["r1"] = "missing_input"
+        provider = RecordingGraphReviewerProvider(
+            {
+                "status": "no_action",
+                "diagnostics": ["No safe Reviewer patch was found."],
+            }
+        )
+
+        final_state = self.make_graph_with_reviewer(provider).invoke(
+            initial_state(raw_ir)
+        )
+
+        self.assertEqual(len(provider.requests), 1)
+        self.assertEqual(
+            provider.requests[0].failure_stage,
+            ReviewerFailureStage.ANALYZER,
+        )
+        self.assertEqual(final_state["repair_count"], 1)
+        self.assertEqual(final_state["repair_actions"], [])
+        self.assertEqual(final_state["reviewer_attempt_count"], 1)
+        self.assertEqual(
+            final_state["reviewer_repair_status"],
+            ReviewerRepairStatus.NO_ACTION.value,
+        )
+        self.assertFalse(final_state["reviewer_patch_applied"])
+        self.assertIn("missing_input", "\n".join(final_state["analysis_errors"]))
+
+    def test_analyzer_reviewer_patch_reenters_compiler_pipeline(self):
+        raw_ir = sample_multi_task_ir()
+        raw_ir["workflow"]["steps"][0]["inputs"]["r1"] = "missing_input"
+        provider = RecordingGraphReviewerProvider(
+            {
+                "status": "patch_proposed",
+                "patch": {
+                    "summary": "Reconnect the qc input to an existing workflow input.",
+                    "actions": [
+                        {
+                            "operation": "replace",
+                            "path": "/workflow/steps/0/inputs/r1",
+                            "value": "raw_r1",
+                            "reason": "Use the declared workflow input.",
+                        }
+                    ],
+                    "diagnostic_references": [
+                        "references unknown value 'missing_input'"
+                    ],
+                    "confidence": 0.9,
+                },
+                "diagnostics": ["The replacement uses an existing workflow input."],
+            }
+        )
+
+        final_state = self.make_graph_with_reviewer(provider).invoke(
+            initial_state(raw_ir)
+        )
+
+        self.assertEqual(len(provider.requests), 1)
+        self.assertEqual(final_state["reviewer_attempt_count"], 1)
+        self.assertEqual(
+            final_state["reviewer_repair_status"],
+            ReviewerRepairStatus.PATCH_PROPOSED.value,
+        )
+        self.assertTrue(final_state["reviewer_patch_applied"])
+        self.assertEqual(final_state["analysis_errors"], [])
+        self.assertEqual(
+            final_state["workflow_ir"]["workflow"]["steps"][0]["inputs"]["r1"],
+            "raw_r1",
+        )
+        self.assertIn("r1 = raw_r1", final_state["current_wdl"])
+
+    def test_analyzer_reviewer_attempt_budget_stops_second_model_call(self):
+        raw_ir = sample_multi_task_ir()
+        raw_ir["workflow"]["steps"][0]["inputs"]["r1"] = "missing_input"
+        provider = UnexpectedGraphReviewerProvider()
+        state = initial_state(raw_ir)
+        state["reviewer_attempt_count"] = 1
+        state["reviewer_repair_request"] = {"failure_stage": "analyzer"}
+        state["reviewer_ir_patch"] = {"summary": "Previous parsed patch"}
+        state["reviewer_rejection_reason"] = "Previous rejection"
+        state["reviewer_diagnostics"] = ["Previous diagnostic"]
+
+        final_state = self.make_graph_with_reviewer(provider).invoke(state)
+
+        self.assertEqual(provider.call_count, 0)
+        self.assertEqual(final_state["reviewer_attempt_count"], 1)
+        self.assertEqual(
+            final_state["reviewer_ir_patch"],
+            {"summary": "Previous parsed patch"},
+        )
+        self.assertEqual(
+            final_state["reviewer_rejection_reason"],
+            "Previous rejection",
+        )
+        self.assertEqual(
+            final_state["reviewer_diagnostics"],
+            [
+                "Previous diagnostic",
+                "Reviewer repair attempt budget exhausted (1).",
+            ],
+        )
+
+    def test_checker_failure_does_not_route_to_analyzer_reviewer(self):
+        provider = UnexpectedGraphReviewerProvider()
+        graph = self.make_graph_with_reviewer(provider)
+
+        with patch("src.nodes.checker.wdl_validator") as validator:
+            validator.invoke.return_value = {
+                "is_valid": False,
+                "message": "Synthetic Checker failure.",
+            }
+            final_state = graph.invoke(initial_state(sample_multi_task_ir()))
+
+        self.assertEqual(provider.call_count, 0)
+        self.assertEqual(final_state["analysis_errors"], [])
+        self.assertEqual(final_state["repair_actions"], [])
+        self.assertEqual(final_state["repair_count"], 1)
+        self.assertEqual(final_state["validation_message"], "Synthetic Checker failure.")
+        self.assertIsNone(final_state["reviewer_repair_status"])
 
     def test_compiler_graph_compiles_recipe_tool_plan(self):
         final_state = compiler_graph.invoke(initial_state(sample_rnaseq_tool_plan()))

--- a/tests/test_workflow_service.py
+++ b/tests/test_workflow_service.py
@@ -188,6 +188,43 @@ class WorkflowServiceTests(unittest.TestCase):
             ["qc", "align"],
         )
 
+    def test_analyzer_repair_failure_emits_failed_event(self):
+        events = []
+
+        def event_callback(event_type, node, summary, state, payload):
+            events.append(
+                {
+                    "type": event_type,
+                    "node": node,
+                    "summary": summary,
+                    "payload": payload or {},
+                }
+            )
+
+        with patch(
+            "src.nodes.repairer.repair_workflow_ir",
+            side_effect=RuntimeError("Synthetic repairer failure."),
+        ):
+            result = compile_structured_workflow(
+                repairable_forward_reference_ir(),
+                check=False,
+                event_callback=event_callback,
+            )
+
+        self.assertFalse(result.succeeded)
+        self.assertTrue(result.state["repairer_failed"])
+        self.assertEqual(result.state["repair_count"], 1)
+        self.assertEqual(result.repair_actions, [])
+        repairer_events = [event for event in events if event["node"] == "repairer"]
+        self.assertEqual(
+            [event["type"] for event in repairer_events],
+            ["node.started", "node.failed"],
+        )
+        self.assertEqual(
+            repairer_events[-1]["payload"],
+            {"repairer_failed": True},
+        )
+
     def test_validation_repair_emits_workflow_ir_artifact_update_before_repair_event(self):
         events = []
         state = build_initial_state(repairable_forward_reference_ir())


### PR DESCRIPTION
## Summary

- route Analyzer failures through deterministic repair first, then an injected Reviewer repair branch when no safe deterministic action exists
- re-enter Analyzer, Renderer, and Checker only after a policy-validated Reviewer patch is applied
- enforce an independent one-attempt Reviewer budget while preserving parsed patch, rejection reason, and diagnostics
- distinguish deterministic repairer failures from normal no-action results so internal failures terminate without invoking Reviewer
- keep the default compiler graph Reviewer-disabled and leave Checker failure routing unchanged

## Why

P2.3 introduced the Reviewer node and provider boundary, but the Compiler Graph did not yet route Analyzer failures into it. Analyzer failures without a deterministic repair action therefore ended immediately. This PR adds the first bounded P2.4 recovery path without making deterministic structured compilation depend on a model or API key.

## Scope

- Analyzer failure routing only
- Checker failure routing remains deterministic and is deferred to a follow-up PR
- Run Service events, named artifacts, and history observability remain P2.5 work

## Validation

- Analyzer routing tests: 7 passed
- Reviewer node tests: 14 passed
- Workflow service tests: 13 passed
- Full Python suite: 248 tests, 241 passed, 4 skipped, 3 blocked by unavailable local WOMtool/miniwdl validators
- Representative RNA-seq DEG WDL generated successfully with `--no-check`
- `git diff --check` passed