### PR TITLE
Add Reviewer run observability

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -152,10 +152,11 @@ repairer_node       # 始终先尝试确定性修复
 模型。`repair_failure_stage` 显式区分 Analyzer 与 Checker diagnostics；缺少本地 WDL
 validator 时直接结束，不进入 deterministic 或 Reviewer repair。
 
-上述 Reviewer failure recovery 当前只描述 `compiler_graph` 的 P2.4 路由。为保留
-现有 run event 顺序，`compile_structured_workflow(..., event_callback=...)` 暂时继续使用
-deterministic-only 的服务层编译循环；Reviewer events、artifacts 与该路径的行为统一由
-P2.5 Run Service / API Observability 完成。
+`compile_structured_workflow` 的直接调用和带 `event_callback` 的 Run Service 调用均构建
+同一份 Compiler Graph；事件化路径通过 LangGraph task stream 观察节点执行，不再维护
+独立的 deterministic-only 编译循环。Run Service 可显式注入已启用的 Reviewer node，
+默认仍保持禁用，因此结构化确定性编译不依赖 API key。Reviewer 尝试通过 run events、
+named artifacts 和最终 diagnostics 暴露，且不会把 raw provider output 写入持久化记录。
 
 ## 已完成的容器管理边界
 
@@ -457,7 +458,7 @@ W4/W5 Web 界面已接入真实 run 生命周期：`/workspace?example=rnaseq-de
 }
 ```
 
-请求体 schema 错误仍返回 HTTP 422。Planner、Catalog、Analyzer 或 Checker 阶段失败时，run 本身会进入 `failed` 状态，失败信息写入持久化 diagnostics 和事件流，便于历史页回放。
+请求体 schema 错误仍返回 HTTP 422。Planner、Catalog、Analyzer、Reviewer 或 Checker 阶段失败时，run 本身会进入 `failed` 状态，失败信息写入持久化 diagnostics 和事件流，便于历史页回放。
 
 `GET /api/runs/{run_id}` 返回当前或历史快照：
 
@@ -507,7 +508,12 @@ W4/W5 Web 界面已接入真实 run 生命周期：`/workspace?example=rnaseq-de
     "validation_message": "WDL syntax validation skipped (--no-check).",
     "is_valid": false,
     "succeeded": true,
-    "check_performed": false
+    "check_performed": false,
+    "reviewer_attempt_count": 0,
+    "reviewer_repair_status": null,
+    "reviewer_rejection_reason": null,
+    "reviewer_diagnostics": [],
+    "reviewer_patch_applied": false
   }
 }
 ```
@@ -531,11 +537,19 @@ W4/W5 Web 界面已接入真实 run 生命周期：`/workspace?example=rnaseq-de
 }
 ```
 
-第一版事件类型包含：`run.created`、`node.started`、`node.completed`、`node.failed`、`artifact.updated`、`repair.applied`、`validation.completed` 和 `run.completed`。Run service 会为事件 payload 补充稳定的 observability 字段，例如 `stage`、`status`、`node`、`artifact_name`、`artifact_content_type` 和 `error_type`。这些字段用于前端时间线、失败摘要和历史回放；DAG 状态由 Workflow IR 结构与 unresolved references 派生。事件中不保存 API key、原始模型鉴权信息或其他秘密环境变量。
+事件类型包含：`run.created`、`node.started`、`node.completed`、`node.failed`、
+`artifact.updated`、`repair.proposed`、`repair.rejected`、`repair.applied`、
+`validation.completed` 和 `run.completed`。Run service 会为事件 payload 补充稳定的
+observability 字段，例如 `stage`、`status`、`node`、`artifact_name`、
+`artifact_content_type` 和 `error_type`。Reviewer 事件只保存状态、attempt count、failure
+stage、是否应用和脱敏 rejection reason；完整的脱敏 request 与 parsed patch 分别保存为
+`reviewer_repair_request` 和 `reviewer_ir_patch` named artifacts。DAG 状态由 Workflow IR
+结构与 unresolved references 派生。事件和 artifacts 中不保存 API key、raw provider
+output、原始模型鉴权信息或其他秘密环境变量。
 
 ### 持久化与部署边界
 
-- 本地展示和开发第一版使用 SQLite，保存 run、event、artifact 与 diagnostic 等必要信息，减少环境安装成本。`run_artifacts` 保留 Plan / Workflow IR / WDL 的固定兼容列；`run_artifact_records` 保存按名称索引的通用 artifact manifest 和内容，用于后续 `catalog_retrieval`、planner trace 摘要或 execution result 等新增产物，不再为每个新增 artifact 扩展固定列。
+- 本地展示和开发第一版使用 SQLite，保存 run、event、artifact 与 diagnostic 等必要信息，减少环境安装成本。`run_artifacts` 保留 Plan / Workflow IR / WDL 的固定兼容列；`run_artifact_records` 保存按名称索引的通用 artifact manifest 和内容，当前也承载 Reviewer request、parsed patch 和完整 diagnostics，后续新增产物不再扩展固定列。
 - 公开部署并需要并发或长期保存历史记录时，迁移到 PostgreSQL；持久化 schema 不应绑定到 SQLite 特有行为。
 - Agent 调用与 WDL 生成可以先作为 API 进程内任务运行；真正接入耗时 WDL 执行或容器构建后，再引入任务队列或专门 worker。
 - 前端与 API 可以独立部署，但必须基于同一公开 API contract；仓库仍保留为 monorepo，保证演示迭代效率。
@@ -779,6 +793,10 @@ Candidate ToolSpec
 - Run service 保存 run、events、artifacts、diagnostics，并支持 SSE replay。
 - Planner failure、schema failure、catalog failure、compiler failure 会进入 failed run。
 - Deterministic repairer 可处理安全的 IR 修复，例如拓扑顺序和有限 literal 问题。
+- Reviewer repair 在 deterministic repair 无安全动作后提供默认一次的有界 IR patch
+  尝试；事件化和非事件化服务路径共享同一 Compiler Graph routing。
+- Run snapshot 可回放脱敏 Reviewer request、parsed patch、接受或拒绝事件以及最终
+  Reviewer diagnostics。
 - Execution backend 抽象和 Cromwell backend contract tests 已存在，但不混入默认前端 demo 路径。
 
 | 阶段 | 建设内容 | 主要交付 |

--- a/docs/p2-reviewer-repair-plan.md
+++ b/docs/p2-reviewer-repair-plan.md
@@ -259,9 +259,8 @@ artifacts，避免前端和 API 消费方解析文本 summary。
 - 已应用 patch 重新进入 Analyzer、Renderer 和 Checker。
 - Checker 缺少本地 WOMtool/miniwdl 时直接结束，不把环境缺失当作可修复的 IR
   failure，也不调用 Reviewer。
-- P2.4 的上述行为当前只覆盖 `compiler_graph`。带 `event_callback` 的
-  `compile_structured_workflow` 服务路径仍使用 deterministic-only 编译循环；该路径的
-  Reviewer routing、events 与 artifacts 统一留到 P2.5 接入。
+- `compile_structured_workflow` 的直接调用与带 `event_callback` 的服务调用均使用同一
+  Compiler Graph routing；事件回调不再切换到独立的 deterministic-only 编译循环。
 
 ### P2.5 Run Service 与 API Observability
 
@@ -276,6 +275,25 @@ artifacts，避免前端和 API 消费方解析文本 summary。
 - Reviewer 尝试后 run snapshot 包含 Reviewer artifacts。
 - SSE/history replay 中 `workflow_ir` update 早于 `repair.applied`。
 - Reviewer 失败时，run completion 前仍写入 diagnostics。
+
+当前实现：
+
+- 事件化服务路径使用 LangGraph `tasks` stream 观察真实 Compiler Graph 节点执行，
+  直接调用与事件化调用共享 Analyzer、Checker、deterministic repairer 和 Reviewer
+  routing。
+- `reviewer_repair` 记录 `node.started`，并按结果记录 `node.completed` 或
+  `node.failed`；parsed patch 分别记录 `repair.proposed`、`repair.rejected` 或
+  `repair.applied`。
+- 脱敏后的 `reviewer_repair_request` 和 `reviewer_ir_patch` 通过通用 named artifact
+  records 持久化，不增加 Reviewer 专用数据库列；raw provider output 不进入 event、
+  artifact 或 diagnostic。
+- patch 应用后的 `workflow_ir` artifact 先于 `repair.applied` 写入，SSE 实时事件与
+  history replay 使用相同的持久化事件序列。
+- 最终 `diagnostics` artifact 保存 Reviewer attempt count、最终状态、脱敏 rejection
+  reason、diagnostics 和 patch applied 状态；snapshot 优先从该通用 artifact 恢复完整
+  Reviewer 字段，并兼容旧版固定 diagnostics 列。
+- Run Service 支持显式注入已启用的 Reviewer node；默认未注入时仍使用禁用节点，
+  不会让结构化编译自动依赖 API key。
 
 ### P2.6 文档与验收
 
@@ -317,17 +335,17 @@ Windows PowerShell：
 
 ## 验收清单
 
-- [ ] Deterministic repairer 仍然是第一层修复机制。
-- [ ] Reviewer 只在 Analyzer 或 Checker 失败，且没有安全 deterministic repair 时触发。
-- [ ] Reviewer 输出先经过 schema validation，再经过 patch policy validation。
-- [ ] Patch policy 会拒绝 WDL、Catalog、runtime image、command 和 resource sizing
+- [x] Deterministic repairer 仍然是第一层修复机制。
+- [x] Reviewer 只在 Analyzer 或 Checker 失败，且没有安全 deterministic repair 时触发。
+- [x] Reviewer 输出先经过 schema validation，再经过 patch policy validation。
+- [x] Patch policy 会拒绝 WDL、Catalog、runtime image、command 和 resource sizing
   修改。
-- [ ] 已接受 patch 只应用到 Workflow IR，并重新进入 Analyzer、Renderer 和 Checker。
-- [ ] 修复次数有硬上限，不能无限循环。
-- [ ] 未配置 Reviewer 时，结构化编译路径仍可在没有 API key 的情况下运行。
-- [ ] Run history 通过 named artifacts 和 events 暴露 Reviewer 尝试。
-- [ ] 最终 diagnostics 能说明成功、拒绝、次数耗尽或 model error。
-- [ ] 测试覆盖成功、拒绝、no-op、次数耗尽和 Reviewer 不可用路径。
+- [x] 已接受 patch 只应用到 Workflow IR，并重新进入 Analyzer、Renderer 和 Checker。
+- [x] 修复次数有硬上限，不能无限循环。
+- [x] 未配置 Reviewer 时，结构化编译路径仍可在没有 API key 的情况下运行。
+- [x] Run history 通过 named artifacts 和 events 暴露 Reviewer 尝试。
+- [x] 最终 diagnostics 能说明成功、拒绝、次数耗尽或 model error。
+- [x] 测试覆盖成功、拒绝、no-op、次数耗尽和 Reviewer 不可用路径。
 
 ## 已确认的 P2.1 决策
 

--- a/docs/test-cases.md
+++ b/docs/test-cases.md
@@ -197,6 +197,7 @@ OK (skipped=2)
 - diagnostics 中 `succeeded == True`。
 - diagnostics 中 `check_performed == False`。
 - analysis errors 为空。
