### PR TITLE
Close out P2 Reviewer repair phase

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -821,9 +821,13 @@ P1 的目标是明确 Compiler Graph，并建立第一版 Orchestration Graph �
 
 👉 **[P1 Orchestration Graph 实施计划](./docs/p1-orchestration-graph-plan.md)**
 
-### P2 实施计划
+### P2 实施计划（已完成）
 
 P2 的目标是将 Reviewer LLM 作为受控 IR 修复分支接入 Compiler Graph。Reviewer 只能在确定性 repairer 没有安全修复动作时提出结构化 Workflow IR patch；patch 必须经过 schema、policy、Analyzer、Renderer 和 Checker 验证，不能直接生成 WDL 或绕过 Catalog 与容器准入边界。
+
+P2 已于 2026-08-24 完成。最终实现覆盖 Reviewer contract、patch policy 与 application、
+Analyzer / Checker failure routing、独立 attempt budget，以及 run events、named artifacts
+和 diagnostics。完整单元测试在 Java 17 与 WOMtool 环境通过；下一工程阶段为 P3。
 
 详细工作拆解、关键契约、验收清单和建议 PR 切分维护在：
 
@@ -832,6 +836,9 @@ P2 的目标是将 Reviewer LLM 作为受控 IR 修复分支接入 Compiler Grap
 ### P3 Architect 与 Bioinfo Reviewer
 
 P3 的目标是把分析方案职责和方法学审查职责分开。Architect Agent 负责形成候选分析方案、步骤和预期输出；Bioinfo Reviewer 负责只读审查并输出 warnings，例如缺少 QC、缺少样本分组或 contrast、未说明 transcriptome index / reference resource、MultiQC 汇总输入不足等。
+
+P3 开始实现前，应先形成独立实施计划，明确 Architect 输出契约、Bioinfo Reviewer
+只读 warnings schema、Orchestration Graph 路由、run observability 和建议 PR 拆分。
 
 Bioinfo Reviewer 的边界：
 

--- a/README.md
+++ b/README.md
@@ -339,6 +339,7 @@ Web 产品化拆解与当前 W6 收口计划详见：
 - [x] 引入 Workflow IR、静态分析器与确定性 WDL Renderer。
 - [x] 接入 Recipe / Tool Catalog 输入到 LangGraph Planner。
 - [x] 闭环修复机制初版：当分析器或校验器发现可确定修复的问题时，优先修复 IR 并重新编译 WDL。
+- [x] 完成 [P2 Reviewer IR 修复闭环](./docs/p2-reviewer-repair-plan.md)：Analyzer / Checker 失败在确定性修复无安全动作后进入有界 Reviewer 分支，结构化 patch 经过 policy 与完整编译链验证，并通过 run events、artifacts 和 diagnostics 回放。
 - [x] Tool Catalog 强制显式声明 `runtime.docker`，作为镜像来源的唯一权威。
 - [x] 支持 `workflow.steps` 与 WDL scatter，RNA-seq DEG recipe 升级为多样本 Salmon -> tximport -> DESeq2 -> MultiQC。
 - [x] 抽取 workflow/catalog application service，供 CLI 与 API 复用。
@@ -352,6 +353,7 @@ Web 产品化拆解与当前 W6 收口计划详见：
 - [x] 完成 W4 工作台：结构化示例 / 自然语言 run 创建、snapshot 轮询、SSE 时间线、Plan / IR / WDL / Diagnostics tabs 和失败态展示。
 - [x] 完成 [W5 DAG 可视化和历史详情页](./docs/w5-dag-history-plan.md)：真实 run 列表、详情回放、Workflow IR DAG、结构状态和失败 run 摘要。
 - [ ] 完成 [W6 部署与作品集打磨](./docs/w6-portfolio-launch-plan.md)：在线 demo、示例数据、架构图、截图/录屏、API 文档与 README 导航。
+- [ ] 完成 P3 Architect 与 Bioinfo Reviewer 分层：Architect 负责候选分析方案，Bioinfo Reviewer 只读输出科学性 warnings。
 - [ ] 扩展更多常用生信 recipe 与 tool catalog。
 
 ## 📄 许可证

