### PR TITLE
Route checker failures through bounded Reviewer repair

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -136,9 +136,9 @@ checker_node     # WDL syntax validation
   ↓
 END
 
-Analyzer failure recovery：
+Analyzer / Checker failure recovery：
 
-analyzer_node
+analyzer_node / checker_node
   ↓
 repairer_node       # 始终先尝试确定性修复
   ├─ 内部失败 -> END，并保留 repairer diagnostic
@@ -148,8 +148,8 @@ repairer_node       # 始终先尝试确定性修复
                       └─ disabled / rejected / error / budget exhausted -> END
 
 `reviewer_repair` 默认禁用，独立预算默认为一次；禁用或缺少 provider 时不会调用
-模型。Checker failure 当前仍只走 deterministic repairer，Reviewer routing 留给后续
-独立 PR。
+模型。`repair_failure_stage` 显式区分 Analyzer 与 Checker diagnostics；缺少本地 WDL
+validator 时直接结束，不进入 deterministic 或 Reviewer repair。
 ```
 
 ## 已完成的容器管理边界

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -146,11 +146,16 @@ repairer_node       # 始终先尝试确定性修复
   └─ 正常完成但无安全动作 -> reviewer_repair
                       ├─ patch 已应用 -> analyzer_node -> renderer_node -> checker_node
                       └─ disabled / rejected / error / budget exhausted -> END
+```
 
 `reviewer_repair` 默认禁用，独立预算默认为一次；禁用或缺少 provider 时不会调用
 模型。`repair_failure_stage` 显式区分 Analyzer 与 Checker diagnostics；缺少本地 WDL
 validator 时直接结束，不进入 deterministic 或 Reviewer repair。