+- Reviewer attempt count 为零，其余 Reviewer diagnostics 使用空值或空列表默认值。
 - artifacts 中 workflow 名称为 `RNASeqDEG`。
 - artifacts 中 WDL 包含 `workflow RNASeqDEG`。
 
@@ -338,6 +339,18 @@ OK (skipped=2)
 
 - Catalog service 的 tool records 与 API DTO 兼容。
 - Tool runtime、Catalog admission 与 execution verification 可以分别暴露给前端。
+
+### `test_run_event_types_include_reviewer_repair_lifecycle`
+
+期望输出：
+
+- `RunEventType.REPAIR_PROPOSED == "repair.proposed"`。
+- `RunEventType.REPAIR_REJECTED == "repair.rejected"`。
+
+覆盖点：
+
+- API event enum 显式包含 Reviewer patch 提议与拒绝生命周期，SSE 和 history replay
+  不需要复用含义不清的通用事件。
 
 ### `test_run_event_defines_persistable_event_envelope`
 
@@ -700,7 +713,8 @@ OK (skipped=2)
 - 一个 structured compile run。
 - 两个 run events：`run.created` 与 `node.started`。
 - `WorkflowArtifacts`，包含 plan、Workflow IR 和 WDL。
-- `DiagnosticReport`，表示跳过 WDL syntax validation 且 run 成功。
+- `DiagnosticReport`，表示跳过 WDL syntax validation、Reviewer 已应用一次 patch 且
+  run 成功。
 
 执行：
 
@@ -713,11 +727,15 @@ OK (skipped=2)
 - snapshot artifacts 保留 Workflow IR、WDL 和 manifest。
 - manifest 中包含 `plan`、`workflow_ir`、`wdl` 和 `diagnostics`。
 - named artifact records 中 `wdl` content type 为 `text/plain`，其余核心 JSON artifact 为 `application/json`。
+- snapshot 从 `diagnostics` named artifact 恢复 Reviewer attempt count、最终状态、
+  Reviewer diagnostics 和 patch applied 状态。
 
 覆盖点：
 
 - 固定 artifact 列与通用 `run_artifact_records` manifest 会同步写入。
 - diagnostics 既保留在专用 diagnostic 表中，也作为命名 artifact 进入 manifest，方便后续统一 artifact 展示。
+- 新增 Reviewer diagnostics 字段不要求扩展旧版固定 diagnostics 表；snapshot 优先读取
+  通用 diagnostics artifact，同时保留旧数据库 fallback。
 
 ### `test_list_runs_returns_paginated_summaries_with_status_filter`
 
@@ -907,6 +925,72 @@ OK (skipped=2)
 - 修复发生时，历史事件先通知 Workflow IR artifact 更新，再记录 repair action。
 - 前端和 SSE 消费方不需要根据 summary 文案推断 repair 后的 artifact 类型。
 
+### `test_structured_compile_run_persists_reviewer_events_and_artifacts`
+
+输入：
+
+- Analyzer 无法解析 `missing_input` 的 Workflow IR。
+- 注入启用的 Reviewer node 和返回合法 wiring patch 的 fake provider。
+- `check=False`。
+
+期望输出：
+
+- run 成功，diagnostics 记录一次 Reviewer 尝试、`patch_proposed` 和
+  `reviewer_patch_applied == true`。
+- snapshot extras/manifest 包含脱敏 `reviewer_repair_request` 与 parsed
+  `reviewer_ir_patch`。
+- Reviewer 事件依次包含 started、request artifact、patch artifact、proposed、
+  workflow_ir artifact、applied 和 completed。
+- `workflow_ir` 更新早于 `repair.applied`，diagnostics 更新早于 `run.completed`。
+- SSE replay 包含 `repair.proposed` 和 `repair.applied`。
+
+覆盖点：
+
+- P2.5 成功路径的实时事件、历史回放、named artifacts 和最终 diagnostics 使用同一
+  持久化 run 记录。
+- Reviewer patch 只修改 Workflow IR candidate，随后仍由真实 Compiler Graph 完成
+  Analyzer 与 Renderer 路径。
+
+### `test_structured_compile_run_persists_reviewer_failure_diagnostics`
+
+输入：
+
+- Analyzer failure Workflow IR。
+- fake Reviewer provider 抛出带敏感原始消息的 `ReviewerProviderError`。
+
+期望输出：
+
+- run 以 `failed` 完成，diagnostics 记录一次尝试、`model_error` 和未应用 patch。
+- snapshot 保存脱敏 request，不保存 patch，也不包含 provider 原始敏感消息。
+- Reviewer 事件依次为 started、request artifact、node failed。
+- 未生成 WDL，因此不会追加 `validation.completed` 跳过校验事件。
+- Reviewer failure 后仍先写 diagnostics artifact，再写 `run.completed`。
+
+覆盖点：
+
+- Provider 失败不会丢失 Reviewer 可观测信息，也不会泄漏 raw provider output。
+- 失败结果作为正常 Compiler Graph diagnostic 结束，不被 Run Service 误记为缺少上下文
+  的 generic compiler exception。
+
+### `test_structured_compile_run_persists_reviewer_rejection`
+
+输入：
+
+- fake Reviewer provider 提议修改被 policy 禁止的 runtime Docker image。
+
+期望输出：
+
+- run 失败，diagnostics 状态为 `policy_rejected` 并保存脱敏 rejection reason。
+- snapshot 同时保留 Reviewer request 和被拒绝的 parsed patch artifacts。
+- history 依次记录 `repair.proposed`、`repair.rejected`，对应 payload status 分别为
+  `proposed` 和 `rejected`。
+- diagnostics artifact 仍在 `run.completed` 前写入。
+
+覆盖点：
+
+- P2.5 policy rejection 可通过 SSE/history 审计，但不会产生 `repair.applied` 或改变
+  Workflow IR。
+
 ### `test_natural_language_run_succeeds_after_planning`
 
 输入：
@@ -923,7 +1007,8 @@ OK (skipped=2)
 期望输出：
 
 - `plan_and_compile_workflow` 被调用一次。
-- 调用参数包含自然语言 request、`check=False` 和 `event_callback`。
+- 调用参数包含自然语言 request、`check=False`、`event_callback` 和当前
+  `reviewer_node` 配置。
 - snapshot `status == "succeeded"`。
 - snapshot artifacts 包含 catalog retrieval、Recipe Tool Plan 和 WDL。
 
@@ -3940,13 +4025,13 @@ Agent 占位逻辑。
 - 结构化 Workflow IR 入口不会触发自然语言 planner。
 - service 能区分 Recipe Tool Plan 与标准 Workflow IR。
 
-### `test_compile_structured_workflow_without_check_does_not_invoke_graph`
+### `test_compile_structured_workflow_without_check_uses_unchecked_graph`
 
 输入：
 
 - `examples/rnaseq_deg_recipe_plan.json`
 - `check=False`
-- mock `src.services.workflow_service.compiler_graph.invoke`，如果被调用则抛出错误。
+- spy `build_compiler_graph(...)`。
 
 执行：
 
@@ -3956,12 +4041,12 @@ Agent 占位逻辑。
 
 - `result.succeeded == True`。
 - `result.check_performed == False`。
-- compiled graph 的 `compiler_graph.invoke` 未被调用。
+- graph builder 以 `reviewer_node=None, check=False` 调用一次。
 
 覆盖点：
 
-- `check=False` 路径走手动 deterministic compiler nodes。
-- 跳过 checker 时不会进入包含 checker 的 compiled graph。
+- `check=False` 仍使用与事件化路径一致的 Compiler Graph routing。
+- graph 在 Renderer 后直接结束，因此跳过 Checker 的同时不会维护第二份手工编译循环。
 
 ### `test_compile_structured_workflow_returns_diagnostics_for_invalid_plan`
 
@@ -4008,6 +4093,74 @@ Agent 占位逻辑。
 
 - workflow service 保留 deterministic repairer 的显式失败状态。
 - repairer 异常不会被错误记录为“正常完成但无安全修复动作”。
+
+### `test_evented_reviewer_patch_emits_artifacts_before_repair_events`
+
+输入：
+
+- Analyzer failure Workflow IR。
+- fake Reviewer provider 返回合法 call-input wiring patch。
+- `check=False` 与 event callback。
+
+期望输出：
+
+- 编译成功，Reviewer attempt count 为一，状态为 `patch_proposed`，patch 已应用。
+- Reviewer 事件依次为 started、request artifact、patch artifact、proposed、Workflow IR
+  artifact、applied、completed。
+- patch 后的 Workflow IR artifact 在 `repair.applied` 前可见。
+
+覆盖点：
+
+- event callback 观察真实 Compiler Graph Reviewer branch，不再旁路到
+  deterministic-only 服务循环。
+- 结构化 request/patch 通过 artifact 传递，事件 payload 只保留稳定摘要。
+
+### `test_evented_and_non_evented_reviewer_results_match`
+
+执行：
+
+- 使用相同输入和等价 fake Reviewer provider，分别调用直接编译和事件化编译。
+
+期望输出：
+
+- 两个 `WorkflowCompilationResult.to_dict()` 完全一致。
+- 两条路径各调用 Reviewer provider 一次。
+
+覆盖点：
+
+- 可观测性适配器不改变 Compiler Graph 的状态转移或最终编译结果。
+
+### `test_evented_reviewer_policy_rejection_emits_proposed_and_rejected`
+
+输入：
+
+- fake Reviewer provider 提议修改 `/tasks/fastp/runtime/docker`。
+
+期望输出：
+
+- 编译失败，最终 Reviewer 状态为 `policy_rejected`，Workflow IR 未应用 patch。
+- Reviewer 事件包含 request/patch artifacts、`repair.proposed`、`repair.rejected` 和
+  completed，不包含 `repair.applied`。
+
+覆盖点：
+
+- 被 policy 拒绝的 parsed patch 仍可审计，但不会改变 Compiler state。
+
+### `test_evented_reviewer_model_error_emits_request_then_failure`
+
+输入：
+
+- fake Reviewer provider 抛出带敏感消息的 typed provider error。
+
+期望输出：
+
+- Reviewer 最终状态为 `model_error`，attempt count 为一。
+- 事件先保存 request artifact，再记录 Reviewer `node.failed`。
+- service result 不包含 provider 原始敏感消息。
+
+覆盖点：
+
+- Reviewer provider failure 具有脱敏、可持久化的失败事件语义。
 
 ### `test_plan_and_compile_workflow_plans_then_compiles`
 
@@ -4105,11 +4258,12 @@ Agent 占位逻辑。
 - dict 中 `wdl` 包含 `workflow RNASeqDEG`。
 - dict 中 `analysis_errors == []`。
 - dict 中 `succeeded == True`。
+- dict 中包含 Reviewer attempt、status、rejection reason、diagnostics 和 applied 字段。
 
 覆盖点：
 
 - `WorkflowCompilationResult` 可以转换为 API 友好的 dict。
-- API 层后续可以稳定读取 plan、IR、WDL、diagnostics 和状态字段。
+- API 层可以稳定读取 plan、IR、WDL、Reviewer diagnostics 和状态字段。
 
 ## `tests/test_nl_planner.py`
 
