### PR TITLE
Add compile-ready ChIP-seq tool catalog

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -842,6 +842,10 @@ RAG 开发序列放在 P4 之下维护：
 verification 的边界，允许暂缓真实 e2e，但不允许用不完整占位条目绕过正式
 Tool Catalog 契约。
 
+当前 `bowtie2`、`samtools` 和 `macs2` 已作为 `unverified`、compile-ready
+工具进入正式 Catalog。下一步是增加 `chipseq_peak_calling` recipe 和首次跨
+family retrieval baseline；在 recipe 合并前，ChIP-seq 仍不属于已支持 workflow。
+
 R1/R2 仍属于受控 Catalog 内检索，不进入 P6 的未知工具发现边界。外部网页、论文、未知工具和 Candidate ToolSpec 的发现应继续归入 P6。
 
 ### P5 Resource Agent

--- a/docs/catalog-expansion-rag-plan.md
+++ b/docs/catalog-expansion-rag-plan.md
@@ -521,6 +521,7 @@ supported recall，但必须暴露 direct lexical match 和 fallback 风险。
 - 已加入 `bowtie2`、`samtools` 和 `macs2`。
 - 复用 `fastp`、`multiqc`。
 - 已添加 schema/load/rendering tests。
+- 测试 recipe 生成的代表性 WDL 已通过 WOMtool 91 syntax validation。
 - 三个工具均按真实 evidence 标记为 `unverified`。
 
 ### PR 3: ChIP-seq Recipe And Retrieval Baseline

--- a/docs/catalog-expansion-rag-plan.md
+++ b/docs/catalog-expansion-rag-plan.md
@@ -42,7 +42,7 @@ workflow 科学范围、参数数量和执行验证深度，不是 ToolSpec 契�
 - 2 个 recipe，均属于 bulk RNA-seq family：
   - `rnaseq_differential_expression`
   - `rnaseq_reference_preparation`
-- 9 个 tool：
+- 12 个 tool：
   - `fastp`
   - `salmon`
   - `salmon_index`
@@ -52,13 +52,23 @@ workflow 科学范围、参数数量和执行验证深度，不是 ToolSpec 契�
   - `edger`
   - `limma_voom`
   - `multiqc`
+  - `bowtie2`
+  - `samtools`
+  - `macs2`
 - 24 条 retrieval query：
   - 20 条 supported RNA-seq query。
   - 4 条 unsupported negative query。
 
-当前 `lexical_v1` baseline 的 Planner Context Tool Recall 和 Planner Context
-Role Coverage 均为 `1.0000`。这说明当前 RNA-seq Catalog 内的 prompt context
-覆盖稳定，但不能证明跨 workflow family 的检索能力。
+新增的三个 ChIP-seq 工具已达到 compile-ready，但正式 Catalog 仍只有两个
+RNA-seq recipe。因此 ChIP-seq query 在 recipe/product capability 层面继续标记为
+unsupported，不能因为能直接召回 `macs2` 就声称 workflow 已受支持。
+
+在同一组 24 条 query 上，扩充后的 `lexical_v1` baseline 为：Tool Recall@8
+`0.8900`、Tool MRR `0.9583`、Raw Role Coverage `0.8933`；Planner Context Tool
+Recall 和 Planner Context Role Coverage 仍均为 `1.0000`。Raw 指标相较 9-tool
+Catalog 下降，说明更多跨 family tool 已开始挤占 lexical top-K，但 recipe expansion
+仍能保持当前 RNA-seq Planner context 完整。该中间状态不能作为 R3 决策依据，需在
+ChIP-seq recipe 和 family-labeled query 落地后重新评估。
 
 现有 `Recipe Recall@3` 和 `Tool Recall@8` 在 Catalog 较小时区分度有限。扩展
 Catalog 后应增加更严格的 top-K 和 family-level 指标。
@@ -192,7 +202,7 @@ paired-end ChIP-seq FASTQ
 - `fastp`
 - `multiqc`
 
-建议新增工具：
+已新增 compile-ready 工具：
 
 - `bowtie2`
 - `samtools`
@@ -200,6 +210,15 @@ paired-end ChIP-seq FASTQ
 
 为控制范围，`samtools` 可以先提供边界清晰的 sort/index command contract，
 不必覆盖完整 samtools 子命令集合。
+
+当前固定 runtime 为：
+
+- `quay.io/biocontainers/bowtie2:2.5.5--ha27dd3b_0`
+- `quay.io/biocontainers/samtools:1.24--h9dcdb79_1`
+- `quay.io/biocontainers/macs2:2.2.9.1--py310h1fe012e_5`
+
+这些 tag 已按 Bioconda package 页面和 Quay registry 核实存在，但尚未运行本项目
+的 smoke test 或 tiny e2e，因此 execution verification 均保持 `unverified`。
 
 ### Inputs And Outputs
 
