### PR TITLE
Add tool execution verification contract

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -156,6 +156,8 @@ analyzer_node    # 修复后重新分析、渲染、校验
 - [x] **Cromwell runner 基线**：独立 Cromwell server 已运行，Docker 与相关执行 backend 已可用。
 - [x] **e2e 镜像就绪**：RNA-seq DEG tiny e2e 所需镜像已拉取到 runner 本地。
 - [x] **真实 tiny e2e 手动验证**：已通过显式 opt-in 的 Cromwell e2e 入口手动运行真实 RNA-seq tiny workflow。
+- [x] **工具执行验证契约**：正式 Tool Catalog 通过 `execution_verification` 独立记录 `unverified`、`smoke-tested` 或 `e2e-validated` 及其 evidence；`catalog-approved` 只表达 Catalog 准入，不再隐含真实执行能力。
+- [x] **未验证工具执行策略**：应用层 execution preflight 默认拒绝 `unverified` 工具，只有调用方显式 opt-in 时才允许继续；底层 backend 保持 WDL transport/execution 职责。
 
 P0 后续工作重点不再是证明 runner 能否运行，而是把已验证流程沉淀为便捷检查脚本、可复现验证摘要和更清晰的作品集展示材料。
 

--- a/docs/catalog-expansion-rag-plan.md
+++ b/docs/catalog-expansion-rag-plan.md
@@ -124,24 +124,43 @@ Recipe Tool Plan 选择，也不能进入 Workflow IR。
 - Renderer 可以生成确定性 WDL。
 - WDL 语法验证通过。
 
-Compile-ready 不等于执行已验证。当前 ToolSpec 尚未记录该区别，第一项实现
-工作应为 Tool Catalog 增加独立的 execution verification 状态。字段命名和
-枚举在实现 PR 中确定，但至少应表达：
+Compile-ready 不等于执行已验证。正式 ToolSpec 使用独立的
+`execution_verification` 结构记录状态和 evidence：
 