@@ -5119,6 +5273,9 @@ retrieval artifact。
 - Renderer 对 call、scatter、array flatten、workflow output 和 task 的 WDL 渲染。
 - Deterministic repairer 对 call 顺序和 output 字面量的安全修复。
 - Reviewer repair request / patch / result 契约模型与 P2 patch policy skeleton。
+- Reviewer Compiler Graph routing 在直接与事件化 service 路径中的结果一致性。
+- Reviewer 成功、policy 拒绝和 provider 失败的 run events、named artifacts、SSE replay
+  与最终 diagnostics 持久化。
 - Workflow service 对结构化编译入口、自然语言规划后编译入口和 API 友好结果对象的封装。
 - FastAPI DTO 对 workflow、catalog 和 event envelope 的输入输出契约。
 - FastAPI endpoints 对 W0 workflow/catalog services 的复用、HTTP 状态映射和响应序列化。
@@ -5134,8 +5291,7 @@ retrieval artifact。
 - 多 recipe、多工具候选和更复杂 tool selection。
 - 参数范围错误以外的更多 Tool Catalog schema 边界。
 - nested scatter、conditional step、subworkflow 等 roadmap feature。
-- Reviewer 在线 provider 集成、Run observability、Resource Agent 和 Bioinfo
-  Reviewer 等规划中 Agent。
+- Reviewer 在线 provider 集成、Resource Agent 和 Bioinfo Reviewer 等规划中 Agent。
 - Nextflow 或其他 backend。
 - 真实自然语言模型调用的在线集成测试。
 - Next.js 工作台、DAG 可视化和 run history 的浏览器级视觉回归测试。

--- a/src/api/models/events.py
+++ b/src/api/models/events.py
@@ -15,6 +15,8 @@ class RunEventType(StrEnum):
     NODE_COMPLETED = "node.completed"
     NODE_FAILED = "node.failed"
     ARTIFACT_UPDATED = "artifact.updated"
+    REPAIR_PROPOSED = "repair.proposed"
+    REPAIR_REJECTED = "repair.rejected"
     REPAIR_APPLIED = "repair.applied"
     VALIDATION_COMPLETED = "validation.completed"
     RUN_COMPLETED = "run.completed"

--- a/src/api/models/workflows.py
+++ b/src/api/models/workflows.py
@@ -92,7 +92,7 @@ class WorkflowArtifacts(BaseModel):
 
 
 class DiagnosticReport(BaseModel):
-    """Analyzer, repairer, and checker diagnostics for one compile/run result."""
+    """Analyzer, repairer, Reviewer, and checker diagnostics for one run."""
 
     model_config = ConfigDict(extra="forbid")
 
@@ -103,6 +103,11 @@ class DiagnosticReport(BaseModel):
     is_valid: bool = False
     succeeded: bool = False
     check_performed: bool = True
+    reviewer_attempt_count: int = Field(default=0, ge=0)
+    reviewer_repair_status: str | None = None
+    reviewer_rejection_reason: str | None = None
+    reviewer_diagnostics: list[str] = Field(default_factory=list)
+    reviewer_patch_applied: bool = False
 
 
 class RunDiagnosticSummary(BaseModel):
@@ -173,6 +178,11 @@ class CompilationResultResponse(BaseModel):
                 is_valid=result.is_valid,
                 succeeded=result.succeeded,
                 check_performed=result.check_performed,
+                reviewer_attempt_count=result.reviewer_attempt_count,
+                reviewer_repair_status=result.reviewer_repair_status,
+                reviewer_rejection_reason=result.reviewer_rejection_reason,
+                reviewer_diagnostics=result.reviewer_diagnostics,
+                reviewer_patch_applied=result.reviewer_patch_applied,
             ),
             planner_prompt=result.planner_prompt,
             planner_raw_response=result.planner_raw_response,

--- a/src/graph.py
+++ b/src/graph.py
@@ -74,8 +74,12 @@ def _missing_local_validator(state: WorkflowState) -> bool:
     return VALIDATOR_MISSING_MARKER in state.get("validation_message", "")
 
 
-def build_compiler_graph(*, reviewer_node: ReviewerNode | None = None):
-    """Build the compiler graph with an explicitly injected Reviewer node."""
+def build_compiler_graph(
+    *,
+    reviewer_node: ReviewerNode | None = None,
+    check: bool = True,
+):
+    """Build the compiler graph with explicit Reviewer and Checker behavior."""
     resolved_reviewer_node = (
         reviewer_node
         if reviewer_node is not None
@@ -92,7 +96,7 @@ def build_compiler_graph(*, reviewer_node: ReviewerNode | None = None):
     builder.add_edge(START, "ir_normalizer")
     builder.add_conditional_edges("ir_normalizer", route_after_ir_normalizer)
     builder.add_conditional_edges("analyzer", route_after_analyzer)
-    builder.add_edge("renderer", "checker")
+    builder.add_edge("renderer", "checker" if check else END)
     builder.add_conditional_edges("checker", route_after_checker)
     builder.add_conditional_edges("repairer", route_after_repairer)
     builder.add_conditional_edges("reviewer_repair", route_after_reviewer)

--- a/src/services/run_repository.py
+++ b/src/services/run_repository.py
@@ -551,7 +551,11 @@ class RunRepository:
         return RunSnapshotRecord(
             run=run,
             artifacts=_row_to_artifacts(artifact_row, artifact_records),
-            diagnostics=_row_to_diagnostics(diagnostic_row, check_performed=run.check_performed),
+            diagnostics=_row_to_diagnostics(
+                diagnostic_row,
+                artifact_records,
+                check_performed=run.check_performed,
+            ),
         )
 
     def ensure_schema(self) -> None:
@@ -1027,7 +1031,18 @@ def _artifact_record_content_or_legacy(
     return legacy_content
 
 
-def _row_to_diagnostics(row: sqlite3.Row | None, *, check_performed: bool) -> DiagnosticReport:
+def _row_to_diagnostics(
+    row: sqlite3.Row | None,
+    artifact_records: list[RunArtifactRecord],
+    *,
+    check_performed: bool,
+) -> DiagnosticReport:
+    diagnostics_artifact = next(
+        (record for record in artifact_records if record.name == "diagnostics"),
+        None,
+    )
+    if diagnostics_artifact is not None and isinstance(diagnostics_artifact.content, dict):
+        return DiagnosticReport.model_validate(diagnostics_artifact.content)
     if row is None:
         return DiagnosticReport(check_performed=check_performed)
     return DiagnosticReport(

--- a/src/services/run_service.py
+++ b/src/services/run_service.py
@@ -23,6 +23,7 @@ from src.api.models import (
     WorkflowRunSnapshotResponse,
 )
 from src.nl_planner import DEFAULT_PLANNER_MODEL, NaturalLanguagePlanningError
+from src.nodes.reviewer_repair import ReviewerNode
 from src.services import workflow_service
 from src.services.run_repository import JSON_CONTENT_TYPE, TEXT_CONTENT_TYPE
 from src.services.run_repository import RunRepository
@@ -35,17 +36,38 @@ DEFAULT_SSE_POLL_INTERVAL_SECONDS = 0.25
 REQUEST_SUMMARY_MAX_LENGTH = 160
 PLANNING_NODES = {"catalog_retriever", "planner"}
 ORCHESTRATION_NODES = {"compiler_graph"}
-COMPILER_NODES = {"compiler", "ir_normalizer", "analyzer", "repairer", "renderer", "checker"}
+COMPILER_NODES = {
+    "compiler",
+    "ir_normalizer",
+    "analyzer",
+    "repairer",
+    "reviewer_repair",
+    "renderer",
+    "checker",
+}
 DIAGNOSTIC_NODES = {"diagnostics"}
-JSON_ARTIFACTS = {"catalog_retrieval", "diagnostics", "plan", "workflow_ir"}
+JSON_ARTIFACTS = {
+    "catalog_retrieval",
+    "diagnostics",
+    "plan",
+    "reviewer_ir_patch",
+    "reviewer_repair_request",
+    "workflow_ir",
+}
 TEXT_ARTIFACTS = {"wdl"}
 
 
 class RunService:
     """Create, execute, and read persistent workflow runs."""
 
-    def __init__(self, repository: RunRepository | None = None):
+    def __init__(
+        self,
+        repository: RunRepository | None = None,
+        *,
+        reviewer_node: ReviewerNode | None = None,
+    ):
         self.repository = repository or RunRepository()
+        self.reviewer_node = reviewer_node
 
     def create_natural_language_run(self, request: NaturalLanguageRunRequest) -> RunAcceptedResponse:
         run_id = _new_run_id()
@@ -102,6 +124,7 @@ class RunService:
                 model=planner_model,
                 check=request.check,
                 event_callback=self._workflow_event_callback(run_id),
+                reviewer_node=self.reviewer_node,
             )
         except NaturalLanguagePlanningError as exc:
             self._append_failed_event_if_missing(
@@ -131,6 +154,7 @@ class RunService:
                 request.payload,
                 check=request.check,
                 event_callback=self._workflow_event_callback(run_id),
+                reviewer_node=self.reviewer_node,
             )
         except Exception as exc:
             self._append_compiler_failed_event(run_id, exc)
@@ -256,6 +280,11 @@ class RunService:
             is_valid=result.is_valid,
             succeeded=result.succeeded,
             check_performed=result.check_performed,
+            reviewer_attempt_count=result.reviewer_attempt_count,
+            reviewer_repair_status=result.reviewer_repair_status,
+            reviewer_rejection_reason=result.reviewer_rejection_reason,
+            reviewer_diagnostics=result.reviewer_diagnostics,
+            reviewer_patch_applied=result.reviewer_patch_applied,
         )
         self.repository.save_diagnostics(run_id, diagnostics)
         final_status = RunStatus.SUCCEEDED if result.succeeded else RunStatus.FAILED
@@ -321,6 +350,9 @@ class RunService:
                     "check_performed": diagnostics.check_performed,
                     "is_valid": diagnostics.is_valid,
                     "succeeded": diagnostics.succeeded,
+                    "reviewer_attempt_count": diagnostics.reviewer_attempt_count,
+                    "reviewer_repair_status": diagnostics.reviewer_repair_status,
+                    "reviewer_patch_applied": diagnostics.reviewer_patch_applied,
                 },
             ),
         )
@@ -500,6 +532,8 @@ def _event_status(event_type: str, payload: dict) -> str:
         RunEventType.NODE_COMPLETED.value: "completed",
         RunEventType.NODE_FAILED.value: RunStatus.FAILED.value,
         RunEventType.ARTIFACT_UPDATED.value: "updated",
+        RunEventType.REPAIR_PROPOSED.value: "proposed",
+        RunEventType.REPAIR_REJECTED.value: "rejected",
         RunEventType.REPAIR_APPLIED.value: "applied",
         RunEventType.VALIDATION_COMPLETED.value: "completed",
         RunEventType.RUN_COMPLETED.value: "completed",

--- a/src/services/workflow_service.py
+++ b/src/services/workflow_service.py
@@ -1,11 +1,10 @@
 """Workflow planning and compilation service entry points."""
 
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, field, replace
 from typing import Any, Callable, Mapping, cast
 
 from src.catalog.loader import ToolCatalog