@@ -497,12 +516,12 @@ supported recall，但必须暴露 direct lexical match 和 fallback 风险。
 - Retriever artifact、API 类型和前端状态文案已同步。
 - application-level execution preflight 已增加未验证工具 policy。
 
-### PR 2: ChIP-seq Tool Catalog
+### PR 2: ChIP-seq Tool Catalog（已实现）
 
-- 加入 `bowtie2`、`samtools` 和 `macs2`。
+- 已加入 `bowtie2`、`samtools` 和 `macs2`。
 - 复用 `fastp`、`multiqc`。
-- 添加 schema/load/rendering tests。
-- 标记真实 execution verification 状态。
+- 已添加 schema/load/rendering tests。
+- 三个工具均按真实 evidence 标记为 `unverified`。
 
 ### PR 3: ChIP-seq Recipe And Retrieval Baseline
 
@@ -586,9 +605,11 @@ recipe resolution、Workflow IR 或 WDL 输出时，还应：
 
 ## Immediate Next Step
 
-Tool Capability And Verification Contract 已落地。下一项工作是加入简化版
-ChIP-seq Tool Catalog：`bowtie2`、`samtools` 和 `macs2` 必须满足完整
-compile-ready ToolSpec，并按实际 evidence 标记 execution verification。
+Tool Capability And Verification Contract 及简化版 ChIP-seq Tool Catalog 已
+落地。下一项工作是实现 `chipseq_peak_calling` recipe 和首次跨 family retrieval
+baseline：连接 `fastp`、`bowtie2`、`samtools`、`macs2` 和 `multiqc`，增加
+example plan 与确定性 WDL validation，将现有 ChIP-seq negative query 转为
+supported，并加入 Recall@1、Tool Recall@3/5 和 `workflow_family` 分组。
 
-ChIP-seq 工具契约合并后，再实现 recipe 和 retrieval baseline；随后按相同
-模式推进 scRNA-seq 与 variant calling。
+ChIP-seq recipe 与 baseline 合并后，再按相同模式推进 scRNA-seq 与 variant
+calling。

--- a/docs/r2-retrieval-evaluation-roadmap.md
+++ b/docs/r2-retrieval-evaluation-roadmap.md
@@ -124,6 +124,19 @@ tests/fixtures/retrieval_queries.json
   `expected_tools` 中，并且只允许该 tool 覆盖
   `expected_roles.differential_expression`。
 
+### R2c ChIP-seq Tool Catalog Intermediate Checkpoint
+
+在正式 Catalog 增加 compile-ready 的 `bowtie2`、`samtools` 和 `macs2` 后，
+tool 数量从 9 增加到 12，但 recipe 仍只有两个 RNA-seq workflow。该 checkpoint
+继续使用同一组 24 条 query，以观察纯 tool catalog expansion 对 top-K 的影响：
+
+- ChIP-seq negative query 暂不转为 supported，因为 `chipseq_peak_calling`
+  recipe 尚未进入正式 Catalog。
+- 能直接召回 `macs2` 只表示 tool metadata 命中，不等于 workflow capability
+  已受支持。
+- 该中间 checkpoint 用于记录 top-K crowding，不用于决定 R3 backend。
+- 下一 checkpoint 应随 ChIP-seq recipe、family label 和跨 family query 一同建立。
+
 ## Metrics
 
 第一版 eval 应保持轻量、可解释、可在本地稳定运行。