-```text
-unverified
-smoke-tested
-e2e-validated
+```yaml
+execution_verification:
+  status: unverified  # unverified | smoke-tested | e2e-validated
+  evidence: []
 ```
+
+`smoke-tested` 和 `e2e-validated` 必须提供非空 evidence；`unverified` 不得
+附带验证 evidence。Catalog admission 由条目进入正式 Catalog 并成功加载表示，
+compile readiness 由完整 ToolSpec、Resolver、Renderer 和 WDL validation 表示，
+不额外持久化容易失真的布尔字段。
+
+| Status | Meaning |
+| --- | --- |
+| `unverified` | 没有可追溯的成功执行记录 |
+| `smoke-tested` | 当前 tool version/runtime 已通过最小直接调用或 wrapper smoke test |
+| `e2e-validated` | 当前 tool version/runtime 已参与至少一次成功的小数据端到端 workflow |
+
+这些状态不表示生产级生物学正确性、参数覆盖率或性能 benchmark。
 
 Catalog admission、compilation readiness 和 execution verification 是不同
 概念，不应继续通过单个硬编码 `catalog-approved` 文案隐含全部状态。
 
+当前 evidence 迁移保持保守：已记录在 RNA-seq tiny e2e 中的 `fastp`、
+`salmon`、`tximport`、`deseq2` 和 `multiqc` 标记为 `e2e-validated`；
+`salmon_index`、`gtf_tx2gene`、`edger` 和 `limma_voom` 在没有成功执行记录前
+保持 `unverified`。存在 smoke test 脚本本身不作为测试已经成功的证据。
+
 ### Execution Policy
 
 - 默认 disabled execution backend 不受影响。
-- 真实 execution backend 应拒绝未验证工具，或要求显式 opt-in。
+- application-level execution preflight 默认拒绝未验证工具，或要求显式 opt-in；
+  低层 execution backend 不扩张为 Catalog policy owner。
 - API、run artifact 和前端应显示 execution verification 状态。
+- 新 retrieval artifact 必须记录状态；前端仍兼容契约落地前已持久化的历史 artifact。
 - 未验证工具可以用于 Planner 和 WDL 编译演示，但不得描述为已经真实运行。
 - 项目维护的 R/Python/helper wrapper 仍需 Dockerfile、打包脚本和最小
   `smoke_test.sh`。如果当前阶段不准备满足该要求，应先保留为
@@ -471,12 +490,12 @@ supported recall，但必须暴露 direct lexical match 和 fallback 风险。
 
 ## Proposed PR Sequence
 
-### PR 1: Tool Capability And Verification Contract
+### PR 1: Tool Capability And Verification Contract（已实现）
 
-- 为 ToolSpec 设计 execution verification 状态。
-- 区分 Catalog admission、compile readiness 和 execution verification。
-- 更新 Retriever artifact、API 类型和前端状态文案。
-- 为 execution backend 增加未验证工具 policy。
+- ToolSpec 已增加带 evidence 的 execution verification 状态。
+- Catalog admission、compile readiness 和 execution verification 已明确分离。
+- Retriever artifact、API 类型和前端状态文案已同步。
+- application-level execution preflight 已增加未验证工具 policy。
 
 ### PR 2: ChIP-seq Tool Catalog
 
@@ -567,8 +586,9 @@ recipe resolution、Workflow IR 或 WDL 输出时，还应：
 
 ## Immediate Next Step
 
-本计划落地后的第一项代码工作是 Tool Capability And Verification Contract。
-在该契约合并前，不向正式 Catalog 批量加入未执行验证的新工具。
+Tool Capability And Verification Contract 已落地。下一项工作是加入简化版
+ChIP-seq Tool Catalog：`bowtie2`、`samtools` 和 `macs2` 必须满足完整
+compile-ready ToolSpec，并按实际 evidence 标记 execution verification。
 
-契约稳定后，优先实现简化版 ChIP-seq tool metadata、recipe 和 retrieval
-baseline，再按相同模式推进 scRNA-seq 与 variant calling。
+ChIP-seq 工具契约合并后，再实现 recipe 和 retrieval baseline；随后按相同
+模式推进 scRNA-seq 与 variant calling。

--- a/docs/test-cases.md
+++ b/docs/test-cases.md
@@ -328,15 +328,16 @@ OK (skipped=2)
 
 期望输出：
 
-- `fastp` tool version 为 `0.23.2`。
+- `fastp` tool version 为 `1.3.3`。
 - `trust_status == "catalog-approved"`。
-- runtime docker 为 `quay.io/biocontainers/fastp:0.23.2`。
+- `execution_verification.status == "e2e-validated"`，并保留 evidence。
+- runtime docker 为 `quay.io/biocontainers/fastp:1.3.3--h43da1c4_0`。
 - outputs 包含 `clean_r1`。
 
 覆盖点：
 
 - Catalog service 的 tool records 与 API DTO 兼容。
-- Tool runtime 与 trust status 可以直接暴露给前端。
+- Tool runtime、Catalog admission 与 execution verification 可以分别暴露给前端。
 
 ### `test_run_event_defines_persistable_event_envelope`
 
@@ -467,8 +468,9 @@ OK (skipped=2)
 
 - HTTP status 为 `200`。
 - `catalog_service.list_tools()` 被调用一次。
-- `fastp` 记录中 `version == "0.23.2"`。
+- `fastp` 记录中 `version == "1.3.3"`。
 - `fastp` 记录中 `trust_status == "catalog-approved"`。
+- `fastp` 记录中 `execution_verification.status == "e2e-validated"`。
 
 覆盖点：
 
@@ -1385,6 +1387,35 @@ OK (skipped=2)
 - 替代工具仍通过完整 Recipe / Tool Catalog 校验，而不是由 Planner 自由选择未批准工具。
 - 不改变 Workflow IR 或 WDL renderer 架构即可扩展同一 recipe step 的工具集合。
 
+### `test_catalog_tools_declare_execution_verification`
+
+输入：当前正式 Tool Catalog。
+
+期望输出：
+
+- tiny RNA-seq e2e 中使用的 `fastp` 标记为 `e2e-validated`。
+- 尚无执行记录的 `salmon_index` 标记为 `unverified`。
+
+覆盖点：所有正式 ToolSpec 必须显式区分 Catalog 准入与真实执行验证。
+
+### `test_tool_spec_requires_execution_verification`
+
+输入：从合法 `fastp` ToolSpec 中删除 `execution_verification` 字段。
+
+期望输出：模型校验失败，避免正式 Catalog 通过隐式默认值隐藏执行状态。
+
+### `test_verified_execution_status_requires_evidence`
+
+输入：`status == "smoke-tested"` 且 evidence 为空的 execution verification。
+
+期望输出：模型校验失败，并说明已验证状态必须提供 evidence。
+
+### `test_unverified_execution_status_rejects_evidence`
+
+输入：`status == "unverified"` 但附带 verification evidence 的记录。
+
+期望输出：模型校验失败，避免状态与证据互相矛盾。
+
 ### `test_tool_spec_requires_runtime_docker`
 
 输入：
@@ -1631,11 +1662,12 @@ Recipe / Tool Catalog 中做确定性词法召回，不访问网络、不引入 
 - tool 召回结果包含 `fastp`、`salmon`、`tximport`、`deseq2` 和 `multiqc`。
 - recipe/tool 结果包含非零 `score`、`matched_terms`、`matched_fields` 和 `reason`。
 - tool 结果包含 `trust_status == "catalog-approved"`。
+- tool 结果包含独立的 `execution_verification` 状态和 evidence。
 
 覆盖点：
 
 - R1 retriever 可以从正式 catalog 中召回 RNA-seq DEG 所需 recipe 和关键工具。
-- 输出契约使用稳定 JSON key，便于后续 Planner、API、SSE 和前端复用。
+- 输出契约分别保留 Catalog admission 与 execution verification，便于后续 Planner、API、SSE 和前端复用。
 
 ### `test_retrieves_reference_prep_and_de_alternative_tools`
 
@@ -1955,12 +1987,14 @@ catalog baseline metrics。Fixture 不伪造工具；unsupported 负例单独统
   - `version == "1.3.3"`
   - `runtime["docker"] == "quay.io/biocontainers/fastp:1.3.3--h43da1c4_0"`
   - `trust_status == "catalog-approved"`
+  - `execution_verification.status == "e2e-validated"`
+  - execution verification evidence 包含 `docs/test-cases.md`
   - `outputs` 包含 `clean_r1`
 
 覆盖点：
 
 - Tool runtime docker 从 Catalog 权威来源读取。
-- API-facing tool 记录包含 container trust status。
+- API-facing tool 记录分别包含 Catalog trust status 和 execution verification。
 
 ### `test_get_tool_returns_explicit_version`
 
@@ -4320,6 +4354,19 @@ qc.html_report + qc.json_report
 - `AI_BIOWORKFLOW_RUN_BACKEND=cromwell` 时 factory 返回 `CromwellBackend`，并读取 Cromwell URL、poll interval 和 timeout 配置。
 - `local-miniwdl` 后端仍保持未实现。
 
+## `tests/test_execution_policy.py`
+
+该文件验证 application-level Tool execution preflight，不修改底层 backend
+协议。
+
+覆盖点：
+
+- 默认拒绝包含 `unverified` ToolSpec 的真实执行请求，并列出稳定的
+  `tool@version` 标识。
+- `allow_unverified=True` 作为显式 opt-in 时允许继续。
+- `smoke-tested` 与 `e2e-validated` 工具可以通过 preflight。
+- 本地 miniwdl 与真实 Cromwell tiny e2e 在执行 WDL 前都会对 plan 中的工具执行该检查。
+
 ## `tests/test_cromwell_backend.py`
 
 该文件验证 Cromwell server mode REST client 的 contract，不依赖真实 Cromwell、Docker 或生信输入文件。
@@ -4637,7 +4684,7 @@ npm run test:catalog-retrieval
 
 - `null` retrieval。
 - 空 query、空 recipes、空 tools 且未 fallback 的 retrieval。
-- 包含 RNA-seq query、recipe 和 tool 候选的 retrieval。
+- 包含 RNA-seq query、recipe 和带 execution verification 的 tool 候选的 retrieval。
 
 期望输出：
 
@@ -4647,6 +4694,18 @@ npm run test:catalog-retrieval
 覆盖点：
 
 - 前端不会为结构化入口或未产生检索产物的 run 伪造 Catalog Retrieval 展示。
+
+### `accepts legacy retrieval tools without execution verification`
+
+输入：契约落地前已持久化、tool 候选不包含 `execution_verification` 的历史
+retrieval artifact。
+
+期望输出：
+
+- artifact 仍被识别为有效 retrieval。
+- UI 可以显示“执行状态未记录”，而不是隐藏整份历史 artifact。
+
+覆盖点：execution verification 对新 artifact 必填，但前端读取层保持历史兼容。
 
 ### `selects top catalog recipe and limited tools`
 
@@ -4702,13 +4761,14 @@ npm run test:catalog-retrieval
 
 - Recipe Tool Plan schema 与 recipe/catalog 校验。
 - Catalog runtime docker 必填约束。
+- Tool execution verification 状态/evidence 一致性及未验证工具 preflight policy。
 - Recipe Tool Plan 到 Workflow IR 的 resolver 主路径。
 - RNA-seq reference prep recipe、Salmon index 和 tx2gene helper 的 Catalog resolver / WDL renderer 路径。
 - RNA-seq DEG recipe 中 DESeq2、edgeR 和 limma-voom 替代 differential expression 后端。
 - Catalog 查询服务的 recipe/tool JSON-ready 输出。
 - Approved Catalog Retriever 的词法召回、CJK tokenization、fallback 原因和 JSON-ready 输出契约。
 - 自然语言 run 对 catalog retrieval artifact 的持久化、snapshot 暴露和 SSE 事件回放顺序。
-- 前端 Catalog Retrieval 摘要对 top recipe/tools、matched terms 和 score 格式的处理。
+- 前端 Catalog Retrieval 摘要对 top recipe/tools、execution verification、历史 artifact、matched terms 和 score 格式的处理。
 - Analyzer 对引用、optional input、scatter output 类型提升的处理。
 - Renderer 对 call、scatter、array flatten、workflow output 和 task 的 WDL 渲染。
 - Deterministic repairer 对 call 顺序和 output 字面量的安全修复。

--- a/src/api/models/catalog.py
+++ b/src/api/models/catalog.py
@@ -6,6 +6,8 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from src.catalog.schema import ExecutionVerificationStatus
+
 
 TrustStatus = Literal["catalog-approved", "auto-validated", "experimental", "rejected"]
 
@@ -61,6 +63,13 @@ class RuntimeDto(BaseModel):
     disks: str | None = None
 
 
+class ExecutionVerificationDto(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: ExecutionVerificationStatus
+    evidence: list[str] = Field(default_factory=list)
+
+
 class ToolInputDto(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -103,6 +112,7 @@ class ToolDto(BaseModel):
     outputs: dict[str, ToolOutputDto] = Field(default_factory=dict)
     runtime: RuntimeDto = Field(default_factory=RuntimeDto)
     trust_status: TrustStatus
+    execution_verification: ExecutionVerificationDto
 
 
 class ToolListResponse(BaseModel):

--- a/src/catalog/__init__.py
+++ b/src/catalog/__init__.py
@@ -1,10 +1,16 @@
 from src.catalog.loader import ToolCatalog, load_tool_catalog
 from src.catalog.retriever import retrieve_catalog_context, tokenize_for_retrieval
 from src.catalog.resolver import resolve_tool_plan
-from src.catalog.schema import ToolSpec
+from src.catalog.schema import (
+    ExecutionVerificationSpec,
+    ExecutionVerificationStatus,
+    ToolSpec,
+)
 
 
 __all__ = [
+    "ExecutionVerificationSpec",
+    "ExecutionVerificationStatus",
     "ToolCatalog",
     "ToolSpec",
     "load_tool_catalog",

--- a/src/catalog/retriever.py
+++ b/src/catalog/retriever.py
@@ -278,6 +278,7 @@ def _tool_result(match: _ScoredItem) -> dict[str, Any]:
         "matched_terms": match.matched_terms,
         "matched_fields": match.matched_fields,
         "trust_status": CATALOG_APPROVED_TRUST_STATUS,
+        "execution_verification": tool.execution_verification.model_dump(mode="json"),
         "reason": _match_reason("tool", match.matched_terms, match.matched_fields),
     }
 
@@ -314,6 +315,7 @@ def _fallback_tool_result(tool: ToolSpec) -> dict[str, Any]:
         "matched_terms": [],
         "matched_fields": [],
         "trust_status": CATALOG_APPROVED_TRUST_STATUS,
+        "execution_verification": tool.execution_verification.model_dump(mode="json"),
         "reason": "Fallback result from approved tool catalog.",
     }
 

--- a/src/catalog/schema.py
+++ b/src/catalog/schema.py
@@ -6,6 +6,35 @@ from src.schema import IDENTIFIER_PATTERN, RuntimeSpec, extract_command_inputs
 
 
 WDL_PRIMITIVE_TYPES = {"Boolean", "File", "Float", "Int", "String"}
+ExecutionVerificationStatus = Literal["unverified", "smoke-tested", "e2e-validated"]
+
+
+class ExecutionVerificationSpec(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: ExecutionVerificationStatus
+    evidence: list[str] = Field(default_factory=list)
+
+    @field_validator("evidence")
+    @classmethod
+    def validate_evidence(cls, value: list[str]) -> list[str]:
+        normalized: list[str] = []
+        for item in value:
+            evidence = item.strip()
+            if not evidence:
+                raise ValueError("execution verification evidence must not be empty")
+            if evidence in normalized:
+                raise ValueError("execution verification evidence must be unique")
+            normalized.append(evidence)
+        return normalized
+
+    @model_validator(mode="after")
+    def validate_status_evidence(self):
+        if self.status == "unverified" and self.evidence:
+            raise ValueError("unverified tools must not declare execution verification evidence")
+        if self.status != "unverified" and not self.evidence:
+            raise ValueError(f"{self.status} tools must declare execution verification evidence")
+        return self
 
 
 class ToolInputSpec(BaseModel):
@@ -58,6 +87,7 @@ class ToolSpec(BaseModel):
     version: str
     aliases: list[str] = Field(default_factory=list)
     description: str = ""
+    execution_verification: ExecutionVerificationSpec
     inputs: dict[str, ToolInputSpec] = Field(default_factory=dict)
     params: dict[str, ToolParamSpec] = Field(default_factory=dict)
     outputs: dict[str, ToolOutputSpec] = Field(default_factory=dict)

--- a/src/catalog/tools/deseq2/1.42.1.yaml
+++ b/src/catalog/tools/deseq2/1.42.1.yaml
@@ -4,6 +4,11 @@ aliases:
   - differential expression
   - DEG
 description: Differential expression analysis from count matrix and sample groups.
+execution_verification:
+  status: e2e-validated
+  evidence:
+    - DEVELOPMENT.md
+    - docs/test-cases.md
 
 inputs:
   counts:

--- a/src/catalog/tools/edger/4.0.16.yaml
+++ b/src/catalog/tools/edger/4.0.16.yaml
@@ -6,6 +6,9 @@ aliases:
   - DEG
   - quasi-likelihood differential expression
 description: Differential expression analysis from a gene count matrix using edgeR quasi-likelihood testing.
+execution_verification:
+  status: unverified
+  evidence: []
 
 inputs:
   counts:

--- a/src/catalog/tools/fastp/1.3.3.yaml
+++ b/src/catalog/tools/fastp/1.3.3.yaml
@@ -4,6 +4,11 @@ aliases:
   - fastq qc
   - adapter trimming
 description: FASTQ quality control and adapter trimming.
+execution_verification:
+  status: e2e-validated
+  evidence:
+    - DEVELOPMENT.md
+    - docs/test-cases.md
 
 inputs:
   r1:

--- a/src/catalog/tools/gtf_tx2gene/1.0.0.yaml
+++ b/src/catalog/tools/gtf_tx2gene/1.0.0.yaml
@@ -5,6 +5,9 @@ aliases:
   - GTF transcript to gene mapping
   - transcript gene map
 description: Extract a tx2gene table from transcript_id and gene_id attributes in a GTF file.
+execution_verification:
+  status: unverified
+  evidence: []
 
 inputs:
   annotation_gtf:

--- a/src/catalog/tools/limma_voom/3.58.1.yaml
+++ b/src/catalog/tools/limma_voom/3.58.1.yaml
@@ -6,6 +6,9 @@ aliases:
   - differential expression
   - DEG
 description: Differential expression analysis from a gene count matrix using limma-voom.
+execution_verification:
+  status: unverified
+  evidence: []
 
 inputs:
   counts:

--- a/src/catalog/tools/multiqc/1.21.yaml
+++ b/src/catalog/tools/multiqc/1.21.yaml
@@ -4,6 +4,11 @@ aliases:
   - QC report
   - workflow summary
 description: Aggregate per-step quality control files into a MultiQC HTML report.
+execution_verification:
+  status: e2e-validated
+  evidence:
+    - DEVELOPMENT.md
+    - docs/test-cases.md
 
 inputs:
   report_files:

--- a/src/catalog/tools/salmon/1.9.0.yaml
+++ b/src/catalog/tools/salmon/1.9.0.yaml
@@ -4,6 +4,11 @@ aliases:
   - transcript quantification
   - RNA-seq quantification
 description: Transcript-level quantification for RNA-seq reads.
+execution_verification:
+  status: e2e-validated
+  evidence:
+    - DEVELOPMENT.md
+    - docs/test-cases.md
 
 inputs:
   r1:

--- a/src/catalog/tools/salmon_index/1.9.0.yaml
+++ b/src/catalog/tools/salmon_index/1.9.0.yaml
@@ -5,6 +5,9 @@ aliases:
   - transcriptome index
   - RNA-seq reference index
 description: Build a Salmon transcriptome index archive from a transcriptome FASTA.
+execution_verification:
+  status: unverified
+  evidence: []
 
 inputs:
   transcriptome_fasta:

--- a/src/catalog/tools/tximport/1.30.0.yaml
+++ b/src/catalog/tools/tximport/1.30.0.yaml
@@ -4,6 +4,11 @@ aliases:
   - transcript to gene counts
   - Salmon aggregation
 description: Summarize Salmon transcript quantifications into a gene-level count matrix.
+execution_verification:
+  status: e2e-validated
+  evidence:
+    - DEVELOPMENT.md
+    - docs/test-cases.md
 
 inputs:
   quant_files:

--- a/src/execution/__init__.py
+++ b/src/execution/__init__.py
@@ -1,6 +1,7 @@
 from src.execution.cromwell import CromwellBackend
 from src.execution.disabled import DisabledBackend
 from src.execution.factory import get_execution_backend
+from src.execution.policy import UnverifiedToolExecutionError, ensure_tools_execution_eligible
 from src.execution.protocol import BackendAvailability, ExecutionBackend, ExecutionResult
 
 __all__ = [
@@ -9,5 +10,7 @@ __all__ = [
     "DisabledBackend",
     "ExecutionBackend",
     "ExecutionResult",
+    "UnverifiedToolExecutionError",
+    "ensure_tools_execution_eligible",
     "get_execution_backend",
 ]

--- a/src/execution/policy.py
+++ b/src/execution/policy.py
@@ -1,0 +1,35 @@
+"""Application-level policy for executing Catalog tools."""
+
+from collections.abc import Iterable
+
+from src.catalog.schema import ToolSpec
+
+
+class UnverifiedToolExecutionError(ValueError):
+    """Raised when real execution includes tools without verification evidence."""
+
+
+def ensure_tools_execution_eligible(
+    tools: Iterable[ToolSpec],
+    *,
+    allow_unverified: bool = False,
+) -> None:
+    """Reject unverified tools unless the caller explicitly accepts that risk."""
+    if allow_unverified:
+        return
+
+    unverified = sorted(
+        {
+            f"{tool.id}@{tool.version}"
+            for tool in tools
+            if tool.execution_verification.status == "unverified"
+        }
+    )
+    if not unverified:
+        return
+
+    joined = ", ".join(unverified)
+    raise UnverifiedToolExecutionError(
+        "Execution blocked for unverified Catalog tools: "
+        f"{joined}. Set allow_unverified=True to opt in explicitly."
+    )

--- a/src/nl_planner.py
+++ b/src/nl_planner.py
@@ -255,6 +255,7 @@ def _tool_spec_prompt_context(
         "version": tool.version,
         "description": tool.description,
         "trust_status": CATALOG_APPROVED_TRUST_STATUS,
+        "execution_verification": tool.execution_verification.model_dump(mode="json"),
         "inputs": {
             input_name: spec.model_dump(exclude_none=True)
             for input_name, spec in tool.inputs.items()

--- a/src/services/catalog_service.py
+++ b/src/services/catalog_service.py
@@ -108,6 +108,7 @@ def _tool_to_record(tool: ToolSpec, *, tool_catalog: ToolCatalog) -> dict[str, A
         },
         "runtime": tool.runtime.model_dump(mode="json", exclude_none=True),
         "trust_status": CATALOG_APPROVED_TRUST_STATUS,
+        "execution_verification": tool.execution_verification.model_dump(mode="json"),
     }
 
 

--- a/tests/api/test_models.py
+++ b/tests/api/test_models.py
@@ -180,6 +180,8 @@ class CatalogDtoTests(unittest.TestCase):
         fastp = next(tool for tool in response.tools if tool.id == "fastp")
         self.assertEqual(fastp.version, "1.3.3")
         self.assertEqual(fastp.trust_status, "catalog-approved")
+        self.assertEqual(fastp.execution_verification.status, "e2e-validated")
+        self.assertIn("DEVELOPMENT.md", fastp.execution_verification.evidence)
         self.assertEqual(fastp.runtime.docker, "quay.io/biocontainers/fastp:1.3.3--h43da1c4_0")
         self.assertIn("clean_r1", fastp.outputs)
 

--- a/tests/api/test_routes.py
+++ b/tests/api/test_routes.py
@@ -77,6 +77,7 @@ class ApiRouteTests(unittest.TestCase):
         fastp = next(tool for tool in tools if tool["id"] == "fastp")
         self.assertEqual(fastp["version"], "1.3.3")
         self.assertEqual(fastp["trust_status"], "catalog-approved")
+        self.assertEqual(fastp["execution_verification"]["status"], "e2e-validated")
 
     def test_get_tool_with_version(self):
         tool_record = get_tool("salmon", "1.9.0")

--- a/tests/e2e/test_tiny_run.py
+++ b/tests/e2e/test_tiny_run.py
@@ -4,7 +4,8 @@ import unittest
 from pathlib import Path
 
 import main as cli
-from src.execution import get_execution_backend
+from src.catalog import load_tool_catalog
+from src.execution import ensure_tools_execution_eligible, get_execution_backend
 
 
 EXAMPLES_DIR = Path(__file__).parents[2] / "examples"
@@ -33,6 +34,13 @@ class CromwellTinyRunTests(unittest.TestCase):
             self.fail(f"tiny-run inputs JSON does not exist: {tiny_inputs}")
 
         plan = cli.load_workflow_input(EXAMPLES_DIR / "rnaseq_deg_recipe_plan.json")
+        tool_catalog = load_tool_catalog()
+        selected_tools = [
+            tool_catalog.get(tool_call["tool"], tool_call["version"])
+            for tool_call in plan["workflow"]["tool_calls"]
+        ]
+        ensure_tools_execution_eligible(selected_tools)
+
         state = cli.compile_workflow(plan, check=True)
         self.assertTrue(state["is_valid"], state["validation_message"])
 

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -7,7 +7,7 @@ import yaml
 
 from src.analyzer import analyze_workflow_ir
 from src.catalog import load_tool_catalog, resolve_tool_plan
-from src.catalog.schema import ToolSpec
+from src.catalog.schema import ExecutionVerificationSpec, ToolSpec
 from src.recipes import load_recipe_catalog
 from src.renderers import render_wdl
 from src.schema import flatten_workflow_calls
@@ -157,6 +157,43 @@ class CatalogDefinitionTests(unittest.TestCase):
                 self.assertEqual(yaml_path.parent.name, data.get("id"))
                 self.assertEqual(yaml_path.stem, str(data.get("version")))
 
+    def test_catalog_tools_declare_execution_verification(self):
+        tool_catalog = load_tool_catalog()
+
+        self.assertEqual(
+            tool_catalog.get("fastp", "1.3.3").execution_verification.status,
+            "e2e-validated",
+        )
+        self.assertEqual(
+            tool_catalog.get("salmon_index", "1.9.0").execution_verification.status,
+            "unverified",
+        )
+
+    def test_tool_spec_requires_execution_verification(self):
+        tool_data = load_tool_catalog().get("fastp", "1.3.3").model_dump(mode="python")
+        del tool_data["execution_verification"]
+
+        with self.assertRaisesRegex(ValueError, "execution_verification"):
+            ToolSpec.model_validate(tool_data)
+
+    def test_verified_execution_status_requires_evidence(self):
+        with self.assertRaisesRegex(ValueError, "must declare execution verification evidence"):
+            ExecutionVerificationSpec.model_validate(
+                {
+                    "status": "smoke-tested",
+                    "evidence": [],
+                }
+            )
+
+    def test_unverified_execution_status_rejects_evidence(self):
+        with self.assertRaisesRegex(ValueError, "must not declare execution verification evidence"):
+            ExecutionVerificationSpec.model_validate(
+                {
+                    "status": "unverified",
+                    "evidence": ["tests/example.py"],
+                }
+            )
+
 
 class CatalogResolutionTests(unittest.TestCase):
     def setUp(self):
@@ -268,6 +305,10 @@ class CatalogResolutionTests(unittest.TestCase):
                     "id": "fastp",
                     "version": "1.3.3",
                     "description": "FASTQ quality control.",
+                    "execution_verification": {
+                        "status": "unverified",
+                        "evidence": [],
+                    },
                     "inputs": {
                         "r1": {
                             "type": "File",

--- a/tests/test_catalog_retriever.py
+++ b/tests/test_catalog_retriever.py
@@ -44,6 +44,7 @@ class CatalogRetrieverTests(unittest.TestCase):
         self.assertIn("differential", deseq2["matched_terms"])
         self.assertTrue(deseq2["matched_fields"])
         self.assertEqual(deseq2["trust_status"], "catalog-approved")
+        self.assertEqual(deseq2["execution_verification"]["status"], "e2e-validated")
         self.assertIn("Matched approved catalog tool", deseq2["reason"])
 
     def test_retrieves_reference_prep_and_de_alternative_tools(self):
@@ -102,6 +103,10 @@ class CatalogRetrieverTests(unittest.TestCase):
         self.assertEqual(len(result["tools"]), 3)
         for tool in result["tools"]:
             self.assertEqual(tool["trust_status"], "catalog-approved")
+            self.assertIn(
+                tool["execution_verification"]["status"],
+                {"unverified", "smoke-tested", "e2e-validated"},
+            )
             self.assertEqual(tool["matched_terms"], [])
             self.assertIn("Fallback result", tool["reason"])
 

--- a/tests/test_catalog_service.py
+++ b/tests/test_catalog_service.py
@@ -30,6 +30,8 @@ class CatalogServiceTests(unittest.TestCase):
         self.assertEqual(fastp["version"], "1.3.3")
         self.assertEqual(fastp["runtime"]["docker"], "quay.io/biocontainers/fastp:1.3.3--h43da1c4_0")
         self.assertEqual(fastp["trust_status"], "catalog-approved")
+        self.assertEqual(fastp["execution_verification"]["status"], "e2e-validated")
+        self.assertIn("docs/test-cases.md", fastp["execution_verification"]["evidence"])
         self.assertIn("clean_r1", fastp["outputs"])
 
     def test_get_tool_returns_explicit_version(self):
@@ -38,6 +40,7 @@ class CatalogServiceTests(unittest.TestCase):
         self.assertEqual(tool["id"], "salmon")
         self.assertEqual(tool["version"], "1.9.0")
         self.assertEqual(tool["inputs"]["r1"]["type"], "File")
+        self.assertEqual(tool["execution_verification"]["status"], "e2e-validated")
         self.assertIn("1.9.0", tool["versions"])
 
     def test_get_tool_defaults_to_highest_catalog_version(self):

--- a/tests/test_execution_policy.py
+++ b/tests/test_execution_policy.py
@@ -1,0 +1,40 @@
+import unittest
+
+from src.catalog import ExecutionVerificationSpec, load_tool_catalog
+from src.execution import UnverifiedToolExecutionError, ensure_tools_execution_eligible
+
+
+class ToolExecutionPolicyTests(unittest.TestCase):
+    def setUp(self):
+        self.tool_catalog = load_tool_catalog()
+
+    def test_blocks_unverified_tools_by_default(self):
+        tool = self.tool_catalog.get("edger", "4.0.16")
+
+        with self.assertRaisesRegex(
+            UnverifiedToolExecutionError,
+            "edger@4.0.16.*allow_unverified=True",
+        ):
+            ensure_tools_execution_eligible([tool])
+
+    def test_allows_explicit_opt_in_for_unverified_tools(self):
+        tool = self.tool_catalog.get("salmon_index", "1.9.0")
+
+        ensure_tools_execution_eligible([tool], allow_unverified=True)
+
+    def test_allows_smoke_tested_and_e2e_validated_tools(self):
+        e2e_tool = self.tool_catalog.get("fastp", "1.3.3")
+        smoke_tested_tool = self.tool_catalog.get("edger", "4.0.16").model_copy(
+            update={
+                "execution_verification": ExecutionVerificationSpec(
+                    status="smoke-tested",
+                    evidence=["containers/edger/4.0.16/smoke_test.sh"],
+                )
+            }
+        )
+
+        ensure_tools_execution_eligible([smoke_tested_tool, e2e_tool])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_nl_planner.py
+++ b/tests/test_nl_planner.py
@@ -145,6 +145,7 @@ class NaturalLanguagePlannerTests(unittest.TestCase):
         self.assertIn("validation_boundary", prompt)
         self.assertIn("matched_terms", prompt)
         self.assertIn("trust_status", prompt)
+        self.assertIn("execution_verification", prompt)
         self.assertNotIn("Use only tools and versions listed in the retrieved", prompt)
         self.assertIn("Run RNA-seq differential expression.", prompt)
 

--- a/tests/test_tiny_run.py
+++ b/tests/test_tiny_run.py
@@ -7,6 +7,8 @@ import unittest
 from pathlib import Path
 
 import main as cli
+from src.catalog import load_tool_catalog
+from src.execution import ensure_tools_execution_eligible
 from src.tools.validator import miniwdl_available
 
 
@@ -42,6 +44,13 @@ class OptionalTinyRunTests(unittest.TestCase):
             self.skipTest(f"tiny run inputs are not available: {tiny_inputs}")
 
         plan = cli.load_workflow_input(EXAMPLES_DIR / "rnaseq_deg_recipe_plan.json")
+        tool_catalog = load_tool_catalog()
+        selected_tools = [
+            tool_catalog.get(tool_call["tool"], tool_call["version"])
+            for tool_call in plan["workflow"]["tool_calls"]
+        ]
+        ensure_tools_execution_eligible(selected_tools)
+
         state = cli.compile_workflow(plan, check=True)
         self.assertTrue(state["is_valid"], state["validation_message"])
 

--- a/web/app/catalog/page.tsx
+++ b/web/app/catalog/page.tsx
@@ -7,11 +7,11 @@ import { apiDocsUrl } from "@/lib/api";
 import { rnaseqDemoWorkspaceHref, rnaseqRecipeSteps } from "@/lib/examples";
 
 const tools = [
-  ["fastp", "读段质量控制", "quay.io/biocontainers/fastp"],
-  ["salmon", "转录本定量", "quay.io/biocontainers/salmon"],
-  ["tximport", "基因层面汇总", "项目维护镜像"],
-  ["deseq2", "差异表达分析", "项目维护镜像"],
-  ["multiqc", "质控报告汇总", "项目维护镜像"],
+  ["fastp", "读段质量控制", "quay.io/biocontainers/fastp", "e2e-validated"],
+  ["salmon", "转录本定量", "quay.io/biocontainers/salmon", "e2e-validated"],
+  ["tximport", "基因层面汇总", "项目维护镜像", "e2e-validated"],
+  ["deseq2", "差异表达分析", "项目维护镜像", "e2e-validated"],
+  ["multiqc", "质控报告汇总", "项目维护镜像", "e2e-validated"],
 ];
 
 export default function CatalogPage() {
@@ -75,11 +75,14 @@ export default function CatalogPage() {
             <Badge variant="outline">静态 tool 示例</Badge>
           </div>
           <div className="mt-5 grid gap-3">
-            {tools.map(([tool, role, runtime]) => (
+            {tools.map(([tool, role, runtime, verification]) => (
               <div key={tool} className="rounded-md border bg-background p-4">
                 <div className="flex flex-wrap items-center justify-between gap-3">
                   <div className="font-semibold">{tool}</div>
-                  <Badge variant="secondary">catalog-approved</Badge>
+                  <div className="flex flex-wrap gap-2">
+                    <Badge variant="secondary">catalog-approved</Badge>
+                    <Badge variant="outline">{verification}</Badge>
+                  </div>
                 </div>
                 <div className="mt-2 text-sm text-muted-foreground">{role}</div>
                 <div className="mt-3 flex items-center gap-2 text-xs text-muted-foreground">
@@ -104,11 +107,12 @@ export default function CatalogPage() {
             <Link href={apiDocsUrl}>查看 API 契约</Link>
           </Button>
         </div>
-        <div className="grid gap-4 md:grid-cols-3">
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
           {[
             ["schema", "inputs、outputs、parameters 和 command templates 都是显式定义。"],
             ["runtime", "编译后的 WDL 使用 catalog 声明的 container。"],
-            ["trust", "工具记录会暴露 catalog-approved 或 experimental 状态。"],
+            ["admission", "catalog-approved 只表示工具已进入正式 Catalog。"],
+            ["verification", "执行状态独立显示为 unverified、smoke-tested 或 e2e-validated。"],
           ].map(([label, detail]) => (
             <div key={label} className="flex gap-3 rounded-md border bg-background p-4">
               <CheckCircle2 className="mt-0.5 h-5 w-5 flex-none text-primary" />
@@ -123,7 +127,7 @@ export default function CatalogPage() {
           <div className="rounded-md border bg-background p-4">
             <div className="font-semibold text-primary">当前已实现</div>
             <p className="mt-2 text-sm leading-6 text-muted-foreground">
-              展示 RNA-seq recipe steps、准入工具、runtime 和 trust status 的前端呈现方式。
+              展示 RNA-seq recipe steps、Catalog 准入、runtime 和独立 execution verification 状态。
             </p>
           </div>
           <div className="rounded-md border bg-background p-4">

--- a/web/components/run/catalog-retrieval-summary.tsx
+++ b/web/components/run/catalog-retrieval-summary.tsx
@@ -1,6 +1,14 @@
 "use client";
 
-import { AlertTriangle, Database, Search, ShieldCheck, Tags } from "lucide-react";
+import {
+  AlertTriangle,
+  BadgeCheck,
+  Database,
+  FlaskConical,
+  Search,
+  ShieldCheck,
+  Tags,
+} from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
 import {
@@ -14,6 +22,7 @@ import type {
   CatalogRetrievalArtifact,
   CatalogRetrievalRecipe,
   CatalogRetrievalTool,
+  ExecutionVerification,
 } from "@/lib/types";
 import { cn } from "@/lib/utils";
 
@@ -44,13 +53,55 @@ function MatchedTerms({ terms }: { terms: string[] }) {
   );
 }
 
+function ExecutionVerificationBadge({
+  verification,
+}: {
+  verification?: ExecutionVerification;
+}) {
+  if (!verification) {
+    return (
+      <Badge variant="outline" className="gap-1.5" title="历史 artifact 未记录执行验证状态">
+        <AlertTriangle className="h-3.5 w-3.5" />
+        执行状态未记录
+      </Badge>
+    );
+  }
+
+  if (verification.status === "unverified") {
+    return (
+      <Badge variant="outline" className="gap-1.5" title="工具尚无成功执行验证记录">
+        <AlertTriangle className="h-3.5 w-3.5" />
+        执行未验证
+      </Badge>
+    );
+  }
+
+  if (verification.status === "smoke-tested") {
+    return (
+      <Badge variant="secondary" className="gap-1.5" title="工具已通过 smoke test">
+        <FlaskConical className="h-3.5 w-3.5" />
+        Smoke test 已验证
+      </Badge>
+    );
+  }
+
+  return (
+    <Badge variant="secondary" className="gap-1.5" title="工具已通过小数据端到端执行">
+      <BadgeCheck className="h-3.5 w-3.5" />
+      E2E 已验证
+    </Badge>
+  );
+}
+
 function CandidateMeta({
   candidate,
 }: {
   candidate: CatalogRetrievalRecipe | CatalogRetrievalTool;
 }) {
-  const version = "version" in candidate ? candidate.version : null;
-  const trustStatus = "trust_status" in candidate ? candidate.trust_status : null;
+  const isTool = "version" in candidate;
+  const version = isTool ? candidate.version : null;
+  const trustStatus = isTool ? candidate.trust_status : null;
+  const verification = isTool ? candidate.execution_verification : undefined;
 
   return (
     <div className="flex flex-wrap items-center gap-2">
@@ -62,6 +113,7 @@ function CandidateMeta({
           {trustStatus}
         </Badge>
       ) : null}
+      {isTool ? <ExecutionVerificationBadge verification={verification} /> : null}
       <Badge variant="outline">score {formatRetrievalScore(candidate.score)}</Badge>
     </div>
   );

--- a/web/lib/catalog-retrieval.ts
+++ b/web/lib/catalog-retrieval.ts
@@ -2,6 +2,8 @@ import type {
   CatalogRetrievalArtifact,
   CatalogRetrievalRecipe,
   CatalogRetrievalTool,
+  ExecutionVerification,
+  ExecutionVerificationStatus,
   TrustStatus,
 } from "@/lib/types";
 
@@ -17,6 +19,16 @@ const TRUST_STATUS_VALUES = [
 
 const TRUST_STATUSES = new Set<TrustStatus>(TRUST_STATUS_VALUES);
 
+const EXECUTION_VERIFICATION_STATUS_VALUES = [
+  "unverified",
+  "smoke-tested",
+  "e2e-validated",
+] satisfies ExecutionVerificationStatus[];
+
+const EXECUTION_VERIFICATION_STATUSES = new Set<ExecutionVerificationStatus>(
+  EXECUTION_VERIFICATION_STATUS_VALUES,
+);
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
@@ -27,6 +39,19 @@ function isStringArray(value: unknown): value is string[] {
 
 function isTrustStatus(value: unknown): value is TrustStatus {
   return typeof value === "string" && TRUST_STATUSES.has(value as TrustStatus);
+}
+
+function isExecutionVerification(value: unknown): value is ExecutionVerification {
+  if (
+    !isRecord(value) ||
+    typeof value.status !== "string" ||
+    !EXECUTION_VERIFICATION_STATUSES.has(value.status as ExecutionVerificationStatus) ||
+    !isStringArray(value.evidence)
+  ) {
+    return false;
+  }
+
+  return value.status === "unverified" ? value.evidence.length === 0 : value.evidence.length > 0;
 }
 
 function isCatalogRetrievalRecipe(value: unknown): value is CatalogRetrievalRecipe {
@@ -49,6 +74,8 @@ function isCatalogRetrievalTool(value: unknown): value is CatalogRetrievalTool {
     isStringArray(value.matched_terms) &&
     isStringArray(value.matched_fields) &&
     isTrustStatus(value.trust_status) &&
+    (value.execution_verification === undefined ||
+      isExecutionVerification(value.execution_verification)) &&
     typeof value.reason === "string"
   );
 }

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -4,6 +4,16 @@ export type TrustStatus =
   | "experimental"
   | "rejected";
 
+export type ExecutionVerificationStatus =
+  | "unverified"
+  | "smoke-tested"
+  | "e2e-validated";
+
+export type ExecutionVerification = {
+  status: ExecutionVerificationStatus;
+  evidence: string[];
+};
+
 export type RecipeInput = {
   type: string;
   description?: string | null;
@@ -51,6 +61,7 @@ export type Tool = {
   description: string;
   runtime: Runtime;
   trust_status: TrustStatus;
+  execution_verification: ExecutionVerification;
 };
 
 export type ToolListResponse = {
@@ -132,6 +143,7 @@ export type CatalogRetrievalTool = {
   matched_terms: string[];
   matched_fields: string[];
   trust_status: TrustStatus;
+  execution_verification?: ExecutionVerification;
   reason: string;
 };
 

--- a/web/tests/catalog-retrieval.test.mjs
+++ b/web/tests/catalog-retrieval.test.mjs
@@ -29,6 +29,10 @@ const retrieval = {
       matched_terms: ["differential", "expression"],
       matched_fields: ["id", "description"],
       trust_status: "catalog-approved",
+      execution_verification: {
+        status: "e2e-validated",
+        evidence: ["docs/test-cases.md"],
+      },
       reason: "Matched approved catalog tool fields.",
     },
     {
@@ -38,6 +42,10 @@ const retrieval = {
       matched_terms: ["quantification"],
       matched_fields: ["description"],
       trust_status: "catalog-approved",
+      execution_verification: {
+        status: "e2e-validated",
+        evidence: ["docs/test-cases.md"],
+      },
       reason: "Matched approved catalog tool fields.",
     },
   ],
@@ -66,6 +74,18 @@ test("detects non-empty catalog retrieval artifacts", () => {
   );
   assert.equal(
     hasCatalogRetrieval({
+      ...retrieval,
+      tools: [
+        {
+          ...retrieval.tools[0],
+          execution_verification: { status: "e2e-validated", evidence: [] },
+        },
+      ],
+    }),
+    false,
+  );
+  assert.equal(
+    hasCatalogRetrieval({
       query: "",
       strategy: "lexical_v1",
       recipes: [],
@@ -76,6 +96,15 @@ test("detects non-empty catalog retrieval artifacts", () => {
     false,
   );
   assert.equal(hasCatalogRetrieval(retrieval), true);
+});
+
+test("accepts legacy retrieval tools without execution verification", () => {
+  const legacyRetrieval = {
+    ...retrieval,
+    tools: retrieval.tools.map(({ execution_verification: _verification, ...tool }) => tool),
+  };
+
+  assert.equal(hasCatalogRetrieval(legacyRetrieval), true);
 });
 
 test("selects top catalog recipe and limited tools", () => {


### PR DESCRIPTION
## Summary

- add a required execution verification status and evidence contract to every formal ToolSpec
- migrate the current Catalog conservatively: five RNA-seq tiny-e2e tools are e2e-validated and four tools remain unverified
- expose verification independently from Catalog admission through the API, retrieval artifacts, planner context, and frontend
- add application-level preflight checks that block unverified tools unless execution is explicitly opted in
- preserve compatibility when displaying historical retrieval artifacts and update roadmap and test documentation

## Why

`catalog-approved` expresses Catalog admission, but it can be mistaken for successful real execution. The planned ChIP-seq Catalog expansion needs a truthful contract that allows compile-ready tools without overstating execution coverage.

## Impact

Compilation and retrieval remain available for unverified formal tools. Real miniwdl and Cromwell execution entry points now run the preflight policy first. Low-level execution backend interfaces and generated WDL are unchanged.

## Verification

- `.\.venv\Scripts\python.exe -m unittest tests.test_catalog tests.test_catalog_service tests.test_catalog_retriever tests.test_nl_planner tests.test_execution_policy tests.test_tiny_run tests.e2e.test_tiny_run tests.api.test_models tests.api.test_routes -v` (72 passed, 2 skipped)
- `.\.venv\Scripts\python.exe scripts\evaluate_retrieval.py` (baseline unchanged)
- `npm.cmd run test:catalog-retrieval`
- `npm.cmd run lint`
- `npm.cmd run build`
- `git diff --check`

The full Python discovery run executed 248 tests: 241 passed, 4 skipped, and 3 graph compilation checks could not complete because this machine has no available WOMtool or miniwdl validator. This change does not alter generated WDL.