-from src.graph import MAX_REPAIR_ATTEMPTS, compiler_graph
-from src.nodes.checker import checker_node
+from src.graph import build_compiler_graph
 from src.nl_planner import (
     DEFAULT_PLANNER_MODEL,
     NaturalLanguagePlanningError,
@@ -14,17 +13,14 @@ from src.nl_planner import (
     PlannerLlm,
     PlannerSchemaError,
 )
-from src.nodes.analyzer import analyzer_node
-from src.nodes.ir_normalizer import ir_normalizer_node
-from src.nodes.renderer import renderer_node
-from src.nodes.repairer import repairer_node
+from src.nodes.reviewer_repair import ReviewerNode
 from src.orchestration.graph import build_orchestration_graph
 from src.orchestration.nodes.compiler import make_compile_planned_workflow_node
 from src.orchestration.nodes.planner import make_natural_language_planner_node
 from src.orchestration.state import OrchestrationState, build_initial_orchestration_state
 from src.recipes.loader import RecipeCatalog
+from src.reviewer_repair import ReviewerRepairStatus
 from src.state import WorkflowState
-from src.tools.validator import VALIDATOR_MISSING_MARKER
 
 
 WorkflowEventState = Mapping[str, Any] | None
@@ -50,6 +46,11 @@ class WorkflowCompilationResult:
     succeeded: bool
     check_performed: bool
     state: WorkflowState
+    reviewer_attempt_count: int = 0
+    reviewer_repair_status: str | None = None
+    reviewer_rejection_reason: str | None = None
+    reviewer_diagnostics: list[str] = field(default_factory=list)
+    reviewer_patch_applied: bool = False
     catalog_retrieval: dict[str, Any] | None = None
     planner_prompt: str | None = None
     planner_raw_response: str | None = None
@@ -67,6 +68,11 @@ class WorkflowCompilationResult:
             "is_valid": self.is_valid,
             "succeeded": self.succeeded,
             "check_performed": self.check_performed,
+            "reviewer_attempt_count": self.reviewer_attempt_count,
+            "reviewer_repair_status": self.reviewer_repair_status,
+            "reviewer_rejection_reason": self.reviewer_rejection_reason,
+            "reviewer_diagnostics": self.reviewer_diagnostics,
+            "reviewer_patch_applied": self.reviewer_patch_applied,
             "planner_prompt": self.planner_prompt,
             "planner_raw_response": self.planner_raw_response,
         }
@@ -76,9 +82,16 @@ def compile_structured_workflow(
     parsed_json: dict[str, Any],
     check: bool = True,
     event_callback: CompilerEventCallback | None = None,
+    *,
+    reviewer_node: ReviewerNode | None = None,
 ) -> WorkflowCompilationResult:
     """Compile a Recipe Tool Plan or Workflow IR without natural-language planning."""
-    state = _run_compiler(parsed_json, check=check, event_callback=event_callback)
+    state = _run_compiler(
+        parsed_json,
+        check=check,
+        event_callback=event_callback,
+        reviewer_node=reviewer_node,
+    )
     plan = parsed_json if _is_recipe_tool_plan(parsed_json) else None
     return _result_from_state(state, plan=plan, check=check)
 