@@ -172,7 +185,7 @@ tests/test_retrieval_evaluation.py
 .\.venv\Scripts\python.exe scripts\evaluate_retrieval.py
 ```
 
-当前 `lexical_v1` expanded RNA-seq catalog baseline：
+R2b expanded RNA-seq catalog 的 9-tool checkpoint：
 
 | Metric | Value |
 | --- | ---: |
@@ -190,11 +203,33 @@ tests/test_retrieval_evaluation.py
 | Supported Fallback Rate | 0.0000 |
 | Unsupported Fallback Rate | 0.2500 |
 
+R2c ChIP-seq tool catalog 的 12-tool 中间 checkpoint：
+
+| Metric | Value |
+| --- | ---: |
+| Query count | 24 |
+| Supported queries | 20 |
+| Unsupported queries | 4 |
+| Recipe Recall@3 | 1.0000 |
+| Recipe MRR | 0.9500 |
+| Tool Recall@8 | 0.8900 |
+| Tool MRR | 0.9583 |
+| Role Coverage | 0.8933 |
+| Planner Context Tool Recall | 1.0000 |
+| Planner Context Role Coverage | 1.0000 |
+| Fallback Rate | 0.0417 |
+| Supported Fallback Rate | 0.0000 |
+| Unsupported Fallback Rate | 0.2500 |
+
 已知 baseline 观察：
 
-- `rnaseq_deg_no_tool_names_en` 和 `rnaseq_params_threads_contrast_en` 的 raw
+- 9-tool checkpoint 中，`rnaseq_deg_no_tool_names_en` 和
+  `rnaseq_params_threads_contrast_en` 的 raw
   tool retrieval 未直接召回 `tximport`，说明 query 只描述目标或参数时，
   lexical tool recall 仍会漏掉中间步骤。
+- 12-tool checkpoint 的 Tool Recall@8 和 Raw Role Coverage 分别降至 `0.8900`
+  和 `0.8933`。`ChIP-seq`、paired-end、alignment 等共享词汇让新增工具进入
+  RNA-seq top-K，形成了预期的 catalog crowding 信号。
 - Planner Context Tool Recall 和 Planner Context Role Coverage 均为 1.0000，
   说明当 top recipe 召回正确时，Planner prompt 中通过 recipe allowed tools
   补齐的候选上下文仍覆盖所需工具和 role。

--- a/docs/test-cases.md
+++ b/docs/test-cases.md
@@ -1404,11 +1404,28 @@ OK (skipped=2)
 
 覆盖点：
 
-- 三个新增 ToolSpec 已达到 resolver/analyzer/renderer 意义上的 compile-ready。
+- 三个新增 ToolSpec 已通过 resolver/analyzer/renderer 阶段的结构和确定性渲染验证。
 - 测试 recipe 不写入正式 Recipe Catalog，因此不会提前宣称 ChIP-seq workflow
   已受支持。
 - Catalog output description 保留给 metadata/API/RAG；resolver 只将
   `type`、`value` 和 `tags` 投影到 Workflow IR OutputSpec。
+
+### `test_chipseq_tool_contract_wdl_passes_syntax_validation`
+
+输入：与 `test_chipseq_tool_contracts_resolve_to_valid_renderable_ir` 相同的测试 recipe、
+Recipe Tool Plan 和正式 Tool Catalog。
+
+执行：
+
+1. 通过 resolver 和 renderer 生成代表性的 ChIP-seq WDL。
+2. 调用项目统一的 `wdl_validator`，由配置的 WOMtool 或 miniwdl 执行语法校验。
+
+期望输出：validator 返回 `is_valid=True`；无可用 validator 时按现有测试约定跳过。
+
+覆盖点：为三个新增 ToolSpec 补齐 compile-ready policy 要求的外部 WDL 语法验证，
+并保持无 validator 环境下的纯 Catalog/Analyzer/Renderer 测试继续运行。
+
+本次 Catalog admission 使用 WOMtool 91 实际执行该测试并通过。
 
 ### `test_macs2_optional_control_is_rendered_when_provided`
 

--- a/docs/test-cases.md
+++ b/docs/test-cases.md
@@ -1355,6 +1355,76 @@ OK (skipped=2)
 - Salmon index 和 GTF tx2gene helper 生成的 task 定义可被 Analyzer 与 WDL renderer 接受。
 - Reference prep 输出与现有 DEG recipe 所需的 `transcriptome_index` / `tx2gene` 概念衔接。
 
+### `test_chipseq_tools_are_compile_ready_but_unverified`
+
+输入：当前正式 Tool Catalog 中的 `bowtie2@2.5.5`、`samtools@1.24` 和
+`macs2@2.2.9.1`。
+
+期望输出：
+
+- 三个工具均能通过完整 ToolSpec schema 和 Catalog loader。
+- runtime 分别固定为已核实存在的 BioContainers 镜像 tag。
+- `bowtie2` 声明 paired-end FASTQ、index archive、SAM 和 alignment log 契约。
+- `samtools` 声明 alignment、coordinate-sorted BAM 和 BAI 契约。
+- `macs2` 声明 treatment/control BAM、narrowPeak、summits、peak table 和 log 契约。
+- `macs2` 仅将 MultiQC 实际读取的 `*_peaks.xls` peak table 标记为 `multiqc_input`。
+- 三个工具的 execution verification 均为 `unverified` 且 evidence 为空。
+
+覆盖点：
+
+- 正式 Catalog 可以加入尚未真实运行、但结构和 runtime 完整的 compile-ready
+  工具。
+- Catalog admission 不会被误写成 smoke-tested 或 e2e-validated。
+
+### `test_chipseq_tool_contracts_resolve_to_valid_renderable_ir`
+
+输入：
+
+- 只存在于测试代码中的 `chipseq_tool_contract` recipe。
+- 串联 `bowtie2 -> samtools -> macs2` 的最小 Recipe Tool Plan。
+- 当前正式 Tool Catalog。
+
+执行：
+
+1. 调用 `resolve_tool_plan(...)` 生成 Workflow IR。
+2. 调用 `analyze_workflow_ir(...)` 验证数据依赖和类型。
+3. 调用 `render_wdl(...)` 生成 WDL。
+
+期望输出：
+
+- Analyzer 返回 `is_valid=True`。
+- IR/WDL 包含 `bowtie2_align`、`samtools_prepare_bam` 和 `macs2_peaks`。
+- Bowtie 2 index archive 解包后解析 index prefix，并排除 `.rev.1.bt2` /
+  `.rev.1.bt2l` reverse-index 文件。
+- `align.aligned_sam` 正确连接到 samtools，`prepare_bam.sorted_bam` 正确连接到
+  MACS2。
+- samtools command 同一 task 内依次执行 coordinate sort 和 index。
+- 未提供 control 时 MACS2 command 不渲染 `-c`。
+- workflow 输出暴露 sorted BAM、BAI、narrowPeak 和 peak summits。
+
+覆盖点：
+
+- 三个新增 ToolSpec 已达到 resolver/analyzer/renderer 意义上的 compile-ready。
+- 测试 recipe 不写入正式 Recipe Catalog，因此不会提前宣称 ChIP-seq workflow
+  已受支持。
+- Catalog output description 保留给 metadata/API/RAG；resolver 只将
+  `type`、`value` 和 `tags` 投影到 Workflow IR OutputSpec。
+
+### `test_macs2_optional_control_is_rendered_when_provided`
+
+输入：在最小 ChIP-seq tool contract plan 中增加 `control_bam` workflow input，
+并传给 MACS2 call。
+
+期望输出：
+
+- Analyzer 返回 `is_valid=True`。
+- MACS2 task input 保持 `File? control_bam`。
+- call wiring 包含 `control_bam = control_bam`。
+- command 包含 `-c ~{control_bam}`。
+
+覆盖点：MACS2 control 输入的 optional schema 和 conditional command template
+保持一致。
+
 ### `test_rnaseq_de_tool_alternatives_resolve_to_valid_wdl`
 
 输入：
@@ -1812,11 +1882,15 @@ catalog baseline metrics。Fixture 不伪造工具；unsupported 负例单独统
 - `supported_query_count == 20`。
 - `unsupported_query_count == 4`。
 - 每个 metric 均为 0 到 1 之间的稳定数值。
+- `planner_context_tool_recall == 1.0`。
+- `planner_context_role_coverage == 1.0`。
 
 覆盖点：
 
 - 当前 Catalog 可以生成可重复 retrieval baseline。
 - Baseline artifact 包含 per-query retrieval、miss、fallback 与 aggregate metrics。
+- 新增 ChIP-seq tools 挤动 raw top-K 时，现有 RNA-seq recipe expansion 仍保持
+  Planner context 完整；这不替代下一 PR 的 family-level baseline。
 
 ### `test_computes_supported_metrics_and_tracks_unsupported_matches`
 
@@ -2037,6 +2111,26 @@ catalog baseline metrics。Fixture 不伪造工具；unsupported 负例单独统
 覆盖点：
 
 - 未指定版本时，Catalog service 选择当前 catalog 中最高版本。
+
+### `test_get_chipseq_tool_exposes_unverified_compile_ready_metadata`
+
+输入：不指定版本调用 `get_tool("macs2")`。
+
+期望输出：
+
+- 返回 `macs2@2.2.9.1`。
+- `trust_status == "catalog-approved"`。
+- runtime 使用固定 BioContainers image。
+- `control_bam` 保持 optional。
+- `narrow_peaks` 的 Catalog output description 对 API 可见。
+- execution verification 为 `unverified` 且 evidence 为空。
+
+覆盖点：
+
+- compile-ready ChIP-seq metadata 可被 API/RAG surface 使用。
+- Catalog admission 与 execution verification 在 API 输出中继续独立表达。
+- Catalog 专属 output description 不需要进入 Workflow IR，也不会在 resolver
+  投影时丢失源 metadata。
 
 ### `test_unknown_recipe_and_tool_raise_key_error`
 

--- a/src/catalog/resolver.py
+++ b/src/catalog/resolver.py
@@ -115,7 +115,11 @@ def resolve_tool_plan(
             "inputs": task_inputs,
             "command": command,
             "outputs": {
-                output_name: output.model_dump(mode="json", exclude_none=True, exclude_defaults=True)
+                output_name: output.model_dump(
+                    mode="json",
+                    include={"type", "value", "tags"},
+                    exclude_defaults=True,
+                )
                 for output_name, output in tool.outputs.items()
             },
             "runtime": tool.runtime.model_dump(mode="json", exclude_none=True),

--- a/src/catalog/tools/bowtie2/2.5.5.yaml
+++ b/src/catalog/tools/bowtie2/2.5.5.yaml
@@ -1,0 +1,67 @@
+id: bowtie2
+version: "2.5.5"
+aliases:
+  - Bowtie 2
+  - ChIP-seq alignment
+  - paired-end read alignment
+  - short-read genome alignment
+description: Align paired-end ChIP-seq reads to a prebuilt Bowtie 2 genome index.
+execution_verification:
+  status: unverified
+  evidence: []
+
+inputs:
+  r1:
+    type: File
+    required: true
+    description: First cleaned paired-end FASTQ file.
+  r2:
+    type: File
+    required: true
+    description: Second cleaned paired-end FASTQ file.
+  index_archive:
+    type: File
+    required: true
+    description: Gzip-compressed tar archive containing a Bowtie 2 bt2 or bt2l genome index.
+
+params:
+  threads:
+    type: Int
+    default: 8
+    min: 1
+    description: Number of Bowtie 2 alignment threads.
+
+outputs:
+  aligned_sam:
+    type: File
+    value: '"aligned.sam"'
+    description: Paired-end alignments in SAM format.
+  alignment_log:
+    type: File
+    value: '"bowtie2.log"'
+    description: Bowtie 2 alignment summary written to standard error.
+    tags:
+      - multiqc_input
+
+command_template: |
+  set -euo pipefail;
+  index_path="~{index_archive}";
+  mkdir -p bowtie2_index_input;
+  tar -xzf "$index_path" -C bowtie2_index_input;
+  index_file="$(find bowtie2_index_input -type f \( -name '*.1.bt2' -o -name '*.1.bt2l' \) ! -name '*.rev.1.bt2' ! -name '*.rev.1.bt2l' -print -quit)";
+  [ -n "$index_file" ] || { echo "Bowtie 2 index archive does not contain a .1.bt2 or .1.bt2l file" >&2; exit 1; };
+  index_prefix="${index_file%.1.bt2}";
+  index_prefix="${index_prefix%.1.bt2l}";
+  bowtie2
+  -x "$index_prefix"
+  -1 ~{r1}
+  -2 ~{r2}
+  -p ~{threads}
+  --very-sensitive
+  -S aligned.sam
+  2> bowtie2.log
+
+runtime:
+  docker: quay.io/biocontainers/bowtie2:2.5.5--ha27dd3b_0
+  cpu: 8
+  memory: 16G

--- a/src/catalog/tools/macs2/2.2.9.1.yaml
+++ b/src/catalog/tools/macs2/2.2.9.1.yaml
@@ -1,0 +1,71 @@
+id: macs2
+version: "2.2.9.1"
+aliases:
+  - MACS2
+  - ChIP-seq peak calling
+  - transcription factor binding peaks
+  - enriched genomic regions
+description: Call narrow ChIP-seq peaks from paired-end treatment and optional control BAM files.
+execution_verification:
+  status: unverified
+  evidence: []
+
+inputs:
+  treatment_bam:
+    type: File
+    required: true
+    description: Coordinate-sorted paired-end ChIP-seq treatment BAM.
+  control_bam:
+    type: File
+    required: false
+    description: Optional coordinate-sorted paired-end input or control BAM.
+
+params:
+  genome_size:
+    type: String
+    default: hs
+    description: Effective genome size accepted by MACS2, such as hs, mm, or a numeric value.
+  qvalue:
+    type: Float
+    default: 0.05
+    min: 0.0
+    max: 1.0
+    description: False-discovery-rate cutoff used to call significant peaks.
+
+outputs:
+  narrow_peaks:
+    type: File
+    value: '"macs2_output/chipseq_peaks.narrowPeak"'
+    description: NarrowPeak table containing enriched genomic regions.
+  summits:
+    type: File
+    value: '"macs2_output/chipseq_summits.bed"'
+    description: BED file containing called peak summit positions.
+  peak_table:
+    type: File
+    value: '"macs2_output/chipseq_peaks.xls"'
+    description: Tabular MACS2 peak report.
+    tags:
+      - multiqc_input
+  callpeak_log:
+    type: File
+    value: '"macs2.log"'
+    description: MACS2 callpeak diagnostic log.
+
+command_template: |
+  mkdir -p macs2_output && macs2 callpeak
+  -t ~{treatment_bam}
+  {% if control_bam %}-c ~{control_bam}{% endif %}
+  -f BAMPE
+  -g ~{genome_size}
+  -q ~{qvalue}
+  --keep-dup auto
+  --call-summits
+  -n chipseq
+  --outdir macs2_output
+  2> macs2.log
+
+runtime:
+  docker: quay.io/biocontainers/macs2:2.2.9.1--py310h1fe012e_5
+  cpu: 2
+  memory: 8G

--- a/src/catalog/tools/samtools/1.24.yaml
+++ b/src/catalog/tools/samtools/1.24.yaml
@@ -1,0 +1,49 @@
+id: samtools
+version: "1.24"
+aliases:
+  - SAM to BAM
+  - BAM sort and index
+  - coordinate-sorted alignment
+  - alignment processing
+description: Coordinate-sort a SAM or BAM alignment and build its BAM index.
+execution_verification:
+  status: unverified
+  evidence: []
+
+inputs:
+  alignment:
+    type: File
+    required: true
+    description: Input alignment in SAM or BAM format.
+
+params:
+  threads:
+    type: Int
+    default: 4
+    min: 1
+    description: Number of threads used for sorting and indexing.
+
+outputs:
+  sorted_bam:
+    type: File
+    value: '"aligned.sorted.bam"'
+    description: Coordinate-sorted BAM alignment.
+  bam_index:
+    type: File
+    value: '"aligned.sorted.bam.bai"'
+    description: BAI index for the coordinate-sorted BAM alignment.
+
+command_template: |
+  samtools sort
+  -@ ~{threads}
+  -o aligned.sorted.bam
+  ~{alignment}
+  && samtools index
+  -@ ~{threads}
+  aligned.sorted.bam
+  aligned.sorted.bam.bai
+
+runtime:
+  docker: quay.io/biocontainers/samtools:1.24--h9dcdb79_1
+  cpu: 4
+  memory: 8G

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -13,6 +13,7 @@ from src.recipes.loader import RecipeCatalog
 from src.recipes.schema import RecipeSpec
 from src.renderers import render_wdl
 from src.schema import flatten_workflow_calls
+from src.tools.validator import wdl_validator, wdl_validator_available
 
 
 CATALOG_TOOLS_DIR = Path(__file__).resolve().parents[1] / "src" / "catalog" / "tools"
@@ -418,6 +419,19 @@ class CatalogResolutionTests(unittest.TestCase):
         self.assertIn("File bam_index = prepare_bam.bam_index", wdl)
         self.assertIn("File narrow_peaks = peaks.narrow_peaks", wdl)
         self.assertIn("File peak_summits = peaks.summits", wdl)
+
+    @unittest.skipUnless(wdl_validator_available(), "WDL validator is not installed")
+    def test_chipseq_tool_contract_wdl_passes_syntax_validation(self):
+        workflow_ir = resolve_tool_plan(
+            sample_chipseq_tool_contract_plan(),
+            chipseq_tool_contract_recipe_catalog(),
+            self.tool_catalog,
+        )
+        wdl = render_wdl(workflow_ir)
+
+        result = wdl_validator.invoke({"wdl_code": wdl})
+
+        self.assertTrue(result["is_valid"], result["message"])
 
     def test_macs2_optional_control_is_rendered_when_provided(self):
         plan = sample_chipseq_tool_contract_plan()

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -9,6 +9,8 @@ from src.analyzer import analyze_workflow_ir
 from src.catalog import load_tool_catalog, resolve_tool_plan
 from src.catalog.schema import ExecutionVerificationSpec, ToolSpec
 from src.recipes import load_recipe_catalog
+from src.recipes.loader import RecipeCatalog
+from src.recipes.schema import RecipeSpec
 from src.renderers import render_wdl
 from src.schema import flatten_workflow_calls
 
@@ -146,6 +148,88 @@ def sample_rnaseq_reference_prep_plan() -> dict[str, Any]:
     }
 
 
+def chipseq_tool_contract_recipe_catalog() -> RecipeCatalog:
+    recipe = RecipeSpec.model_validate(
+        {
+            "id": "chipseq_tool_contract",
+            "name": "ChIP-seq tool contract test",
+            "required_inputs": {
+                "r1": {"type": "File"},
+                "r2": {"type": "File"},
+                "genome_index": {"type": "File"},
+            },
+            "steps": [
+                {
+                    "id": "align_reads",
+                    "role": "genome_alignment",
+                    "allowed_tools": ["bowtie2"],
+                },
+                {
+                    "id": "sort_and_index",
+                    "role": "bam_sort_and_index",
+                    "allowed_tools": ["samtools"],
+                },
+                {
+                    "id": "call_peaks",
+                    "role": "peak_calling",
+                    "allowed_tools": ["macs2"],
+                },
+            ],
+        }
+    )
+    return RecipeCatalog({recipe.id: recipe})
+
+
+def sample_chipseq_tool_contract_plan() -> dict[str, Any]:
+    return {
+        "workflow": {
+            "name": "ChIPSeqToolContract",
+            "recipe": "chipseq_tool_contract",
+            "inputs": {
+                "r1": "File",
+                "r2": "File",
+                "genome_index": "File",
+            },
+            "tool_calls": [
+                {
+                    "id": "align",
+                    "step": "align_reads",
+                    "tool": "bowtie2",
+                    "version": "2.5.5",
+                    "inputs": {
+                        "r1": "r1",
+                        "r2": "r2",
+                        "index_archive": "genome_index",
+                    },
+                    "params": {"threads": 8},
+                },
+                {
+                    "id": "prepare_bam",
+                    "step": "sort_and_index",
+                    "tool": "samtools",
+                    "version": "1.24",
+                    "inputs": {"alignment": "align.aligned_sam"},
+                    "params": {"threads": 4},
+                },
+                {
+                    "id": "peaks",
+                    "step": "call_peaks",
+                    "tool": "macs2",
+                    "version": "2.2.9.1",
+                    "inputs": {"treatment_bam": "prepare_bam.sorted_bam"},
+                    "params": {"genome_size": "hs", "qvalue": 0.01},
+                },
+            ],
+            "outputs": {
+                "sorted_bam": "prepare_bam.sorted_bam",
+                "bam_index": "prepare_bam.bam_index",
+                "narrow_peaks": "peaks.narrow_peaks",
+                "peak_summits": "peaks.summits",
+            },
+        }
+    }
+
+
 class CatalogDefinitionTests(unittest.TestCase):
     def test_catalog_file_path_matches_tool_id_and_version(self):
         for yaml_path in sorted(CATALOG_TOOLS_DIR.rglob("*.yaml")):
@@ -168,6 +252,43 @@ class CatalogDefinitionTests(unittest.TestCase):
             tool_catalog.get("salmon_index", "1.9.0").execution_verification.status,
             "unverified",
         )
+
+    def test_chipseq_tools_are_compile_ready_but_unverified(self):
+        tool_catalog = load_tool_catalog()
+        expected_tools = {
+            "bowtie2": {
+                "version": "2.5.5",
+                "docker": "quay.io/biocontainers/bowtie2:2.5.5--ha27dd3b_0",
+                "inputs": {"r1", "r2", "index_archive"},
+                "outputs": {"aligned_sam", "alignment_log"},
+            },
+            "samtools": {
+                "version": "1.24",
+                "docker": "quay.io/biocontainers/samtools:1.24--h9dcdb79_1",
+                "inputs": {"alignment"},
+                "outputs": {"sorted_bam", "bam_index"},
+            },
+            "macs2": {
+                "version": "2.2.9.1",
+                "docker": "quay.io/biocontainers/macs2:2.2.9.1--py310h1fe012e_5",
+                "inputs": {"treatment_bam", "control_bam"},
+                "outputs": {"narrow_peaks", "summits", "peak_table", "callpeak_log"},
+            },
+        }
+
+        for tool_id, expected in expected_tools.items():
+            with self.subTest(tool=tool_id):
+                tool = tool_catalog.get(tool_id, expected["version"])
+                self.assertEqual(tool.runtime.docker, expected["docker"])
+                self.assertEqual(set(tool.inputs), expected["inputs"])
+                self.assertEqual(set(tool.outputs), expected["outputs"])
+                self.assertTrue(tool.command_template.strip())
+                self.assertEqual(tool.execution_verification.status, "unverified")
+                self.assertEqual(tool.execution_verification.evidence, [])
+
+        macs2 = tool_catalog.get("macs2", "2.2.9.1")
+        self.assertEqual(macs2.outputs["peak_table"].tags, ["multiqc_input"])
+        self.assertEqual(macs2.outputs["callpeak_log"].tags, [])
 
     def test_tool_spec_requires_execution_verification(self):
         tool_data = load_tool_catalog().get("fastp", "1.3.3").model_dump(mode="python")
@@ -263,6 +384,63 @@ class CatalogResolutionTests(unittest.TestCase):
         self.assertIn("run_gtf_tx2gene.py \\\n    --annotation-gtf ~{annotation_gtf}", wdl)
         self.assertIn("File transcriptome_index = index.index_archive", wdl)
         self.assertIn("File tx2gene = mapping.tx2gene", wdl)
+
+    def test_chipseq_tool_contracts_resolve_to_valid_renderable_ir(self):
+        workflow_ir = resolve_tool_plan(
+            sample_chipseq_tool_contract_plan(),
+            chipseq_tool_contract_recipe_catalog(),
+            self.tool_catalog,
+        )
+        report = analyze_workflow_ir(workflow_ir)
+        wdl = render_wdl(workflow_ir)
+
+        self.assertTrue(report.is_valid, report.errors)
+        self.assertIn("bowtie2_align", workflow_ir.tasks)
+        self.assertIn("samtools_prepare_bam", workflow_ir.tasks)
+        self.assertIn("macs2_peaks", workflow_ir.tasks)
+        self.assertIn("call bowtie2_align as align", wdl)
+        self.assertIn("call samtools_prepare_bam as prepare_bam", wdl)
+        self.assertIn("call macs2_peaks as peaks", wdl)
+        self.assertIn("index_archive = genome_index", wdl)
+        self.assertIn("alignment = align.aligned_sam", wdl)
+        self.assertIn("treatment_bam = prepare_bam.sorted_bam", wdl)
+        self.assertIn("find bowtie2_index_input -type f", wdl)
+        self.assertIn("! -name '*.rev.1.bt2'", wdl)
+        self.assertIn("-print -quit", wdl)
+        self.assertIn('-x "$index_prefix"', wdl)
+        self.assertIn("samtools sort", wdl)
+        self.assertIn("&& samtools index", wdl)
+        self.assertIn("macs2 callpeak", wdl)
+        self.assertNotIn("-c ~{control_bam}", wdl)
+        self.assertIn('genome_size = "hs"', wdl)
+        self.assertIn("qvalue = 0.01", wdl)
+        self.assertIn("File sorted_bam = prepare_bam.sorted_bam", wdl)
+        self.assertIn("File bam_index = prepare_bam.bam_index", wdl)
+        self.assertIn("File narrow_peaks = peaks.narrow_peaks", wdl)
+        self.assertIn("File peak_summits = peaks.summits", wdl)
+
+    def test_macs2_optional_control_is_rendered_when_provided(self):
+        plan = sample_chipseq_tool_contract_plan()
+        plan["workflow"]["inputs"]["control_bam"] = "File"
+        peaks_call = next(
+            tool_call
+            for tool_call in plan["workflow"]["tool_calls"]
+            if tool_call["tool"] == "macs2"
+        )
+        peaks_call["inputs"]["control_bam"] = "control_bam"
+
+        workflow_ir = resolve_tool_plan(
+            plan,
+            chipseq_tool_contract_recipe_catalog(),
+            self.tool_catalog,
+        )
+        report = analyze_workflow_ir(workflow_ir)
+        wdl = render_wdl(workflow_ir)
+
+        self.assertTrue(report.is_valid, report.errors)
+        self.assertIn("File? control_bam", wdl)
+        self.assertIn("control_bam = control_bam", wdl)
+        self.assertIn("-c ~{control_bam}", wdl)
 
     def test_rnaseq_de_tool_alternatives_resolve_to_valid_wdl(self):
         alternatives = [

--- a/tests/test_catalog_service.py
+++ b/tests/test_catalog_service.py
@@ -49,6 +49,25 @@ class CatalogServiceTests(unittest.TestCase):
         self.assertEqual(tool["id"], "multiqc")
         self.assertEqual(tool["version"], "1.21")
 
+    def test_get_chipseq_tool_exposes_unverified_compile_ready_metadata(self):
+        tool = get_tool("macs2")
+
+        self.assertEqual(tool["version"], "2.2.9.1")
+        self.assertEqual(tool["trust_status"], "catalog-approved")
+        self.assertEqual(
+            tool["runtime"]["docker"],
+            "quay.io/biocontainers/macs2:2.2.9.1--py310h1fe012e_5",
+        )
+        self.assertFalse(tool["inputs"]["control_bam"]["required"])
+        self.assertIn(
+            "enriched genomic regions",
+            tool["outputs"]["narrow_peaks"]["description"],
+        )
+        self.assertEqual(
+            tool["execution_verification"],
+            {"status": "unverified", "evidence": []},
+        )
+
     def test_unknown_recipe_and_tool_raise_key_error(self):
         with self.assertRaisesRegex(KeyError, "unknown recipe"):
             get_recipe("missing_recipe")

--- a/tests/test_retrieval_evaluation.py
+++ b/tests/test_retrieval_evaluation.py
@@ -130,6 +130,8 @@ class RetrievalEvaluationTests(unittest.TestCase):
         for metric in result["metrics"].values():
             self.assertGreaterEqual(metric, 0.0)
             self.assertLessEqual(metric, 1.0)
+        self.assertEqual(result["metrics"]["planner_context_tool_recall"], 1.0)
+        self.assertEqual(result["metrics"]["planner_context_role_coverage"], 1.0)
 
     def test_computes_supported_metrics_and_tracks_unsupported_matches(self):
         queries = [


### PR DESCRIPTION
## Summary

- add compile-ready Tool Catalog entries for Bowtie2, samtools sort/index, and MACS2
- preserve explicit `unverified` execution status while pinning verified BioContainers image tags
- project Catalog output metadata into the narrower Workflow IR output contract
- document the 12-tool retrieval checkpoint and ChIP-seq capability boundary

## Scope

This PR adds tool contracts only. It does not add a formal `chipseq_peak_calling` recipe, convert ChIP-seq retrieval negatives to supported queries, or claim executable ChIP-seq workflow support.

## Testing

- `python -m unittest discover -v` (267 total: 265 passed, 2 environment-dependent execution tests skipped)
- generated ChIP-seq WDL syntax validated by WOMtool 91 through `test_chipseq_tool_contract_wdl_passes_syntax_validation`
- `python scripts/evaluate_retrieval.py` (24 queries; Planner Context Tool Recall and Role Coverage both 1.0000)
- `git diff --check`