-```
+
+上述 Reviewer failure recovery 当前只描述 `compiler_graph` 的 P2.4 路由。为保留
+现有 run event 顺序，`compile_structured_workflow(..., event_callback=...)` 暂时继续使用
+deterministic-only 的服务层编译循环；Reviewer events、artifacts 与该路径的行为统一由
+P2.5 Run Service / API Observability 完成。
 
 ## 已完成的容器管理边界
 

--- a/docs/p2-reviewer-repair-plan.md
+++ b/docs/p2-reviewer-repair-plan.md
@@ -246,17 +246,19 @@ artifacts，避免前端和 API 消费方解析文本 summary。
 - deterministic repair 放弃且 policy 允许时调用 Reviewer。
 - 修复次数耗尽时返回 failed diagnostic report。
 
-当前拆分：
+当前实现：
 
-- 第一部分只接入 Analyzer failure routing。deterministic repairer 有安全动作时不
-  调用 Reviewer；无安全动作时才进入 Reviewer branch。
+- Analyzer 和 Checker failure routing 均先尝试 deterministic repairer；有安全动作
+  时不调用 Reviewer，正常完成但无安全动作时才进入 Reviewer branch。
+- `repair_failure_stage` 显式记录当前 repair cycle 来源，Reviewer request 不通过
+  `analysis_errors` 或 `validation_message` 的内容猜测 failure stage。
 - deterministic repairer 内部失败使用独立状态终止当前分支并保留 diagnostic，
   不得被解释为正常的 `no_action`，也不得触发 Reviewer model call。
 - Reviewer 使用独立 `reviewer_attempt_count`，默认最多调用 provider 一次。禁用、
   provider 不可用、拒绝、model error 或预算耗尽都终止该分支并保留 diagnostics。
 - 已应用 patch 重新进入 Analyzer、Renderer 和 Checker。
-- Checker failure routing 不在第一部分启用，继续使用现有 deterministic repair
-  行为，后续独立 PR 再接入 Reviewer。
+- Checker 缺少本地 WOMtool/miniwdl 时直接结束，不把环境缺失当作可修复的 IR
+  failure，也不调用 Reviewer。
 
 ### P2.5 Run Service 与 API Observability
 
@@ -353,15 +355,17 @@ Windows PowerShell：
 - Policy rejection 与 application failure 使用不同异常类别。前者表示越过 P2
   allowlist，后者表示 policy 允许的 patch 无法安全应用到当前 Workflow IR。
 
-## 已确认的 P2.4 Analyzer Routing 决策
+## 已确认的 P2.4 Compiler Routing 决策
 
 - `build_compiler_graph(...)` 通过显式注入 Reviewer node 启用模型路径；默认导出的
   `compiler_graph` 使用 disabled Reviewer，不依赖 API key。
 - Analyzer failure 始终先尝试 deterministic repair。只有没有安全动作，或
   deterministic budget 已耗尽时，才进入 Analyzer Reviewer branch。
+- Checker failure 使用相同顺序，并通过 `repair_failure_stage=checker` 构造包含完整
+  `validation_message` 的 Reviewer request；缺少本地 validator 时不进入 repair。
 - Reviewer provider 默认最多调用一次，预算与 `repair_count` 分离。预算耗尽时不
   再创建或调用 provider，并保留已有 parsed patch、rejection reason 和 diagnostics。
 - 只有 `reviewer_patch_applied=True` 才重新进入 Analyzer；其他 Reviewer 状态全部
   结束当前 Compiler Graph 分支。
-- Checker failure 通过 `analysis_errors` 为空与 Analyzer branch 隔离，本 PR 不改变
-  Checker routing。
+- Analyzer 和 Checker 共用一次 Reviewer provider budget；failure stage 只决定 request
+  diagnostics 来源，不绕过 budget、patch policy 或 compiler re-entry validation。

--- a/docs/p2-reviewer-repair-plan.md
+++ b/docs/p2-reviewer-repair-plan.md
@@ -259,6 +259,9 @@ artifacts，避免前端和 API 消费方解析文本 summary。
 - 已应用 patch 重新进入 Analyzer、Renderer 和 Checker。
 - Checker 缺少本地 WOMtool/miniwdl 时直接结束，不把环境缺失当作可修复的 IR
   failure，也不调用 Reviewer。
+- P2.4 的上述行为当前只覆盖 `compiler_graph`。带 `event_callback` 的
+  `compile_structured_workflow` 服务路径仍使用 deterministic-only 编译循环；该路径的
+  Reviewer routing、events 与 artifacts 统一留到 P2.5 接入。
 
 ### P2.5 Run Service 与 API Observability
 

--- a/docs/test-cases.md
+++ b/docs/test-cases.md
@@ -2600,9 +2600,8 @@ result 和 policy 边界。
 ## `tests/test_reviewer_node.py`
 
 该文件验证 P2.3 `reviewer_repair` compiler node 的独立行为。Node 具备 Provider
-注入、request 构造、patch 校验、应用和 attempt budget 能力。P2.4 Analyzer
-routing 通过 `build_compiler_graph(...)` 使用该 node；Checker request contract 已
-保留，但 Checker routing 仍留给后续 PR。
+注入、request 构造、patch 校验、应用和 attempt budget 能力。P2.4 Analyzer 与
+Checker routing 均通过 `build_compiler_graph(...)` 使用该 node。
 
 ### `test_default_reviewer_node_is_callable_and_disabled`
 
@@ -2778,11 +2777,11 @@ routing 通过 `build_compiler_graph(...)` 使用该 node；Checker request cont
   rejection state。
 - 保存 parsed patch 与错误信息脱敏是两个独立契约。
 
-### `test_reviewer_node_builds_checker_request_without_routing_it`
+### `test_reviewer_node_builds_checker_request_from_state_failure_stage`
 
 输入：
 
-- `failure_stage = checker`。
+- state 中 `repair_failure_stage = checker`。
 - state 包含 WOMtool validation message。
 - fake provider 返回 `no_action`。
 
@@ -2793,8 +2792,8 @@ routing 通过 `build_compiler_graph(...)` 使用该 node；Checker request cont
 
 覆盖点：
 
-- P2.3 同时设计 Analyzer/Checker request contract。
-- Checker graph routing 仍明确留在后续 PR。
+- Reviewer node 优先使用当前 repair cycle 的显式 failure stage。
+- Checker request 不依赖构图时硬编码第二个 Reviewer node。
 
 ### `test_direct_workflow_ir_request_uses_empty_catalog_context`
 
@@ -2919,7 +2918,7 @@ routing 通过 `build_compiler_graph(...)` 使用该 node；Checker request cont
 ## `tests/test_graph.py`
 
 该文件验证 Compiler Graph、Analyzer、Renderer、deterministic repairer 和有界
-Analyzer Reviewer branch 的交互。
+Analyzer/Checker Reviewer branch 的交互。
 
 ### `test_multi_task_ir_analyzes_and_renders`
 
@@ -3276,27 +3275,101 @@ files = flatten([qc.html_report, qc.json_report, [extra_report]])
 - Reviewer budget 在 provider 创建或调用前强制执行。
 - 次数耗尽会显式结束，不丢失已有审计数据。
 
-### `test_checker_failure_does_not_route_to_analyzer_reviewer`
+### `test_checker_failure_routes_to_reviewer_after_no_safe_repair`
 
-输入：
-
-- 有效的 `sample_multi_task_ir()`。
-- Checker 返回合成 validation failure。
-- 注入一个记录调用次数的 enabled Analyzer Reviewer provider。
-
-执行：
-
-- 调用 Compiler Graph。
+输入：有效 Workflow IR、合成 Checker failure，以及返回 `no_action` 的 enabled
+Reviewer provider。
 
 期望输出：
 
-- Checker failure 仍先进入 deterministic repairer，且没有安全动作。
-- Analyzer Reviewer provider 调用次数为零。
-- validation message 保留，Reviewer status 仍为空。
+- deterministic repairer 先执行一次且没有安全动作。
+- Provider 收到一次 `failure_stage=checker` request 和完整 validation message。
+- Reviewer status 为 `no_action`，原始 Checker diagnostic 保留。
 
-覆盖点：
+覆盖点：Checker failure 在 deterministic no-action 后进入 Reviewer，且不形成循环。
 
-- P2.4 第一部分没有提前启用 Checker Reviewer routing。
+### `test_checker_failure_stops_after_disabled_reviewer`
+
+输入：有效 Workflow IR、合成 Checker failure，以及默认 disabled Reviewer graph。
+
+期望输出：
+
+- deterministic repairer 执行一次。
+- Reviewer attempt count 保持零，status 为 `no_action`。
+- diagnostics 明确记录 Reviewer disabled。
+
+覆盖点：默认结构化编译路径不会因 Checker routing 依赖模型或 API key。
+
+### `test_checker_repair_budget_exhaustion_routes_directly_to_reviewer`
+
+输入：Checker failure，且初始 `repair_count` 已达到 deterministic 上限。
+
+期望输出：
+
+- deterministic repairer 不再执行，repair count 和 actions 不变。
+- Provider 直接收到 `failure_stage=checker` request。
+
+覆盖点：deterministic budget 与 Reviewer budget 独立，前者耗尽不会跳过受控 Reviewer
+branch。
+
+### `test_checker_reviewer_patch_reenters_compiler_pipeline`
+
+输入：首次 Checker validation 失败；Reviewer 提议增加引用现有 call output 的 workflow
+output；第二次 Checker validation 成功。
+
+期望输出：
+
+- Provider 只调用一次，request stage 为 `checker`。
+- patch 通过 policy/schema validation 并应用到 canonical Workflow IR。
+- 图重新经过 Analyzer、Renderer、Checker，validator 共调用两次并最终成功。
+- 生成 WDL 包含新增 workflow output。
+
+覆盖点：Checker Reviewer 只能修改 Workflow IR，成功 patch 必须重新通过完整编译链路。
+
+### `test_checker_deterministic_repair_does_not_call_reviewer`
+
+输入：首次 Checker validation 失败；deterministic repairer 返回安全动作；第二次
+validation 成功。
+
+期望输出：Reviewer provider 调用次数为零，修复动作保留，最终 validation 成功。
+
+覆盖点：Reviewer 不抢占可由 deterministic repairer 处理的 Checker failure。
+
+### `test_checker_missing_validator_does_not_call_reviewer`
+
+输入：Checker 返回 `VALIDATOR_MISSING_MARKER` 环境诊断。
+
+期望输出：
+
+- deterministic repairer 和 Reviewer 均不执行。
+- validation message 保留，Reviewer status 为空。
+
+覆盖点：缺少 WOMtool/miniwdl 是环境能力缺失，不是可交给 Reviewer 修复的 IR failure。
+
+### `test_checker_repairer_failure_stops_before_reviewer`
+
+输入：Checker validation 失败，随后 deterministic repair implementation 抛出异常。
+
+期望输出：
+
+- `repairer_failed == True`，repair count 增加一次。
+- failure stage 保持 `checker`，Reviewer provider 不调用。
+
+覆盖点：repairer 内部失败不会被误判为正常 no-action 或触发模型调用。
+
+### `test_checker_reviewer_budget_stops_model_call`
+
+输入：Checker validation 失败；Reviewer attempt count 已达到一次上限，并带有既有
+parsed patch、rejection reason、diagnostics 和上一轮 applied 标记。
+
+期望输出：
+
+- Provider 不调用，attempt count 不增加。
+- 既有 parsed patch、rejection reason 和 diagnostics 保留，并追加 budget diagnostic。
+- 当前节点的 `reviewer_patch_applied` 重置为 `False`，validation message 保留。
+
+覆盖点：Analyzer/Checker 共用 Reviewer provider budget；历史 applied 状态不会被误作
+当前节点 re-entry 信号。
 
 ### `test_compiler_graph_compiles_recipe_tool_plan`
 
@@ -4950,8 +5023,8 @@ retrieval artifact。
 - 多 recipe、多工具候选和更复杂 tool selection。
 - 参数范围错误以外的更多 Tool Catalog schema 边界。
 - nested scatter、conditional step、subworkflow 等 roadmap feature。
-- Reviewer provider、Compiler Graph 路由、Run observability、Resource Agent 和
-  Bioinfo Reviewer 等规划中 Agent。
+- Reviewer 在线 provider 集成、Run observability、Resource Agent 和 Bioinfo
+  Reviewer 等规划中 Agent。
 - Nextflow 或其他 backend。
 - 真实自然语言模型调用的在线集成测试。
 - Next.js 工作台、DAG 可视化和 run history 的浏览器级视觉回归测试。

--- a/src/graph.py
+++ b/src/graph.py
@@ -41,6 +41,8 @@ def route_after_checker(state: WorkflowState):
         return END
     if _can_attempt_repair(state):
         return "repairer"
+    if state.get("workflow_ir"):
+        return "reviewer_repair"
     return END
 
 
@@ -49,7 +51,7 @@ def route_after_repairer(state: WorkflowState):
         return END
     if state.get("repair_actions"):
         return "analyzer"
-    if state.get("analysis_errors") and state.get("workflow_ir"):
+    if _has_reviewer_failure_stage(state) and state.get("workflow_ir"):
         return "reviewer_repair"
     return END
 
@@ -62,6 +64,10 @@ def route_after_reviewer(state: WorkflowState):
 
 def _can_attempt_repair(state: WorkflowState) -> bool:
     return bool(state.get("workflow_ir")) and state.get("repair_count", 0) < MAX_REPAIR_ATTEMPTS
+
+
+def _has_reviewer_failure_stage(state: WorkflowState) -> bool:
+    return state.get("repair_failure_stage") in {"analyzer", "checker"}
 
 
 def _missing_local_validator(state: WorkflowState) -> bool:

--- a/src/nodes/analyzer.py
+++ b/src/nodes/analyzer.py
@@ -3,6 +3,7 @@ import logging
 from langchain_core.messages import HumanMessage
 
 from src.analyzer import analyze_workflow_ir
+from src.reviewer_repair import ReviewerFailureStage
 from src.schema import coerce_workflow_ir
 from src.state import WorkflowState
 
@@ -23,6 +24,7 @@ def analyzer_node(state: WorkflowState):
         return {
             "analysis_errors": [message],
             "analysis_warnings": [],
+            "repair_failure_stage": ReviewerFailureStage.ANALYZER.value,
             "is_valid": False,
             "messages": [HumanMessage(content=message)],
         }
@@ -35,6 +37,9 @@ def analyzer_node(state: WorkflowState):
     return {
         "analysis_errors": report.errors,
         "analysis_warnings": report.warnings,
+        "repair_failure_stage": (
+            None if report.is_valid else ReviewerFailureStage.ANALYZER.value
+        ),
         "is_valid": report.is_valid,
         "messages": messages,
     }

--- a/src/nodes/checker.py
+++ b/src/nodes/checker.py
@@ -2,6 +2,7 @@ import logging
 
 from langchain_core.messages import HumanMessage
 
+from src.reviewer_repair import ReviewerFailureStage
 from src.state import WorkflowState
 from src.tools.validator import wdl_validator
 
@@ -30,6 +31,7 @@ def checker_node(state: WorkflowState):
             "error_count": current_error_count,
             "is_valid": True,
             "validation_message": message,
+            "repair_failure_stage": None,
         }
     else:
         logger.info("WDL validation failed.")
@@ -39,4 +41,5 @@ def checker_node(state: WorkflowState):
             "error_count": current_error_count + 1,
             "is_valid": False,
             "validation_message": message,
+            "repair_failure_stage": ReviewerFailureStage.CHECKER.value,
         }

--- a/src/nodes/reviewer_repair.py
+++ b/src/nodes/reviewer_repair.py
@@ -86,6 +86,17 @@ def make_reviewer_repair_node(
             )
 
         try:
+            resolved_failure_stage = _resolve_failure_stage(state, failure_stage)
+        except ValueError:
+            return _reviewer_update(
+                state,
+                status=ReviewerRepairStatus.INVALID_REQUEST,
+                diagnostics=["Reviewer failure stage is invalid."],
+                rejection_reason="Reviewer failure stage is invalid.",
+                message="Reviewer request construction failed.",
+            )
+
+        try:
             resolved_provider = (
                 provider if provider is not None else provider_factory(model)
             )
@@ -109,7 +120,7 @@ def make_reviewer_repair_node(
         try:
             request = build_reviewer_repair_request(
                 state,
-                failure_stage=failure_stage,
+                failure_stage=resolved_failure_stage,
                 tool_catalog=tool_catalog,
                 recipe_catalog=recipe_catalog,
             )
@@ -254,6 +265,14 @@ def make_reviewer_repair_node(
         }
 
     return node
+
+
+def _resolve_failure_stage(
+    state: WorkflowState,
+    fallback: ReviewerFailureStage,
+) -> ReviewerFailureStage:
+    state_stage = state.get("repair_failure_stage")
+    return fallback if state_stage is None else ReviewerFailureStage(state_stage)
 
 
 def _reviewer_update(

--- a/src/services/workflow_service.py
+++ b/src/services/workflow_service.py
@@ -161,6 +161,7 @@ def build_initial_state(
         "repair_count": 0,
         "repair_actions": [],
         "repairer_failed": False,
+        "repair_failure_stage": None,
         "reviewer_attempt_count": 0,
         "reviewer_repair_status": None,
         "reviewer_repair_request": None,
@@ -503,6 +504,8 @@ def _merge_state(state: WorkflowState, update: Mapping[str, Any]) -> None:
             state["repair_actions"] = value
         elif key == "repairer_failed":
             state["repairer_failed"] = value
+        elif key == "repair_failure_stage":
+            state["repair_failure_stage"] = value
         elif key == "reviewer_attempt_count":
             state["reviewer_attempt_count"] = value
         elif key == "reviewer_repair_status":

--- a/src/state.py
+++ b/src/state.py
@@ -1,4 +1,5 @@
 import operator
+from typing import Literal
 
 from langchain_core.messages import AnyMessage
 from typing_extensions import Annotated, TypedDict
@@ -37,6 +38,9 @@ class WorkflowState(TypedDict):
 
     # 区分 repairer 内部失败与正常完成但没有安全修复动作
     repairer_failed: bool
+
+    # 记录触发当前 repair cycle 的 compiler failure stage
+    repair_failure_stage: Literal["analyzer", "checker"] | None
 
     # Reviewer repair 使用独立计数和结构化结果，避免与 deterministic repair 混淆
     reviewer_attempt_count: int

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -3,12 +3,13 @@ from typing import Any
 from unittest.mock import patch
 
 from src.analyzer import analyze_workflow_ir
-from src.graph import agent, build_compiler_graph, compiler_graph
+from src.graph import MAX_REPAIR_ATTEMPTS, agent, build_compiler_graph, compiler_graph
 from src.nodes.reviewer_repair import make_reviewer_repair_node
 from src.renderers import render_wdl
 from src.reviewer_repair import ReviewerFailureStage, ReviewerRepairStatus
 from src.schema import coerce_workflow_ir
 from src.state import WorkflowState
+from src.tools.validator import VALIDATOR_MISSING_MARKER
 
 
 def sample_multi_task_ir() -> dict[str, Any]:
@@ -212,6 +213,7 @@ def initial_state(parsed_json: dict[str, Any]) -> WorkflowState:
         "repair_count": 0,
         "repair_actions": [],
         "repairer_failed": False,
+        "repair_failure_stage": None,
         "reviewer_attempt_count": 0,
         "reviewer_repair_status": None,
         "reviewer_repair_request": None,
@@ -622,8 +624,13 @@ class WorkflowCompilationTests(unittest.TestCase):
             ],
         )
 
-    def test_checker_failure_does_not_route_to_analyzer_reviewer(self):
-        provider = UnexpectedGraphReviewerProvider()
+    def test_checker_failure_routes_to_reviewer_after_no_safe_repair(self):
+        provider = RecordingGraphReviewerProvider(
+            {
+                "status": "no_action",
+                "diagnostics": ["No safe Checker repair was found."],
+            }
+        )
         graph = self.make_graph_with_reviewer(provider)
 
         with patch("src.nodes.checker.wdl_validator") as validator:
@@ -633,12 +640,220 @@ class WorkflowCompilationTests(unittest.TestCase):
             }
             final_state = graph.invoke(initial_state(sample_multi_task_ir()))
 
-        self.assertEqual(provider.call_count, 0)
+        self.assertEqual(len(provider.requests), 1)
+        self.assertEqual(
+            provider.requests[0].failure_stage,
+            ReviewerFailureStage.CHECKER,
+        )
+        self.assertEqual(
+            provider.requests[0].validation_message,
+            "Synthetic Checker failure.",
+        )
         self.assertEqual(final_state["analysis_errors"], [])
         self.assertEqual(final_state["repair_actions"], [])
         self.assertEqual(final_state["repair_count"], 1)
         self.assertEqual(final_state["validation_message"], "Synthetic Checker failure.")
+        self.assertEqual(
+            final_state["reviewer_repair_status"],
+            ReviewerRepairStatus.NO_ACTION.value,
+        )
+        self.assertEqual(final_state["repair_failure_stage"], "checker")
+
+    def test_checker_failure_stops_after_disabled_reviewer(self):
+        with patch("src.nodes.checker.wdl_validator") as validator:
+            validator.invoke.return_value = {
+                "is_valid": False,
+                "message": "Synthetic Checker failure.",
+            }
+            final_state = compiler_graph.invoke(initial_state(sample_multi_task_ir()))
+
+        self.assertEqual(final_state["repair_count"], 1)
+        self.assertEqual(final_state["reviewer_attempt_count"], 0)
+        self.assertEqual(
+            final_state["reviewer_repair_status"],
+            ReviewerRepairStatus.NO_ACTION.value,
+        )
+        self.assertIn("disabled", final_state["reviewer_diagnostics"][0])
+
+    def test_checker_repair_budget_exhaustion_routes_directly_to_reviewer(self):
+        provider = RecordingGraphReviewerProvider({"status": "no_action"})
+        graph = self.make_graph_with_reviewer(provider)
+        state = initial_state(sample_multi_task_ir())
+        state["repair_count"] = MAX_REPAIR_ATTEMPTS
+
+        with patch("src.nodes.checker.wdl_validator") as validator:
+            validator.invoke.return_value = {
+                "is_valid": False,
+                "message": "Synthetic Checker failure.",
+            }
+            final_state = graph.invoke(state)
+
+        self.assertEqual(len(provider.requests), 1)
+        self.assertEqual(
+            provider.requests[0].failure_stage,
+            ReviewerFailureStage.CHECKER,
+        )
+        self.assertEqual(final_state["repair_count"], MAX_REPAIR_ATTEMPTS)
+        self.assertEqual(final_state["repair_actions"], [])
+
+    def test_checker_reviewer_patch_reenters_compiler_pipeline(self):
+        provider = RecordingGraphReviewerProvider(
+            {
+                "status": "patch_proposed",
+                "patch": {
+                    "summary": "Expose an existing QC output from the workflow.",
+                    "actions": [
+                        {
+                            "operation": "add",
+                            "path": "/workflow/outputs/qc_clean_r1",
+                            "value": "qc.clean_r1",
+                            "reason": "Use an existing call output.",
+                        }
+                    ],
+                    "diagnostic_references": ["Synthetic Checker failure."],
+                    "confidence": 0.8,
+                },
+                "diagnostics": ["The output reference is already type checked."],
+            }
+        )
+        graph = self.make_graph_with_reviewer(provider)
+
+        with patch("src.nodes.checker.wdl_validator") as validator:
+            validator.invoke.side_effect = [
+                {
+                    "is_valid": False,
+                    "message": "Synthetic Checker failure.",
+                },
+                {
+                    "is_valid": True,
+                    "message": "Synthetic Checker success.",
+                },
+            ]
+            final_state = graph.invoke(initial_state(sample_multi_task_ir()))
+
+        self.assertEqual(validator.invoke.call_count, 2)
+        self.assertEqual(len(provider.requests), 1)
+        self.assertEqual(
+            provider.requests[0].failure_stage,
+            ReviewerFailureStage.CHECKER,
+        )
+        self.assertTrue(final_state["reviewer_patch_applied"])
+        self.assertTrue(final_state["is_valid"])
+        self.assertEqual(final_state["repair_failure_stage"], None)
+        self.assertEqual(
+            final_state["workflow_ir"]["workflow"]["outputs"]["qc_clean_r1"],
+            "qc.clean_r1",
+        )
+        self.assertIn("File qc_clean_r1 = qc.clean_r1", final_state["current_wdl"])
+        self.assertEqual(final_state["validation_message"], "Synthetic Checker success.")
+
+    def test_checker_deterministic_repair_does_not_call_reviewer(self):
+        provider = UnexpectedGraphReviewerProvider()
+
+        def synthetic_repairer(state):
+            return {
+                "workflow_ir": state["workflow_ir"],
+                "analysis_errors": [],
+                "analysis_warnings": [],
+                "current_wdl": "",
+                "is_valid": False,
+                "repair_actions": ["Applied a synthetic deterministic repair."],
+                "repair_count": state.get("repair_count", 0) + 1,
+                "repairer_failed": False,
+                "messages": [],
+            }
+
+        with patch("src.graph.repairer_node", new=synthetic_repairer):
+            graph = self.make_graph_with_reviewer(provider)
+
+        with patch("src.nodes.checker.wdl_validator") as validator:
+            validator.invoke.side_effect = [
+                {"is_valid": False, "message": "Synthetic Checker failure."},
+                {"is_valid": True, "message": "Synthetic Checker success."},
+            ]
+            final_state = graph.invoke(initial_state(sample_multi_task_ir()))
+
+        self.assertEqual(provider.call_count, 0)
+        self.assertEqual(validator.invoke.call_count, 2)
+        self.assertTrue(final_state["is_valid"])
+        self.assertEqual(
+            final_state["repair_actions"],
+            ["Applied a synthetic deterministic repair."],
+        )
+
+    def test_checker_missing_validator_does_not_call_reviewer(self):
+        provider = UnexpectedGraphReviewerProvider()
+        graph = self.make_graph_with_reviewer(provider)
+
+        with patch("src.nodes.checker.wdl_validator") as validator:
+            validator.invoke.return_value = {
+                "is_valid": False,
+                "message": f"{VALIDATOR_MISSING_MARKER}.",
+            }
+            final_state = graph.invoke(initial_state(sample_multi_task_ir()))
+
+        self.assertEqual(provider.call_count, 0)
+        self.assertEqual(final_state["repair_count"], 0)
         self.assertIsNone(final_state["reviewer_repair_status"])
+        self.assertIn(VALIDATOR_MISSING_MARKER, final_state["validation_message"])
+
+    def test_checker_repairer_failure_stops_before_reviewer(self):
+        provider = UnexpectedGraphReviewerProvider()
+        graph = self.make_graph_with_reviewer(provider)
+
+        with (
+            patch("src.nodes.checker.wdl_validator") as validator,
+            patch(
+                "src.nodes.repairer.repair_workflow_ir",
+                side_effect=RuntimeError("Synthetic repairer failure."),
+            ),
+        ):
+            validator.invoke.return_value = {
+                "is_valid": False,
+                "message": "Synthetic Checker failure.",
+            }
+            final_state = graph.invoke(initial_state(sample_multi_task_ir()))
+
+        self.assertEqual(provider.call_count, 0)
+        self.assertTrue(final_state["repairer_failed"])
+        self.assertEqual(final_state["repair_count"], 1)
+        self.assertEqual(final_state["repair_failure_stage"], "checker")
+        self.assertIsNone(final_state["reviewer_repair_status"])
+
+    def test_checker_reviewer_budget_stops_model_call(self):
+        provider = UnexpectedGraphReviewerProvider()
+        graph = self.make_graph_with_reviewer(provider)
+        state = initial_state(sample_multi_task_ir())
+        state["reviewer_attempt_count"] = 1
+        state["reviewer_repair_request"] = {"failure_stage": "analyzer"}
+        state["reviewer_ir_patch"] = {"summary": "Previous parsed patch"}
+        state["reviewer_rejection_reason"] = "Previous rejection"
+        state["reviewer_diagnostics"] = ["Previous diagnostic"]
+        state["reviewer_patch_applied"] = True
+
+        with patch("src.nodes.checker.wdl_validator") as validator:
+            validator.invoke.return_value = {
+                "is_valid": False,
+                "message": "Synthetic Checker failure.",
+            }
+            final_state = graph.invoke(state)
+
+        self.assertEqual(provider.call_count, 0)
+        self.assertEqual(final_state["reviewer_attempt_count"], 1)
+        self.assertEqual(
+            final_state["reviewer_ir_patch"],
+            {"summary": "Previous parsed patch"},
+        )
+        self.assertEqual(final_state["reviewer_rejection_reason"], "Previous rejection")
+        self.assertEqual(
+            final_state["reviewer_diagnostics"],
+            [
+                "Previous diagnostic",
+                "Reviewer repair attempt budget exhausted (1).",
+            ],
+        )
+        self.assertFalse(final_state["reviewer_patch_applied"])
+        self.assertEqual(final_state["validation_message"], "Synthetic Checker failure.")
 
     def test_compiler_graph_compiles_recipe_tool_plan(self):
         final_state = compiler_graph.invoke(initial_state(sample_rnaseq_tool_plan()))

--- a/tests/test_reviewer_node.py
+++ b/tests/test_reviewer_node.py
@@ -365,7 +365,7 @@ class ReviewerNodeTests(unittest.TestCase):
         self.assertFalse(update["reviewer_patch_applied"])
         self.assertNotIn("workflow_ir", update)
 
-    def test_reviewer_node_builds_checker_request_without_routing_it(self):
+    def test_reviewer_node_builds_checker_request_from_state_failure_stage(self):
         provider = RecordingReviewerProvider(
             {
                 "status": "no_action",
@@ -373,12 +373,10 @@ class ReviewerNodeTests(unittest.TestCase):
             }
         )
         state = self.sample_state()
+        state["repair_failure_stage"] = ReviewerFailureStage.CHECKER.value
         state["validation_message"] = "WOMtool rejected the generated WDL."
 
-        update = self.make_node(
-            provider,
-            failure_stage=ReviewerFailureStage.CHECKER,
-        )(state)
+        update = self.make_node(provider)(state)
 
         self.assertEqual(
             update["reviewer_repair_status"],


### PR DESCRIPTION
## Summary

- track whether repair was triggered by Analyzer or Checker diagnostics
- route Checker failures through deterministic repair before bounded Reviewer repair
- re-enter Analyzer, Renderer, and Checker after an accepted Reviewer patch
- preserve existing stop conditions for disabled Reviewer, exhausted budgets, missing validators, and repairer failures
- document the routing contract and add focused regression coverage

## Why

This completes the Checker half of the P2 compiler-routing work. Checker diagnostics can now use the same bounded Reviewer repair interface as Analyzer diagnostics without bypassing deterministic repair or validation boundaries.

## Scope

This P2.4 change covers `compiler_graph`. The evented `compile_structured_workflow(..., event_callback=...)` service path remains deterministic-only; Reviewer routing, events, and artifacts for Run Service/API compilation are tracked as P2.5 work.

## Validation

- Checker routing, retry-budget, disabled Reviewer, missing-validator, repairer-failure, and compiler re-entry tests passed
- `tests.test_reviewer_node`: 14 passed
- `tests.test_workflow_service`: 13 passed
- full suite: 262 tests run; 255 passed, 4 skipped, and 3 existing graph tests failed because no local WOMtool/miniwdl validator is installed
- representative WDL generation completed successfully with `--no-check`
- `git diff --check` passed