--- a/docs/p2-reviewer-repair-plan.md
+++ b/docs/p2-reviewer-repair-plan.md
@@ -17,9 +17,10 @@ Ran 274 tests
 OK (skipped=2)
 ```
 
-两项跳过测试均为需要显式启用真实执行环境的可选 e2e 路径。此次收尾不改变
-Workflow IR schema、expression rules 或生成的 WDL，因此无需更新 `docs/workflow-ir.md`
-或增加额外 WDL fixture。
+跳过项为需要设置 `AI_BIOWORKFLOW_RUN_E2E=1` 的真实 Cromwell tiny e2e，
+以及当前环境未安装 miniwdl 时按设计跳过的本地 miniwdl tiny run。此次收尾不改变
+Workflow IR schema、expression rules 或生成的 WDL，因此无需更新
+`docs/workflow-ir.md` 或增加额外 WDL fixture。
 
 ## 背景与现状
 

--- a/docs/p2-reviewer-repair-plan.md
+++ b/docs/p2-reviewer-repair-plan.md
@@ -4,6 +4,23 @@
 Compiler Graph。它补充 `DEVELOPMENT.md` 中的路线图摘要，并承接 P1
 Orchestration Graph 的分层边界。
 
+## 完成状态
+
+P2 已于 2026-08-24 完成。Reviewer repair contract、受策略约束的 patch application、
+provider boundary、Analyzer / Checker failure routing，以及 run events、named artifacts
+和 diagnostics 已全部落地。下一工程阶段为 P3 Architect 与 Bioinfo Reviewer 分层。
+
+最终验收在配置 Java 17 与 WOMtool 的 Windows 环境执行：
+
+```text
+Ran 274 tests
+OK (skipped=2)
+```
+
+两项跳过测试均为需要显式启用真实执行环境的可选 e2e 路径。此次收尾不改变
+Workflow IR schema、expression rules 或生成的 WDL，因此无需更新 `docs/workflow-ir.md`
+或增加额外 WDL fixture。
+
 ## 背景与现状
 
 P1 已建立双层图边界：
@@ -296,6 +313,8 @@ artifacts，避免前端和 API 消费方解析文本 summary。
   不会让结构化编译自动依赖 API key。
 
 ### P2.6 文档与验收
+
+状态：已完成。
 
 交付：
 

--- a/docs/test-cases.md
+++ b/docs/test-cases.md
@@ -48,16 +48,16 @@ powershell -ExecutionPolicy Bypass -File scripts\check_p0.ps1 `
 - `tests/test_tiny_run.py`：没有 miniwdl、Docker/Podman、本地镜像或 tiny 输入文件时跳过真实 tiny run。
 - `tests/test_container_build.py`：纯单元测试，不调用 Docker；只验证容器构建脚本的 tag contract。
 
-当前 P1.7 事件与 artifacts 收口后的最近一次完整验证结果：
+当前 P2.6 Reviewer IR 修复闭环收口后的最近一次完整验证结果：
 
 ```text
 .\.venv\Scripts\python.exe -m unittest discover -v
-Ran 186 tests
+Ran 274 tests
 OK (skipped=2)
 ```
 
-跳过项为显式 opt-in 的真实 Cromwell tiny e2e，以及本地未安装 miniwdl
-时跳过的可选 miniwdl tiny run。
+跳过项为需要设置 `AI_BIOWORKFLOW_RUN_E2E=1` 的真实 Cromwell tiny e2e，
+以及当前环境未安装 miniwdl 时按设计跳过的本地 miniwdl tiny run。
 
 真实 Cromwell tiny e2e 已在独立 runner 环境中手动运行过；默认单测仍保留
 显式 opt-in 机制，避免普通 Windows/Codex 开发环境误触发真实 workflow 执行。


### PR DESCRIPTION
## Summary

- mark the P2 Reviewer IR repair phase complete in the engineering roadmap
- record the final Java 17 and WOMtool-backed acceptance result
- identify P3 Architect and Bioinfo Reviewer planning as the next engineering stage

## Verification

- .venv/Scripts/python.exe -m unittest discover
- Ran 274 tests; OK (skipped=2)
- git diff --check