@@ -92,6 +105,7 @@ def plan_and_compile_workflow(
     tool_catalog: ToolCatalog | None = None,
     recipe_catalog: RecipeCatalog | None = None,
     event_callback: WorkflowEventCallback | None = None,
+    reviewer_node: ReviewerNode | None = None,
 ) -> WorkflowCompilationResult:
     """Plan from natural language through the orchestration graph, then compile."""
     planner_node = make_natural_language_planner_node(
@@ -101,7 +115,7 @@ def plan_and_compile_workflow(
         event_callback=event_callback,
     )
     compiler_node = make_compile_planned_workflow_node(
-        compiler=_compiler_with_callback(event_callback),
+        compiler=_compiler_with_callback(event_callback, reviewer_node),
         event_callback=event_callback,
     )
     graph = build_orchestration_graph(planner_node=planner_node, compiler_node=compiler_node)
@@ -132,8 +146,9 @@ def plan_and_compile_workflow(
 
 def _compiler_with_callback(
     event_callback: WorkflowEventCallback | None,
+    reviewer_node: ReviewerNode | None,
 ) -> Callable[[dict[str, Any], bool], WorkflowCompilationResult] | None:
-    if event_callback is None:
+    if event_callback is None and reviewer_node is None:
         return None
 
     def compile_with_events(parsed_json: dict[str, Any], check: bool) -> WorkflowCompilationResult:
@@ -141,6 +156,7 @@ def _compiler_with_callback(
             parsed_json,
             check=check,
             event_callback=event_callback,
+            reviewer_node=reviewer_node,
         )
 
     return compile_with_events
@@ -184,63 +200,406 @@ def _run_compiler(
     parsed_json: dict[str, Any],
     check: bool = True,
     event_callback: CompilerEventCallback | None = None,
+    reviewer_node: ReviewerNode | None = None,
 ) -> WorkflowState:
     state = build_initial_state(parsed_json)
-    if check and event_callback is None:
-        return cast(WorkflowState, compiler_graph.invoke(state))
+    graph = build_compiler_graph(reviewer_node=reviewer_node, check=check)
+    if event_callback is None:
+        state = cast(WorkflowState, graph.invoke(state))
+    else:
+        _run_compiler_graph_with_events(
+            graph,
+            state,
+            check=check,
+            event_callback=event_callback,
+        )
 
-    _emit_compiler_event(event_callback, "node.started", "ir_normalizer", "IR normalizer started.", state)
-    _merge_state(state, ir_normalizer_node(state))
-    if state["analysis_errors"]:
+    if not check and state["current_wdl"]:
+        state["validation_message"] = "WDL syntax validation skipped (--no-check)."
+        _emit_compiler_event(
+            event_callback,
+            "validation.completed",
+            "checker",
+            state["validation_message"],
+            state,
+            {"is_valid": state["is_valid"], "check_performed": False},
+        )
+    return state
+
+
+def _run_compiler_graph_with_events(
+    graph: Any,
+    state: WorkflowState,
+    *,
+    check: bool,
+    event_callback: CompilerEventCallback,
+) -> None:
+    active_tasks: dict[str, tuple[str, int]] = {}
+    try:
+        for task in graph.stream(state, stream_mode="tasks"):
+            if not isinstance(task, Mapping):
+                continue
+            task_id = str(task.get("id") or task.get("name") or "compiler-node")
+            node = task.get("name")
+            if not isinstance(node, str):
+                continue
+
+            if "input" in task:
+                active_tasks[task_id] = (
+                    node,
+                    state.get("reviewer_attempt_count", 0),
+                )
+                _emit_compiler_event(
+                    event_callback,
+                    "node.started",
+                    node,
+                    _node_started_summary(node),
+                    state,
+                )
+                continue
+
+            active_node, previous_reviewer_attempt_count = active_tasks.pop(
+                task_id,
+                (node, state.get("reviewer_attempt_count", 0)),
+            )
+            error = task.get("error")
+            if error is not None:
+                _emit_compiler_event(
+                    event_callback,
+                    "node.failed",
+                    active_node,
+                    f"{_node_label(active_node)} failed.",
+                    state,
+                    _task_error_payload(error),
+                )
+                if isinstance(error, BaseException):
+                    raise error
+                raise RuntimeError(f"{_node_label(active_node)} failed: {error}")
+
+            update = task.get("result")
+            if isinstance(update, Mapping):
+                _merge_state(state, update)
+            _emit_node_result_events(
+                event_callback,
+                active_node,
+                state,
+                check=check,
+                previous_reviewer_attempt_count=previous_reviewer_attempt_count,
+            )
+    except Exception as exc:
+        if active_tasks:
+            active_node, _ = list(active_tasks.values())[-1]
+            _emit_compiler_event(
+                event_callback,
+                "node.failed",
+                active_node,
+                f"{_node_label(active_node)} failed.",
+                state,
+                _task_error_payload(exc),
+            )
+        raise
+
+
+def _emit_node_result_events(
+    event_callback: CompilerEventCallback,
+    node: str,
+    state: WorkflowState,
+    *,
+    check: bool,
+    previous_reviewer_attempt_count: int,
+) -> None:
+    if node == "ir_normalizer":
+        if state["analysis_errors"]:
+            _emit_compiler_event(
+                event_callback,
+                "node.failed",
+                node,
+                "IR normalizer failed.",
+                state,
+                {"analysis_errors": state["analysis_errors"]},
+            )
+            return
+        _emit_compiler_event(
+            event_callback,
+            "node.completed",
+            node,
+            "IR normalizer completed.",
+            state,
+        )
+        _emit_artifact_updated(
+            event_callback,
+            node,
+            "Workflow IR artifact updated.",
+            state,
+            "workflow_ir",
+        )
+        return
+
+    if node == "analyzer":
+        if state["analysis_errors"]:
+            _emit_compiler_event(
+                event_callback,
+                "node.failed",
+                node,
+                "Analyzer found Workflow IR errors.",
+                state,
+                {"analysis_errors": state["analysis_errors"]},
+            )
+            return
+        _emit_compiler_event(
+            event_callback,
+            "node.completed",
+            node,
+            "Analyzer completed.",
+            state,
+        )
+        return
+
+    if node == "renderer":
+        _emit_compiler_event(
+            event_callback,
+            "node.completed",
+            node,
+            "Renderer completed.",
+            state,
+        )
+        _emit_artifact_updated(
+            event_callback,
+            node,
+            "WDL artifact updated.",
+            state,
+            "wdl",
+        )
+        return
+
+    if node == "checker":
+        _emit_compiler_event(
+            event_callback,
+            "validation.completed",
+            node,
+            "WDL validation completed.",
+            state,
+            {
+                "is_valid": state["is_valid"],
+                "validation_message": state["validation_message"],
+                "check_performed": check,
+            },
+        )
+        return
+
+    if node == "repairer":
+        if state["repairer_failed"]:
+            _emit_compiler_event(
+                event_callback,
+                "node.failed",
+                node,
+                "Repairer failed.",
+                state,
+                {"repairer_failed": True},
+            )
+            return
+        if state["repair_actions"]:
+            _emit_workflow_ir_artifact_updated(event_callback, state, node=node)
+            _emit_compiler_event(
+                event_callback,
+                "repair.applied",
+                node,
+                "Workflow IR repair applied.",
+                state,
+                {"repair_actions": state["repair_actions"]},
+            )
+            summary = "Repairer completed."
+        else:
+            summary = "Repairer found no safe deterministic fix."
+        _emit_compiler_event(
+            event_callback,
+            "node.completed",
+            node,
+            summary,
+            state,
+        )
+        return
+
+    if node == "reviewer_repair":
+        _emit_reviewer_result_events(
+            event_callback,
+            state,
+            previous_attempt_count=previous_reviewer_attempt_count,
+        )
+
+
+def _emit_reviewer_result_events(
+    event_callback: CompilerEventCallback,
+    state: WorkflowState,
+    *,
+    previous_attempt_count: int,
+) -> None:
+    status = state.get("reviewer_repair_status")
+    current_attempt_count = state.get("reviewer_attempt_count", 0)
+    attempted = current_attempt_count > previous_attempt_count
+    payload = _reviewer_event_payload(state)
+
+    if attempted and state.get("reviewer_repair_request") is not None:
+        _emit_artifact_updated(
+            event_callback,
+            "reviewer_repair",
+            "Reviewer repair request artifact updated.",
+            state,
+            "reviewer_repair_request",
+        )
+
+    current_patch = (
+        attempted
+        and state.get("reviewer_ir_patch") is not None
+        and status
+        in {
+            ReviewerRepairStatus.PATCH_PROPOSED.value,
+            ReviewerRepairStatus.POLICY_REJECTED.value,
+            ReviewerRepairStatus.INVALID_REQUEST.value,
+        }
+    )
+    if current_patch:
+        _emit_artifact_updated(
+            event_callback,
+            "reviewer_repair",
+            "Reviewer IR patch artifact updated.",
+            state,
+            "reviewer_ir_patch",
+        )
+        _emit_compiler_event(
+            event_callback,
+            "repair.proposed",
+            "reviewer_repair",
+            "Reviewer proposed a Workflow IR patch.",
+            state,
+            {
+                **payload,
+                "action_count": len(
+                    (state.get("reviewer_ir_patch") or {}).get("actions", [])
+                ),
+            },
+        )
+
+    if state.get("reviewer_patch_applied"):
+        _emit_workflow_ir_artifact_updated(
+            event_callback,
+            state,
+            node="reviewer_repair",
+        )
+        _emit_compiler_event(
+            event_callback,
+            "repair.applied",
+            "reviewer_repair",
+            "Reviewer patch applied to Workflow IR candidate.",
+            state,
+            payload,
+        )
+        _emit_compiler_event(
+            event_callback,
+            "node.completed",
+            "reviewer_repair",
+            "Reviewer repair completed.",
+            state,
+            payload,
+        )
+        return
+
+    if current_patch and status in {
+        ReviewerRepairStatus.POLICY_REJECTED.value,
+        ReviewerRepairStatus.INVALID_REQUEST.value,
+    }:
+        _emit_compiler_event(
+            event_callback,
+            "repair.rejected",
+            "reviewer_repair",
+            "Reviewer patch was rejected.",
+            state,
+            payload,
+        )
+        _emit_compiler_event(
+            event_callback,
+            "node.completed",
+            "reviewer_repair",
+            "Reviewer repair completed with a rejected patch.",
+            state,
+            payload,
+        )
+        return
+
+    if status in {
+        ReviewerRepairStatus.INVALID_REQUEST.value,
+        ReviewerRepairStatus.MODEL_ERROR.value,
+    }:
         _emit_compiler_event(
             event_callback,
             "node.failed",
-            "ir_normalizer",
-            "IR normalizer failed.",
+            "reviewer_repair",
+            "Reviewer repair failed.",
             state,
-            {"analysis_errors": state["analysis_errors"]},
+            payload,
         )
-        return state
-    _emit_compiler_event(event_callback, "node.completed", "ir_normalizer", "IR normalizer completed.", state)
+        return
+
+    _emit_compiler_event(
+        event_callback,
+        "node.completed",
+        "reviewer_repair",
+        "Reviewer repair completed without an applicable patch.",
+        state,
+        payload,
+    )
+
+
+def _reviewer_event_payload(state: WorkflowState) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "reviewer_status": state.get("reviewer_repair_status"),
+        "reviewer_attempt_count": state.get("reviewer_attempt_count", 0),
+        "failure_stage": state.get("repair_failure_stage"),
+        "patch_applied": bool(state.get("reviewer_patch_applied")),
+    }
+    rejection_reason = state.get("reviewer_rejection_reason")
+    if rejection_reason:
+        payload["rejection_reason"] = rejection_reason
+    return payload
+
+
+def _node_started_summary(node: str) -> str:
+    return f"{_node_label(node)} started."
+
+
+def _node_label(node: str) -> str:
+    return {
+        "ir_normalizer": "IR normalizer",
+        "analyzer": "Analyzer",
+        "renderer": "Renderer",
+        "checker": "Checker",
+        "repairer": "Repairer",
+        "reviewer_repair": "Reviewer repair",
+    }.get(node, node)
+
+
+def _task_error_payload(error: object) -> dict[str, str]:
+    return {
+        "error_type": error.__class__.__name__,
+        "error": str(error),
+    }
+
+
+def _emit_artifact_updated(
+    event_callback: CompilerEventCallback,
+    node: str,
+    summary: str,
+    state: WorkflowState,
+    artifact: str,
+) -> None:
     _emit_compiler_event(
         event_callback,
         "artifact.updated",
-        "ir_normalizer",
-        "Workflow IR artifact updated.",
+        node,
+        summary,
         state,
-        {"artifact": "workflow_ir"},
+        {"artifact": artifact},
     )
-
-    _analyze_with_repair(state, event_callback=event_callback)
-    if state["analysis_errors"]:
-        return state
-
-    _emit_compiler_event(event_callback, "node.started", "renderer", "Renderer started.", state)
-    _merge_state(state, renderer_node(state))
-    _emit_compiler_event(event_callback, "node.completed", "renderer", "Renderer completed.", state)
-    _emit_compiler_event(
-        event_callback,
-        "artifact.updated",
-        "renderer",
-        "WDL artifact updated.",
-        state,
-        {"artifact": "wdl"},
-    )
-
-    if check:
-        _validate_with_repair(state, event_callback=event_callback)
-        return state
-
-    state["validation_message"] = "WDL syntax validation skipped (--no-check)."
-    _emit_compiler_event(
-        event_callback,
-        "validation.completed",
-        "checker",
-        state["validation_message"],
-        state,
-        {"is_valid": state["is_valid"], "check_performed": False},
-    )
-    return state
 
 
 def workflow_succeeded(state: WorkflowState, check: bool) -> bool:
@@ -271,6 +630,11 @@ def _result_from_state(
         is_valid=state["is_valid"],
         succeeded=workflow_succeeded(state, check=check),
         check_performed=check,
+        reviewer_attempt_count=state["reviewer_attempt_count"],
+        reviewer_repair_status=state["reviewer_repair_status"],
+        reviewer_rejection_reason=state["reviewer_rejection_reason"],
+        reviewer_diagnostics=state["reviewer_diagnostics"],
+        reviewer_patch_applied=state["reviewer_patch_applied"],
         state=state,
         catalog_retrieval=catalog_retrieval,
         planner_prompt=planner_prompt,
@@ -322,138 +686,6 @@ def _event_error_type(event: dict[str, Any] | None) -> str | None:
     return error_type if isinstance(error_type, str) else None
 
 
-def _analyze_with_repair(
-    state: WorkflowState,
-    event_callback: CompilerEventCallback | None = None,
-) -> None:
-    while True:
-        _emit_compiler_event(event_callback, "node.started", "analyzer", "Analyzer started.", state)
-        _merge_state(state, analyzer_node(state))
-        if not state["analysis_errors"]:
-            _emit_compiler_event(event_callback, "node.completed", "analyzer", "Analyzer completed.", state)
-            return
-
-        _emit_compiler_event(
-            event_callback,
-            "node.failed",
-            "analyzer",
-            "Analyzer found Workflow IR errors.",
-            state,
-            {"analysis_errors": state["analysis_errors"]},
-        )
-        if not _can_attempt_repair(state):
-            return
-
-        _emit_compiler_event(event_callback, "node.started", "repairer", "Repairer started.", state)
-        _merge_state(state, repairer_node(state))
-        if state["repairer_failed"]:
-            _emit_compiler_event(
-                event_callback,
-                "node.failed",
-                "repairer",
-                "Repairer failed.",
-                state,
-                {"repairer_failed": True},
-            )
-            return
-        if not state["repair_actions"]:
-            _emit_compiler_event(
-                event_callback,
-                "node.completed",
-                "repairer",
-                "Repairer found no safe deterministic fix.",
-                state,
-            )
-            return
-        _emit_workflow_ir_artifact_updated(event_callback, state)
-        _emit_compiler_event(
-            event_callback,
-            "repair.applied",
-            "repairer",
-            "Workflow IR repair applied.",
-            state,
-            {"repair_actions": state["repair_actions"]},
-        )
-        _emit_compiler_event(event_callback, "node.completed", "repairer", "Repairer completed.", state)
-
-
-def _validate_with_repair(
-    state: WorkflowState,
-    event_callback: CompilerEventCallback | None = None,
-) -> None:
-    while True:
-        _emit_compiler_event(event_callback, "node.started", "checker", "Checker started.", state)
-        _merge_state(state, checker_node(state))
-        _emit_compiler_event(
-            event_callback,
-            "validation.completed",
-            "checker",
-            "WDL validation completed.",
-            state,
-            {
-                "is_valid": state["is_valid"],
-                "validation_message": state["validation_message"],
-                "check_performed": True,
-            },
-        )
-        if state["is_valid"] or _missing_local_validator(state) or not _can_attempt_repair(state):
-            return
-
-        _emit_compiler_event(event_callback, "node.started", "repairer", "Repairer started.", state)
-        _merge_state(state, repairer_node(state))
-        if state["repairer_failed"]:
-            _emit_compiler_event(
-                event_callback,
-                "node.failed",
-                "repairer",
-                "Repairer failed.",
-                state,
-                {"repairer_failed": True},
-            )
-            return
-        if not state["repair_actions"]:
-            _emit_compiler_event(
-                event_callback,
-                "node.completed",
-                "repairer",
-                "Repairer found no safe deterministic fix.",
-                state,
-            )
-            return
-        _emit_workflow_ir_artifact_updated(event_callback, state)
-        _emit_compiler_event(
-            event_callback,
-            "repair.applied",
-            "repairer",
-            "Workflow IR repair applied.",
-            state,
-            {"repair_actions": state["repair_actions"]},
-        )
-        _emit_compiler_event(event_callback, "node.completed", "repairer", "Repairer completed.", state)
-        _analyze_with_repair(state, event_callback=event_callback)
-        if state["analysis_errors"]:
-            return
-        _emit_compiler_event(event_callback, "node.started", "renderer", "Renderer started.", state)
-        _merge_state(state, renderer_node(state))
-        _emit_compiler_event(event_callback, "node.completed", "renderer", "Renderer completed.", state)
-        _emit_compiler_event(
-            event_callback,
-            "artifact.updated",
-            "renderer",
-            "WDL artifact updated.",
-            state,
-            {"artifact": "wdl"},
-        )
-
-
-def _can_attempt_repair(state: WorkflowState) -> bool:
-    return bool(state.get("workflow_ir")) and state.get("repair_count", 0) < MAX_REPAIR_ATTEMPTS
-
-
-def _missing_local_validator(state: WorkflowState) -> bool:
-    return VALIDATOR_MISSING_MARKER in state.get("validation_message", "")
-
-
 def _emit_compiler_event(
     event_callback: CompilerEventCallback | None,
     event_type: str,
@@ -469,11 +701,13 @@ def _emit_compiler_event(
 def _emit_workflow_ir_artifact_updated(
     event_callback: CompilerEventCallback | None,
     state: WorkflowState,
+    *,
+    node: str,
 ) -> None:
     _emit_compiler_event(
         event_callback,
         "artifact.updated",
-        "repairer",
+        node,
         "Workflow IR artifact updated.",
         state,
         {"artifact": "workflow_ir"},

--- a/tests/api/test_models.py
+++ b/tests/api/test_models.py
@@ -66,6 +66,11 @@ class WorkflowDtoTests(unittest.TestCase):
         self.assertTrue(response.diagnostics.succeeded)
         self.assertFalse(response.diagnostics.check_performed)
         self.assertEqual(response.diagnostics.analysis_errors, [])
+        self.assertEqual(response.diagnostics.reviewer_attempt_count, 0)
+        self.assertIsNone(response.diagnostics.reviewer_repair_status)
+        self.assertIsNone(response.diagnostics.reviewer_rejection_reason)
+        self.assertEqual(response.diagnostics.reviewer_diagnostics, [])
+        self.assertFalse(response.diagnostics.reviewer_patch_applied)
         self.assertIsNone(response.artifacts.catalog_retrieval)
         self.assertEqual(response.artifacts.workflow_ir["workflow"]["name"], "RNASeqDEG")
         self.assertIn("workflow RNASeqDEG", response.artifacts.wdl)
@@ -187,6 +192,10 @@ class CatalogDtoTests(unittest.TestCase):
 
 
 class EventDtoTests(unittest.TestCase):
+    def test_run_event_types_include_reviewer_repair_lifecycle(self):
+        self.assertEqual(RunEventType.REPAIR_PROPOSED.value, "repair.proposed")
+        self.assertEqual(RunEventType.REPAIR_REJECTED.value, "repair.rejected")
+
     def test_run_event_defines_persistable_event_envelope(self):
         event = RunEvent(
             event_id="evt_001",

--- a/tests/test_run_repository.py
+++ b/tests/test_run_repository.py
@@ -54,6 +54,10 @@ class RunRepositoryTests(unittest.TestCase):
                     validation_message="WDL syntax validation skipped (--no-check).",
                     succeeded=True,
                     check_performed=False,
+                    reviewer_attempt_count=1,
+                    reviewer_repair_status="patch_proposed",
+                    reviewer_diagnostics=["Reviewer patch was accepted."],
+                    reviewer_patch_applied=True,
                 ),
             )
             repository.update_status("run_001", RunStatus.SUCCEEDED)
@@ -72,6 +76,16 @@ class RunRepositoryTests(unittest.TestCase):
             self.assertEqual(manifest["diagnostics"].content_type, "application/json")
             self.assertTrue(snapshot.diagnostics.succeeded)
             self.assertFalse(snapshot.diagnostics.check_performed)
+            self.assertEqual(snapshot.diagnostics.reviewer_attempt_count, 1)
+            self.assertEqual(
+                snapshot.diagnostics.reviewer_repair_status,
+                "patch_proposed",
+            )
+            self.assertEqual(
+                snapshot.diagnostics.reviewer_diagnostics,
+                ["Reviewer patch was accepted."],
+            )
+            self.assertTrue(snapshot.diagnostics.reviewer_patch_applied)
 
             events = repository.list_events("run_001")
             self.assertEqual([event.sequence for event in events], [1, 2])
@@ -84,6 +98,10 @@ class RunRepositoryTests(unittest.TestCase):
             )
             wdl_record = next(record for record in artifact_records if record.name == "wdl")
             self.assertIn("workflow Demo", wdl_record.content)
+            diagnostics_record = next(
+                record for record in artifact_records if record.name == "diagnostics"
+            )
+            self.assertEqual(diagnostics_record.content["reviewer_attempt_count"], 1)
 
     def test_has_event_type_checks_event_existence(self):
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/tests/test_run_service.py
+++ b/tests/test_run_service.py
@@ -15,6 +15,8 @@ from src.api.models import (
     WorkflowArtifacts,
 )
 from src.nl_planner import NaturalLanguagePlanningError
+from src.nodes.reviewer_repair import make_reviewer_repair_node
+from src.reviewer_provider import ReviewerProviderError
 from src.services.run_repository import RunRepository
 from src.services.run_service import RunService
 from src.services.workflow_service import compile_structured_workflow
@@ -57,6 +59,70 @@ def repairable_forward_reference_ir() -> dict:
     workflow_ir = load_example("rnaseq_workflow_ir.json")
     workflow_ir["workflow"]["steps"].reverse()
     return workflow_ir
+
+
+def reviewer_repairable_ir() -> dict:
+    workflow_ir = load_example("rnaseq_workflow_ir.json")
+    workflow_ir["workflow"]["steps"][0]["inputs"]["r1"] = "missing_input"
+    return workflow_ir
+
+
+def reviewer_patch_result() -> dict:
+    return {
+        "status": "patch_proposed",
+        "patch": {
+            "summary": "Reconnect the QC input to a declared workflow input.",
+            "actions": [
+                {
+                    "operation": "replace",
+                    "path": "/workflow/steps/0/inputs/r1",
+                    "value": "raw_r1",
+                    "reason": "Use the existing workflow input.",
+                }
+            ],
+            "diagnostic_references": [
+                "references unknown value 'missing_input'"
+            ],
+            "confidence": 0.9,
+        },
+        "diagnostics": ["The replacement uses an existing workflow input."],
+    }
+
+
+def reviewer_policy_rejected_result() -> dict:
+    return {
+        "status": "patch_proposed",
+        "patch": {
+            "summary": "Attempt a forbidden runtime edit.",
+            "actions": [
+                {
+                    "operation": "replace",
+                    "path": "/tasks/fastp/runtime/docker",
+                    "value": "ubuntu:22.04",
+                    "reason": "Reviewer must not change runtime images.",
+                }
+            ],
+        },
+    }
+
+
+class RecordingReviewerProvider:
+    def __init__(self, result):
+        self.result = result
+        self.requests = []
+
+    def repair(self, request):
+        self.requests.append(request)
+        return self.result
+
+
+class RaisingReviewerProvider:
+    def __init__(self):
+        self.requests = []
+
+    def repair(self, request):
+        self.requests.append(request)
+        raise ReviewerProviderError("TOP_SECRET provider failure")
 
 
 class RunServiceTests(unittest.TestCase):
@@ -142,14 +208,237 @@ class RunServiceTests(unittest.TestCase):
             self.assertLess(workflow_ir_update_index, repair_index)
             self.assertIn("Reordered workflow steps", events[repair_index].payload["repair_actions"][0])
 
+    def test_structured_compile_run_persists_reviewer_events_and_artifacts(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            provider = RecordingReviewerProvider(reviewer_patch_result())
+            service = RunService(
+                RunRepository(Path(temp_dir) / "runs.sqlite3"),
+                reviewer_node=make_reviewer_repair_node(
+                    enabled=True,
+                    provider=provider,
+                ),
+            )
+            request = CompileWorkflowRequest(
+                payload=reviewer_repairable_ir(),
+                check=False,
+            )
+
+            accepted = service.create_structured_compile_run(request)
+            service.execute_structured_compile_run(accepted.run_id, request)
+
+            snapshot = service.get_snapshot(accepted.run_id)
+            self.assertIsNotNone(snapshot)
+            assert snapshot is not None
+            self.assertEqual(snapshot.status, RunStatus.SUCCEEDED)
+            self.assertEqual(snapshot.diagnostics.reviewer_attempt_count, 1)
+            self.assertEqual(
+                snapshot.diagnostics.reviewer_repair_status,
+                "patch_proposed",
+            )
+            self.assertTrue(snapshot.diagnostics.reviewer_patch_applied)
+            self.assertIn("reviewer_repair_request", snapshot.artifacts.extras)
+            self.assertIn("reviewer_ir_patch", snapshot.artifacts.extras)
+            manifest = {artifact.name for artifact in snapshot.artifacts.manifest}
+            self.assertIn("reviewer_repair_request", manifest)
+            self.assertIn("reviewer_ir_patch", manifest)
+            self.assertEqual(
+                snapshot.artifacts.workflow_ir["workflow"]["steps"][0]["inputs"]["r1"],
+                "raw_r1",
+            )
+
+            events = service.get_events(accepted.run_id)
+            self.assertIsNotNone(events)
+            assert events is not None
+            reviewer_events = [
+                event for event in events if event.node == "reviewer_repair"
+            ]
+            self.assertEqual(
+                [event.type for event in reviewer_events],
+                [
+                    RunEventType.NODE_STARTED,
+                    RunEventType.ARTIFACT_UPDATED,
+                    RunEventType.ARTIFACT_UPDATED,
+                    RunEventType.REPAIR_PROPOSED,
+                    RunEventType.ARTIFACT_UPDATED,
+                    RunEventType.REPAIR_APPLIED,
+                    RunEventType.NODE_COMPLETED,
+                ],
+            )
+            proposed_index = next(
+                index
+                for index, event in enumerate(events)
+                if event.type == RunEventType.REPAIR_PROPOSED
+            )
+            workflow_ir_index = next(
+                index
+                for index, event in enumerate(events[proposed_index + 1 :], proposed_index + 1)
+                if event.type == RunEventType.ARTIFACT_UPDATED
+                and event.node == "reviewer_repair"
+                and event.payload.get("artifact") == "workflow_ir"
+            )
+            applied_index = next(
+                index
+                for index, event in enumerate(events)
+                if event.type == RunEventType.REPAIR_APPLIED
+                and event.node == "reviewer_repair"
+            )
+            diagnostics_index = next(
+                index
+                for index, event in enumerate(events)
+                if event.type == RunEventType.ARTIFACT_UPDATED
+                and event.node == "diagnostics"
+            )
+            self.assertLess(workflow_ir_index, applied_index)
+            self.assertLess(applied_index, diagnostics_index)
+            self.assertEqual(events[-1].type, RunEventType.RUN_COMPLETED)
+
+            stream = asyncio.run(_collect_async(service.iter_sse_events(accepted.run_id)))
+            self.assertIn("event: repair.proposed", stream)
+            self.assertIn("event: repair.applied", stream)
+
+    def test_structured_compile_run_persists_reviewer_failure_diagnostics(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            provider = RaisingReviewerProvider()
+            service = RunService(
+                RunRepository(Path(temp_dir) / "runs.sqlite3"),
+                reviewer_node=make_reviewer_repair_node(
+                    enabled=True,
+                    provider=provider,
+                ),
+            )
+            request = CompileWorkflowRequest(
+                payload=reviewer_repairable_ir(),
+                check=False,
+            )
+
+            accepted = service.create_structured_compile_run(request)
+            service.execute_structured_compile_run(accepted.run_id, request)
+
+            snapshot = service.get_snapshot(accepted.run_id)
+            self.assertIsNotNone(snapshot)
+            assert snapshot is not None
+            self.assertEqual(snapshot.status, RunStatus.FAILED)
+            self.assertEqual(snapshot.diagnostics.reviewer_attempt_count, 1)
+            self.assertEqual(
+                snapshot.diagnostics.reviewer_repair_status,
+                "model_error",
+            )
+            self.assertFalse(snapshot.diagnostics.reviewer_patch_applied)
+            self.assertIn("ReviewerProviderError", snapshot.diagnostics.reviewer_diagnostics[0])
+            self.assertIn("reviewer_repair_request", snapshot.artifacts.extras)
+            self.assertNotIn("reviewer_ir_patch", snapshot.artifacts.extras)
+            self.assertNotIn(
+                "TOP_SECRET",
+                json.dumps(snapshot.model_dump(mode="json")),
+            )
+
+            events = service.get_events(accepted.run_id)
+            self.assertIsNotNone(events)
+            assert events is not None
+            reviewer_events = [
+                event for event in events if event.node == "reviewer_repair"
+            ]
+            self.assertEqual(
+                [event.type for event in reviewer_events],
+                [
+                    RunEventType.NODE_STARTED,
+                    RunEventType.ARTIFACT_UPDATED,
+                    RunEventType.NODE_FAILED,
+                ],
+            )
+            self.assertNotIn(
+                RunEventType.VALIDATION_COMPLETED,
+                [event.type for event in events],
+            )
+            reviewer_failure_index = events.index(reviewer_events[-1])
+            diagnostics_index = next(
+                index
+                for index, event in enumerate(events)
+                if event.type == RunEventType.ARTIFACT_UPDATED
+                and event.node == "diagnostics"
+            )
+            self.assertLess(reviewer_failure_index, diagnostics_index)
+            self.assertEqual(events[-1].type, RunEventType.RUN_COMPLETED)
+
+    def test_structured_compile_run_persists_reviewer_rejection(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            provider = RecordingReviewerProvider(reviewer_policy_rejected_result())
+            service = RunService(
+                RunRepository(Path(temp_dir) / "runs.sqlite3"),
+                reviewer_node=make_reviewer_repair_node(
+                    enabled=True,
+                    provider=provider,
+                ),
+            )
+            request = CompileWorkflowRequest(
+                payload=reviewer_repairable_ir(),
+                check=False,
+            )
+
+            accepted = service.create_structured_compile_run(request)
+            service.execute_structured_compile_run(accepted.run_id, request)
+
+            snapshot = service.get_snapshot(accepted.run_id)
+            self.assertIsNotNone(snapshot)
+            assert snapshot is not None
+            self.assertEqual(snapshot.status, RunStatus.FAILED)
+            self.assertEqual(
+                snapshot.diagnostics.reviewer_repair_status,
+                "policy_rejected",
+            )
+            self.assertIn(
+                "forbidden",
+                snapshot.diagnostics.reviewer_rejection_reason or "",
+            )
+            self.assertIn("reviewer_repair_request", snapshot.artifacts.extras)
+            self.assertIn("reviewer_ir_patch", snapshot.artifacts.extras)
+
+            events = service.get_events(accepted.run_id)
+            self.assertIsNotNone(events)
+            assert events is not None
+            reviewer_events = [
+                event for event in events if event.node == "reviewer_repair"
+            ]
+            self.assertEqual(
+                [event.type for event in reviewer_events],
+                [
+                    RunEventType.NODE_STARTED,
+                    RunEventType.ARTIFACT_UPDATED,
+                    RunEventType.ARTIFACT_UPDATED,
+                    RunEventType.REPAIR_PROPOSED,
+                    RunEventType.REPAIR_REJECTED,
+                    RunEventType.NODE_COMPLETED,
+                ],
+            )
+            proposed_event = next(
+                event
+                for event in reviewer_events
+                if event.type == RunEventType.REPAIR_PROPOSED
+            )
+            rejected_event = next(
+                event
+                for event in reviewer_events
+                if event.type == RunEventType.REPAIR_REJECTED
+            )
+            self.assertEqual(proposed_event.payload["status"], "proposed")
+            self.assertEqual(rejected_event.payload["status"], "rejected")
+            self.assertEqual(events[-2].node, "diagnostics")
+            self.assertEqual(events[-1].type, RunEventType.RUN_COMPLETED)
+
     def test_structured_compile_run_default_check_records_validation_event(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             service = RunService(RunRepository(Path(temp_dir) / "runs.sqlite3"))
             request = CompileWorkflowRequest(payload=load_example("rnaseq_deg_recipe_plan.json"))
 
             with patch(
-                "src.services.workflow_service.checker_node",
-                return_value={"is_valid": True, "validation_message": "valid WDL", "error_count": 0},
+                "src.graph.checker_node",
+                return_value={
+                    "is_valid": True,
+                    "validation_message": "valid WDL",
+                    "error_count": 0,
+                    "repair_failure_stage": None,
+                    "messages": [],
+                },
             ):
                 accepted = service.create_structured_compile_run(request)
                 service.execute_structured_compile_run(accepted.run_id, request)
@@ -247,6 +536,7 @@ class RunServiceTests(unittest.TestCase):
             self.assertEqual(plan_and_compile.call_args.args, ("Run RNA-seq DEG.",))
             self.assertEqual(plan_and_compile.call_args.kwargs["check"], False)
             self.assertIn("event_callback", plan_and_compile.call_args.kwargs)
+            self.assertIsNone(plan_and_compile.call_args.kwargs["reviewer_node"])
 
             snapshot = service.get_snapshot(accepted.run_id)
             self.assertIsNotNone(snapshot)

--- a/tests/test_workflow_service.py
+++ b/tests/test_workflow_service.py
@@ -4,10 +4,11 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
+from src.graph import build_compiler_graph
+from src.nodes.reviewer_repair import make_reviewer_repair_node
+from src.reviewer_provider import ReviewerProviderError
 from src.services.workflow_service import (
     _raise_orchestration_error,
-    _validate_with_repair,
-    build_initial_state,
     compile_structured_workflow,
     plan_and_compile_workflow,
 )
@@ -26,6 +27,25 @@ class FakePlannerLlm:
     def invoke(self, prompt: str):
         self.prompts.append(prompt)
         return SimpleNamespace(content=self.response)
+
+
+class RecordingReviewerProvider:
+    def __init__(self, result):
+        self.result = result
+        self.requests = []
+
+    def repair(self, request):
+        self.requests.append(request)
+        return self.result
+
+
+class RaisingReviewerProvider:
+    def __init__(self):
+        self.requests = []
+
+    def repair(self, request):
+        self.requests.append(request)
+        raise ReviewerProviderError("TOP_SECRET provider failure")
 
 
 def load_example(name: str) -> dict:
@@ -108,6 +128,51 @@ def repairable_forward_reference_ir() -> dict:
     }
 
 
+def reviewer_repairable_ir() -> dict:
+    workflow_ir = load_example("rnaseq_workflow_ir.json")
+    workflow_ir["workflow"]["steps"][0]["inputs"]["r1"] = "missing_input"
+    return workflow_ir
+
+
+def reviewer_patch_result() -> dict:
+    return {
+        "status": "patch_proposed",
+        "patch": {
+            "summary": "Reconnect the QC input to a declared workflow input.",
+            "actions": [
+                {
+                    "operation": "replace",
+                    "path": "/workflow/steps/0/inputs/r1",
+                    "value": "raw_r1",
+                    "reason": "Use the existing workflow input.",
+                }
+            ],
+            "diagnostic_references": [
+                "references unknown value 'missing_input'"
+            ],
+            "confidence": 0.9,
+        },
+        "diagnostics": ["The replacement uses an existing workflow input."],
+    }
+
+
+def reviewer_policy_rejected_result() -> dict:
+    return {
+        "status": "patch_proposed",
+        "patch": {
+            "summary": "Attempt a forbidden runtime edit.",
+            "actions": [
+                {
+                    "operation": "replace",
+                    "path": "/tasks/fastp/runtime/docker",
+                    "value": "ubuntu:22.04",
+                    "reason": "Reviewer must not change runtime images.",
+                }
+            ],
+        },
+    }
+
+
 class WorkflowServiceTests(unittest.TestCase):
     def test_compile_structured_workflow_compiles_recipe_plan_without_check(self):
         plan = load_example("rnaseq_deg_recipe_plan.json")
@@ -133,18 +198,18 @@ class WorkflowServiceTests(unittest.TestCase):
         self.assertEqual(result.workflow_ir["workflow"]["name"], "RNASeqPipeline")
         self.assertIn("workflow RNASeqPipeline", result.wdl)
 
-    def test_compile_structured_workflow_without_check_does_not_invoke_graph(self):
+    def test_compile_structured_workflow_without_check_uses_unchecked_graph(self):
         plan = load_example("rnaseq_deg_recipe_plan.json")
 
         with patch(
-            "src.services.workflow_service.compiler_graph.invoke",
-            side_effect=AssertionError("compiled graph should not run when check=False"),
-        ) as graph:
+            "src.services.workflow_service.build_compiler_graph",
+            wraps=build_compiler_graph,
+        ) as graph_builder:
             result = compile_structured_workflow(plan, check=False)
 
         self.assertTrue(result.succeeded, result.analysis_errors)
         self.assertFalse(result.check_performed)
-        graph.assert_not_called()
+        graph_builder.assert_called_once_with(reviewer_node=None, check=False)
 
     def test_compile_structured_workflow_returns_diagnostics_for_invalid_plan(self):
         plan = load_example("rnaseq_deg_recipe_plan.json")
@@ -225,11 +290,10 @@ class WorkflowServiceTests(unittest.TestCase):
             {"repairer_failed": True},
         )
 
-    def test_validation_repair_emits_workflow_ir_artifact_update_before_repair_event(self):
+    def test_evented_reviewer_patch_emits_artifacts_before_repair_events(self):
         events = []
-        state = build_initial_state(repairable_forward_reference_ir())
-        state["workflow_ir"] = repairable_forward_reference_ir()
-        state["current_wdl"] = "broken wdl"
+        provider = RecordingReviewerProvider(reviewer_patch_result())
+        reviewer_node = make_reviewer_repair_node(enabled=True, provider=provider)
 
         def event_callback(event_type, node, summary, state, payload):
             events.append(
@@ -242,43 +306,163 @@ class WorkflowServiceTests(unittest.TestCase):
                 }
             )
 
-        repaired_ir = repairable_forward_reference_ir()
-        repaired_ir["workflow"]["steps"].reverse()
-        with (
-            patch(
-                "src.services.workflow_service.checker_node",
-                side_effect=[
-                    {"is_valid": False, "validation_message": "invalid WDL", "error_count": 1},
-                    {"is_valid": True, "validation_message": "valid WDL", "error_count": 1},
-                ],
-            ),
-            patch(
-                "src.services.workflow_service.repairer_node",
-                return_value={
-                    "workflow_ir": repaired_ir,
-                    "analysis_errors": [],
-                    "analysis_warnings": [],
-                    "current_wdl": "",
-                    "is_valid": False,
-                    "repair_actions": ["Reordered workflow steps."],
-                    "repair_count": 1,
-                    "messages": [],
-                },
-            ),
-            patch("src.services.workflow_service._analyze_with_repair"),
-            patch("src.services.workflow_service.renderer_node", return_value={"current_wdl": "fixed wdl"}),
-        ):
-            _validate_with_repair(state, event_callback=event_callback)
+        result = compile_structured_workflow(
+            reviewer_repairable_ir(),
+            check=False,
+            event_callback=event_callback,
+            reviewer_node=reviewer_node,
+        )
 
-        event_types = [event["type"] for event in events]
-        artifact_index = event_types.index("artifact.updated", event_types.index("repair.applied") - 1)
-        repair_index = event_types.index("repair.applied")
-        self.assertLess(artifact_index, repair_index)
-        self.assertEqual(events[artifact_index]["node"], "repairer")
-        self.assertEqual(events[artifact_index]["payload"], {"artifact": "workflow_ir"})
+        self.assertTrue(result.succeeded, result.analysis_errors)
+        self.assertEqual(len(provider.requests), 1)
+        self.assertEqual(result.reviewer_attempt_count, 1)
+        self.assertEqual(result.reviewer_repair_status, "patch_proposed")
+        self.assertTrue(result.reviewer_patch_applied)
+        reviewer_events = [
+            event for event in events if event["node"] == "reviewer_repair"
+        ]
         self.assertEqual(
-            [step["id"] for step in events[artifact_index]["workflow_ir"]["workflow"]["steps"]],
-            ["qc", "align"],
+            [event["type"] for event in reviewer_events],
+            [
+                "node.started",
+                "artifact.updated",
+                "artifact.updated",
+                "repair.proposed",
+                "artifact.updated",
+                "repair.applied",
+                "node.completed",
+            ],
+        )
+        self.assertEqual(
+            [
+                event["payload"].get("artifact")
+                for event in reviewer_events
+                if event["type"] == "artifact.updated"
+            ],
+            ["reviewer_repair_request", "reviewer_ir_patch", "workflow_ir"],
+        )
+        workflow_ir_index = next(
+            index
+            for index, event in enumerate(reviewer_events)
+            if event["payload"].get("artifact") == "workflow_ir"
+        )
+        repair_index = next(
+            index
+            for index, event in enumerate(reviewer_events)
+            if event["type"] == "repair.applied"
+        )
+        self.assertLess(workflow_ir_index, repair_index)
+        self.assertEqual(
+            reviewer_events[workflow_ir_index]["workflow_ir"]["workflow"]["steps"][0]["inputs"]["r1"],
+            "raw_r1",
+        )
+
+    def test_evented_and_non_evented_reviewer_results_match(self):
+        direct_provider = RecordingReviewerProvider(reviewer_patch_result())
+        evented_provider = RecordingReviewerProvider(reviewer_patch_result())
+
+        direct_result = compile_structured_workflow(
+            reviewer_repairable_ir(),
+            check=False,
+            reviewer_node=make_reviewer_repair_node(
+                enabled=True,
+                provider=direct_provider,
+            ),
+        )
+        evented_result = compile_structured_workflow(
+            reviewer_repairable_ir(),
+            check=False,
+            event_callback=lambda *args: None,
+            reviewer_node=make_reviewer_repair_node(
+                enabled=True,
+                provider=evented_provider,
+            ),
+        )
+
+        self.assertEqual(evented_result.to_dict(), direct_result.to_dict())
+        self.assertEqual(len(direct_provider.requests), 1)
+        self.assertEqual(len(evented_provider.requests), 1)
+
+    def test_evented_reviewer_policy_rejection_emits_proposed_and_rejected(self):
+        events = []
+        provider = RecordingReviewerProvider(reviewer_policy_rejected_result())
+
+        def event_callback(event_type, node, summary, state, payload):
+            events.append(
+                {
+                    "type": event_type,
+                    "node": node,
+                    "payload": payload or {},
+                }
+            )
+
+        result = compile_structured_workflow(
+            reviewer_repairable_ir(),
+            check=False,
+            event_callback=event_callback,
+            reviewer_node=make_reviewer_repair_node(
+                enabled=True,
+                provider=provider,
+            ),
+        )
+
+        self.assertFalse(result.succeeded)
+        self.assertEqual(result.reviewer_repair_status, "policy_rejected")
+        self.assertFalse(result.reviewer_patch_applied)
+        self.assertIn("forbidden", result.reviewer_rejection_reason or "")
+        reviewer_events = [
+            event for event in events if event["node"] == "reviewer_repair"
+        ]
+        self.assertEqual(
+            [event["type"] for event in reviewer_events],
+            [
+                "node.started",
+                "artifact.updated",
+                "artifact.updated",
+                "repair.proposed",
+                "repair.rejected",
+                "node.completed",
+            ],
+        )
+        self.assertNotIn("repair.applied", [event["type"] for event in reviewer_events])
+
+    def test_evented_reviewer_model_error_emits_request_then_failure(self):
+        events = []
+        provider = RaisingReviewerProvider()
+
+        def event_callback(event_type, node, summary, state, payload):
+            events.append(
+                {
+                    "type": event_type,
+                    "node": node,
+                    "payload": payload or {},
+                }
+            )
+
+        result = compile_structured_workflow(
+            reviewer_repairable_ir(),
+            check=False,
+            event_callback=event_callback,
+            reviewer_node=make_reviewer_repair_node(
+                enabled=True,
+                provider=provider,
+            ),
+        )
+
+        self.assertFalse(result.succeeded)
+        self.assertEqual(result.reviewer_repair_status, "model_error")
+        self.assertEqual(result.reviewer_attempt_count, 1)
+        self.assertNotIn("TOP_SECRET", json.dumps(result.to_dict()))
+        reviewer_events = [
+            event for event in events if event["node"] == "reviewer_repair"
+        ]
+        self.assertEqual(
+            [event["type"] for event in reviewer_events],
+            ["node.started", "artifact.updated", "node.failed"],
+        )
+        self.assertEqual(
+            reviewer_events[1]["payload"]["artifact"],
+            "reviewer_repair_request",
         )
 
     def test_compile_structured_workflow_check_true_event_callback_runs_validation_repair_loop(self):
@@ -308,20 +492,28 @@ class WorkflowServiceTests(unittest.TestCase):
 
         with (
             patch(
-                "src.services.workflow_service.checker_node",
+                "src.graph.checker_node",
                 side_effect=[
-                    {"is_valid": False, "validation_message": "invalid WDL", "error_count": 1},
-                    {"is_valid": True, "validation_message": "valid WDL", "error_count": 1},
+                    {
+                        "is_valid": False,
+                        "validation_message": "invalid WDL",
+                        "error_count": 1,
+                        "repair_failure_stage": "checker",
+                        "messages": [],
+                    },
+                    {
+                        "is_valid": True,
+                        "validation_message": "valid WDL",
+                        "error_count": 1,
+                        "repair_failure_stage": None,
+                        "messages": [],
+                    },
                 ],
             ) as checker,
             patch(
-                "src.services.workflow_service.repairer_node",
+                "src.graph.repairer_node",
                 side_effect=repairer_update,
             ) as repairer,
-            patch(
-                "src.services.workflow_service.compiler_graph.invoke",
-                side_effect=AssertionError("event callbacks should use the manual compiler path"),
-            ) as graph,
         ):
             result = compile_structured_workflow(
                 load_example("rnaseq_workflow_ir.json"),
@@ -336,7 +528,6 @@ class WorkflowServiceTests(unittest.TestCase):
         self.assertEqual(result.repair_actions, ["Repaired WDL validation issue."])
         self.assertEqual(checker.call_count, 2)
         repairer.assert_called_once()
-        graph.assert_not_called()
 
         event_types = [event["type"] for event in events]
         self.assertEqual(event_types.count("validation.completed"), 2)
@@ -466,6 +657,11 @@ class WorkflowServiceTests(unittest.TestCase):
         self.assertIn("workflow RNASeqDEG", result["wdl"])
         self.assertEqual(result["analysis_errors"], [])
         self.assertTrue(result["succeeded"])
+        self.assertEqual(result["reviewer_attempt_count"], 0)
+        self.assertIsNone(result["reviewer_repair_status"])
+        self.assertIsNone(result["reviewer_rejection_reason"])
+        self.assertEqual(result["reviewer_diagnostics"], [])
+        self.assertFalse(result["reviewer_patch_applied"])
 
 
 if __name__ == "__main__":

--- a/web/app/workspace/workspace-workbench.tsx
+++ b/web/app/workspace/workspace-workbench.tsx
@@ -59,6 +59,11 @@ const emptyDiagnostics: DiagnosticReport = {
   is_valid: false,
   succeeded: false,
   check_performed: false,
+  reviewer_attempt_count: 0,
+  reviewer_repair_status: null,
+  reviewer_rejection_reason: null,
+  reviewer_diagnostics: [],
+  reviewer_patch_applied: false,
 };
 
 const runModeOptions: Array<{

--- a/web/lib/run-events.ts
+++ b/web/lib/run-events.ts
@@ -6,6 +6,8 @@ export const runEventTypes: RunEventType[] = [
   "node.completed",
   "node.failed",
   "artifact.updated",
+  "repair.proposed",
+  "repair.rejected",
   "repair.applied",
   "validation.completed",
   "run.completed",
@@ -17,6 +19,8 @@ export const runEventLabels: Record<RunEventType, string> = {
   "node.completed": "节点完成",
   "node.failed": "节点失败",
   "artifact.updated": "产物更新",
+  "repair.proposed": "修复提议",
+  "repair.rejected": "修复拒绝",
   "repair.applied": "修复应用",
   "validation.completed": "校验完成",
   "run.completed": "Run 完成",
@@ -33,12 +37,15 @@ export const runNodeLabels: Record<string, string> = {
   planner: "Planner",
   renderer: "Renderer",
   repairer: "Repairer",
+  reviewer_repair: "Reviewer Repair",
 };
 
 export const artifactLabels: Record<string, string> = {
   catalog_retrieval: "Catalog Retrieval",
   diagnostics: "Diagnostics",
   plan: "Recipe Tool Plan",
+  reviewer_ir_patch: "Reviewer IR Patch",
+  reviewer_repair_request: "Reviewer Repair Request",
   wdl: "WDL",
   workflow_ir: "Workflow IR",
 };

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -173,6 +173,11 @@ export type DiagnosticReport = {
   is_valid: boolean;
   succeeded: boolean;
   check_performed: boolean;
+  reviewer_attempt_count: number;
+  reviewer_repair_status: string | null;
+  reviewer_rejection_reason: string | null;
+  reviewer_diagnostics: string[];
+  reviewer_patch_applied: boolean;
 };
 
 export type WorkflowRunSnapshotResponse = {
@@ -194,6 +199,8 @@ export type RunEventType =
   | "node.completed"
   | "node.failed"
   | "artifact.updated"
+  | "repair.proposed"
+  | "repair.rejected"
   | "repair.applied"
   | "validation.completed"
   | "run.completed";


### PR DESCRIPTION
## Summary
- unify evented and direct compilation on the same Compiler Graph, including bounded Reviewer routing
- persist redacted Reviewer requests, parsed IR patches, lifecycle events, and final diagnostics in run history
- update API and web contracts, regression coverage, and P2 implementation documentation

## Testing
- Python unit suite with WOMtool configured: 274 tests passed, 2 optional E2E tests skipped
- representative RNA-seq WDL validated successfully with WOMtool
- npm run lint
- npm run build
- npm run test:catalog-retrieval
- npm run test:graph

## Notes
- Reviewer remains disabled by default, so deterministic structured compilation does not require an API key
- raw Reviewer provider output is not persisted