### PR TITLE
Add ChIP-seq recipe and cross-family retrieval baseline

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -861,8 +861,18 @@ verification 的边界，允许暂缓真实 e2e，但不允许用不完整占位
 Tool Catalog 契约。
 
 当前 `bowtie2`、`samtools` 和 `macs2` 已作为 `unverified`、compile-ready
-工具进入正式 Catalog。下一步是增加 `chipseq_peak_calling` recipe 和首次跨
-family retrieval baseline；在 recipe 合并前，ChIP-seq 仍不属于已支持 workflow。
+工具进入正式 Catalog；`chipseq_peak_calling` recipe、结构化 example plan 和首次
+跨 family retrieval baseline 也已落地。该 recipe 支持单个 paired-end treatment
+sample 的 QC、genome alignment、BAM sort/index、narrow peak calling 和 MultiQC
+编译路径，代表性 WDL 已通过 WOMtool 91 校验；它不包含 control branch、peak
+annotation 或 motif analysis，也未通过真实 ChIP-seq 数据执行验证。
+
+当前 query set 包含 31 条 family-labeled query，覆盖 21 条 supported bulk RNA-seq、
+6 条 supported ChIP-seq 和 4 条 unsupported 负例。`lexical_v1` 的 Recipe Recall@1
+为 `0.8519`，两个 supported family 的 macro Recipe Recall@1 为 `0.9047`，Planner
+Context Tool Recall / Role Coverage 均为 `1.0000`。下一步按扩展计划实现最小
+`scrnaseq_qc_clustering` family；完成 scRNA-seq 与 variant calling 后再决定是否进入
+R3 vector / hybrid backend。
 
 R1/R2 仍属于受控 Catalog 内检索，不进入 P6 的未知工具发现边界。外部网页、论文、未知工具和 Candidate ToolSpec 的发现应继续归入 P6。
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -869,7 +869,7 @@ annotation 或 motif analysis，也未通过真实 ChIP-seq 数据执行验证�
 
 当前 query set 包含 31 条 family-labeled query，覆盖 21 条 supported bulk RNA-seq、
 6 条 supported ChIP-seq 和 4 条 unsupported 负例。`lexical_v1` 的 Recipe Recall@1
-为 `0.8519`，两个 supported family 的 macro Recipe Recall@1 为 `0.9047`，Planner
+为 `0.8519`，两个 supported family 的 macro Recipe Recall@1 为 `0.9048`，Planner
 Context Tool Recall / Role Coverage 均为 `1.0000`。下一步按扩展计划实现最小
 `scrnaseq_qc_clustering` family；完成 scRNA-seq 与 variant calling 后再决定是否进入
 R3 vector / hybrid backend。

--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ powershell -ExecutionPolicy Bypass -File scripts\dev_local.ps1
 # 结构化 Recipe Tool Plan 编译
 uv run main.py --input examples/rnaseq_deg_recipe_plan.json --output outputs/rnaseq_deg.wdl
 
+# ChIP-seq compile-ready 示例（工具执行状态仍为 unverified）
+uv run main.py --input examples/chipseq_peak_calling_recipe_plan.json --output outputs/chipseq_peaks.wdl
+
 # 自然语言规划并编译
 uv run main.py --prompt-file examples/rnaseq_deg_request.txt --output outputs/rnaseq_deg.wdl
 
@@ -348,6 +351,7 @@ Web 产品化拆解与当前 W6 收口计划详见：
 - [x] 在独立 Cromwell runner 上手动跑通真实 RNA-seq tiny e2e。
 - [x] 增加 P0 快速检查脚本，默认覆盖单测和代表性 WDL 编译/校验。
 - [x] 记录一份可复现的 [Cromwell e2e 验证摘要](./docs/p0-e2e-verification.md)，包括 workflow id、最终状态和 output keys。
+- [x] 增加正式 ChIP-seq peak-calling recipe，并建立带 workflow-family 指标的跨领域 RAG baseline。
 - [x] 实现 W2 run 事件、SQLite 展示级持久化和 SSE 事件流。
 - [x] 完成 W4 工作台：结构化示例 / 自然语言 run 创建、snapshot 轮询、SSE 时间线、Plan / IR / WDL / Diagnostics tabs 和失败态展示。
 - [x] 完成 [W5 DAG 可视化和历史详情页](./docs/w5-dag-history-plan.md)：真实 run 列表、详情回放、Workflow IR DAG、结构状态和失败 run 摘要。

--- a/docs/catalog-expansion-rag-plan.md
+++ b/docs/catalog-expansion-rag-plan.md
@@ -77,8 +77,8 @@ Recall@3 `1.0000`、Recipe MRR `0.9259`；Tool Recall@3 `0.7136`、Tool Recall@5
 `0.7500`。
 
 Family-level 结果显示：ChIP-seq Recipe Recall@1 为 `1.0000`，bulk RNA-seq 为
-`0.8095`；两个 supported family 的 macro Recipe Recall@1 为 `0.9047`，macro Tool
-Recall@3/5 分别为 `0.7097` / `0.8485`。这说明正式 recipe expansion 已能补齐 Planner
+`0.8095`；两个 supported family 的 macro Recipe Recall@1 为 `0.9048`，macro Tool
+Recall@3/5 分别为 `0.7097` / `0.8484`。这说明正式 recipe expansion 已能补齐 Planner
 context，但 lexical top-K 仍存在 crowding；同时 direct-match 风险进一步确认 Retriever
 不是 unsupported intent detector。当前只有两个 supported family，仍不足以据此启动
 R3 vector / hybrid backend。

--- a/docs/catalog-expansion-rag-plan.md
+++ b/docs/catalog-expansion-rag-plan.md
@@ -39,9 +39,10 @@ workflow 科学范围、参数数量和执行验证深度，不是 ToolSpec 契�
 
 当前 approved Catalog 包含：
 
-- 2 个 recipe，均属于 bulk RNA-seq family：
+- 3 个 recipe，覆盖 bulk RNA-seq 和 ChIP-seq 两个 family：
   - `rnaseq_differential_expression`
   - `rnaseq_reference_preparation`
+  - `chipseq_peak_calling`
 - 12 个 tool：
   - `fastp`
   - `salmon`
@@ -55,23 +56,32 @@ workflow 科学范围、参数数量和执行验证深度，不是 ToolSpec 契�
   - `bowtie2`
   - `samtools`
   - `macs2`
-- 24 条 retrieval query：
-  - 20 条 supported RNA-seq query。
-  - 4 条 unsupported negative query。
+- 31 条带 `workflow_family` 标签的 retrieval query：
+  - 21 条 supported bulk RNA-seq query。
+  - 6 条 supported ChIP-seq query。
+  - 4 条 unsupported negative query，覆盖 ChIP-seq peak annotation、scRNA-seq、
+    variant calling 和 metagenomics。
 
-新增的三个 ChIP-seq 工具已达到 compile-ready，但正式 Catalog 仍只有两个
-RNA-seq recipe。因此 ChIP-seq query 在 recipe/product capability 层面继续标记为
-unsupported，不能因为能直接召回 `macs2` 就声称 workflow 已受支持。
+`chipseq_peak_calling` 已达到 compile-ready：正式 example plan 可以经 Resolver、
+Analyzer 和 Renderer 生成 WDL，并已通过 WOMtool 91 syntax validation。其第一版范围
+是单个 paired-end treatment sample，经 `fastp -> bowtie2 -> samtools -> macs2 ->
+multiqc` 生成 sorted/indexed BAM、narrowPeak、summits 和 QC report。该 recipe 不包含
+control branch、peak annotation 或 motif analysis。`bowtie2`、`samtools` 和 `macs2`
+仍为 `unverified`，因此 compile-ready 不代表 workflow 已通过真实数据执行验证。
 
-在同一组 24 条 query 上，扩充后的 `lexical_v1` baseline 为：Tool Recall@8
-`0.8900`、Tool MRR `0.9583`、Raw Role Coverage `0.8933`；Planner Context Tool
-Recall 和 Planner Context Role Coverage 仍均为 `1.0000`。Raw 指标相较 9-tool
-Catalog 下降，说明更多跨 family tool 已开始挤占 lexical top-K，但 recipe expansion
-仍能保持当前 RNA-seq Planner context 完整。该中间状态不能作为 R3 决策依据，需在
-ChIP-seq recipe 和 family-labeled query 落地后重新评估。
+当前 31-query `lexical_v1` baseline 为：Recipe Recall@1 `0.8519`、Recipe
+Recall@3 `1.0000`、Recipe MRR `0.9259`；Tool Recall@3 `0.7136`、Tool Recall@5
+`0.8321`、Tool Recall@8 `0.9185`、Tool MRR `0.9506`、Raw Role Coverage
+`0.9210`。Planner Context Tool Recall 和 Planner Context Role Coverage 均为
+`1.0000`。Supported Fallback Rate 为 `0.0000`，Unsupported Direct-Match Rate 为
+`0.7500`。
 
-现有 `Recipe Recall@3` 和 `Tool Recall@8` 在 Catalog 较小时区分度有限。扩展
-Catalog 后应增加更严格的 top-K 和 family-level 指标。
+Family-level 结果显示：ChIP-seq Recipe Recall@1 为 `1.0000`，bulk RNA-seq 为
+`0.8095`；两个 supported family 的 macro Recipe Recall@1 为 `0.9047`，macro Tool
+Recall@3/5 分别为 `0.7097` / `0.8485`。这说明正式 recipe expansion 已能补齐 Planner
+context，但 lexical top-K 仍存在 crowding；同时 direct-match 风险进一步确认 Retriever
+不是 unsupported intent detector。当前只有两个 supported family，仍不足以据此启动
+R3 vector / hybrid backend。
 
 ## Goals
 
@@ -180,7 +190,7 @@ Catalog admission、compilation readiness 和 execution verification 是不同
 
 ### MVP Scope
 
-建议新增 recipe：
+已新增 recipe：
 
 ```text
 chipseq_peak_calling
@@ -222,21 +232,22 @@ paired-end ChIP-seq FASTQ
 
 ### Inputs And Outputs
 
-建议输入：
+第一版正式 recipe 输入：
 
-- sample ids。
-- paired-end ChIP FASTQ。
-- paired-end input/control FASTQ，第一版可以定义为 optional。
-- prebuilt genome index。
-- peak calling genome size 参数。
+- 单个 treatment sample 的 `raw_r1` / `raw_r2` paired-end ChIP-seq FASTQ。
+- `genome_index` Bowtie 2 genome index archive。
+- `genome_size`、`qvalue` 和 threads 等参数由对应 tool call 显式提供。
 
-建议输出：
+第一版 example plan 输出：
 
-- filtered FASTQ。
-- aligned and sorted BAM。
+- coordinate-sorted BAM。
 - BAM index。
-- peak table，例如 narrowPeak。
-- workflow QC summary。
+- MACS2 narrowPeak 和 summits。
+- MultiQC report。
+
+正式 recipe 暂不建模 control branch。底层 `macs2` ToolSpec 保留 optional
+`control_bam` 契约并有 rendering test，但单 treatment recipe 不因此宣称支持完整
+case/control ChIP-seq 设计。
 
 ### Deferred Scope
 
@@ -252,17 +263,18 @@ paired-end ChIP-seq FASTQ
 
 ### Retrieval Coverage
 
-ChIP-seq query 应覆盖：
+当前 ChIP-seq query 已覆盖：
 
 - peak calling。
 - transcription factor binding。
-- histone modification enrichment。
 - MACS2 显式请求。
-- input/control 描述。
 - 只描述 enriched genomic regions 而不写工具名。
 - 与 RNA-seq 共享的 QC/reporting 模糊请求。
+- 中英文、`ChIPseq` 变体和参数提示。
 
-当前 ChIP-seq unsupported negative query 在该 family 落地后转为 supported。
+原 `unsupported_chipseq_peak_calling_en` 已由多条 supported query 取代；仍未实现
+的 peak annotation / motif analysis 保留为
+`unsupported_chipseq_peak_annotation_en`，继续测试产品能力边界。
 
 ## Family 2: scRNA-seq QC And Clustering
 
@@ -416,12 +428,12 @@ supported。
 
 ### Query Set Growth
 
-建议分阶段扩展当前 24 条 fixture：
+Query fixture 从最初的 24 条单 family baseline 分阶段扩展：
 
 | Milestone | Supported queries | Unsupported queries | Focus |
 | --- | ---: | ---: | --- |
 | Current R2 | 20 | 4 | RNA-seq baseline |
-| After ChIP-seq | 30-36 | 4-6 | First cross-family ranking |
+| After ChIP-seq (current) | 27 | 4 | First cross-family ranking |
 | After scRNA-seq | 42-52 | 5-7 | Bulk/single-cell disambiguation |
 | After variant calling | 55-70 | 6-10 | Multi-family retrieval |
 
@@ -439,11 +451,10 @@ Query fixture 应增加显式 `workflow_family` 标签，例如：
 
 ```text
 bulk_rnaseq
-rnaseq_reference
 chipseq
 scrnaseq
-germline_variant
-unsupported
+variant_calling
+metagenomics
 ```
 
 该字段只用于 evaluation 分组，不替代 `expected_recipe`，也不进入 Planner
@@ -524,12 +535,17 @@ supported recall，但必须暴露 direct lexical match 和 fallback 风险。
 - 测试 recipe 生成的代表性 WDL 已通过 WOMtool 91 syntax validation。
 - 三个工具均按真实 evidence 标记为 `unverified`。
 
-### PR 3: ChIP-seq Recipe And Retrieval Baseline
+### PR 3: ChIP-seq Recipe And Retrieval Baseline（已实现）
 
-- 加入 `chipseq_peak_calling`。
-- 添加 example plan 和确定性 WDL validation。
-- 将 ChIP-seq negative query 转为 supported。
-- 增加 cross-family query 和 Recall@1/Tool Recall@3/5。
+- 已加入正式 `chipseq_peak_calling` 和结构化 example plan。
+- 代表性 WDL 已通过 WOMtool 91 syntax validation。
+- 已加入 6 条 supported ChIP-seq query，并将旧负例收窄为仍不支持的 peak
+  annotation / motif analysis。
+- Query schema 已增加 `workflow_family`；evaluation 已增加 Recipe Recall@1、Tool
+  Recall@3/5、family-level metrics、supported-family macro metrics 和 unsupported
+  direct-match rate。
+- 当前 baseline 覆盖 31 条 query、两个 supported workflow family；Planner Context
+  Tool Recall 和 Role Coverage 均为 `1.0000`。
 
 ### PR 4: scRNA-seq Catalog And Recipe
 
@@ -606,11 +622,13 @@ recipe resolution、Workflow IR 或 WDL 输出时，还应：
 
 ## Immediate Next Step
 
-Tool Capability And Verification Contract 及简化版 ChIP-seq Tool Catalog 已
-落地。下一项工作是实现 `chipseq_peak_calling` recipe 和首次跨 family retrieval
-baseline：连接 `fastp`、`bowtie2`、`samtools`、`macs2` 和 `multiqc`，增加
-example plan 与确定性 WDL validation，将现有 ChIP-seq negative query 转为
-supported，并加入 Recall@1、Tool Recall@3/5 和 `workflow_family` 分组。
+Tool Capability And Verification Contract、简化版 ChIP-seq Tool Catalog、正式
+`chipseq_peak_calling` recipe 和首次跨 family lexical baseline 已落地。下一项工作
+是 PR 4：设计并实现 `scrnaseq_qc_clustering` 的最小科学范围、工具契约与
+bulk/scRNA confusion query。
 
-ChIP-seq recipe 与 baseline 合并后，再按相同模式推进 scRNA-seq 与 variant
-calling。
+scRNA-seq 应沿用 compile-ready / execution-verification 分离策略。若项目维护 wrapper
+尚不具备完整 command、runtime、Dockerfile 和 smoke test 契约，应先明确选择
+retrieval-only fixture 或补齐 wrapper admission，不得把不可编译的占位工具写入正式
+Catalog。scRNA-seq family baseline 合并后，再推进 germline variant calling；完成四个
+family 后再作 R3 lexical / vector / hybrid 决策。

--- a/docs/r2-retrieval-evaluation-roadmap.md
+++ b/docs/r2-retrieval-evaluation-roadmap.md
@@ -174,6 +174,9 @@ tool 数量从 9 增加到 12，但 recipe 仍只有两个 RNA-seq workflow。�
 | `Unsupported Direct-Match Rate` | unsupported query 未触发 fallback 的比例 | 暴露 Retriever 不具备 intent rejection 的风险 |
 | `Family / Macro Metrics` | 分 family 统计，并仅对 supported families 做宏平均 | 防止样本量较大的 family 掩盖新 family 的排序问题 |
 
+Evaluation 在 per-query、family 和 macro 聚合期间保留原始浮点精度，只在最终公开
+artifact 边界统一舍入四位，避免从已舍入 family score 再求 macro average。
+
 初始目标不是追求高分，而是建立可重复 baseline：
 
 ```text
@@ -255,11 +258,11 @@ R2d ChIP-seq recipe 与 31-query cross-family baseline：
 | Query count | 31 | 21 | 7 | - |
 | Supported queries | 27 | 21 | 6 | 2 families |
 | Unsupported queries | 4 | 0 | 1 | - |
-| Recipe Recall@1 | 0.8519 | 0.8095 | 1.0000 | 0.9047 |
+| Recipe Recall@1 | 0.8519 | 0.8095 | 1.0000 | 0.9048 |
 | Recipe Recall@3 | 1.0000 | 1.0000 | 1.0000 | 1.0000 |
 | Recipe MRR | 0.9259 | 0.9048 | 1.0000 | 0.9524 |
 | Tool Recall@3 | 0.7136 | 0.7167 | 0.7028 | 0.7097 |
-| Tool Recall@5 | 0.8321 | 0.8191 | 0.8778 | 0.8485 |
+| Tool Recall@5 | 0.8321 | 0.8190 | 0.8778 | 0.8484 |
 | Tool Recall@8 | 0.9185 | 0.8952 | 1.0000 | 0.9476 |
 | Tool MRR | 0.9506 | 0.9365 | 1.0000 | 0.9683 |
 | Role Coverage | 0.9210 | 0.8984 | 1.0000 | 0.9492 |
@@ -283,7 +286,7 @@ R2d ChIP-seq recipe 与 31-query cross-family baseline：
 - R2d 中 ChIP-seq Recipe Recall@1 为 `1.0000`，说明新增 recipe 的 family intent
   在当前样本上可以稳定排首位；bulk RNA-seq Recipe Recall@1 为 `0.8095`，说明
   共享 QC、paired-end 和 reporting 词汇仍会造成首位排序 crowding。
-- R2d 的 macro Recipe Recall@1 为 `0.9047`，但当前只有两个 supported family，
+- R2d 的 macro Recipe Recall@1 为 `0.9048`，但当前只有两个 supported family，
   尚不足以决定引入 vector / hybrid backend。
 - `unsupported_chipseq_peak_annotation_en`、`unsupported_scrnaseq_clustering_en`
   和 `unsupported_variant_calling_en` 产生 direct lexical match，说明当前

--- a/docs/r2-retrieval-evaluation-roadmap.md
+++ b/docs/r2-retrieval-evaluation-roadmap.md
@@ -53,6 +53,7 @@ retrieval query set
   "id": "rnaseq_deg_basic_en",
   "query": "Run bulk RNA-seq differential expression from paired-end FASTQ files.",
   "supported": true,
+  "workflow_family": "bulk_rnaseq",
   "expected_recipe": "rnaseq_differential_expression",
   "expected_tools": ["fastp", "salmon", "tximport", "multiqc"],
   "expected_roles": {
@@ -69,18 +70,20 @@ retrieval query set
 `supported: false` 用于当前 approved Catalog 暂不支持的负例。负例不定义
 `expected_recipe`、`expected_tools` 或 `expected_roles`，因此不会拉低当前
 RNA-seq baseline recall；它们单独用于观察 fallback、误召回和未来 Catalog
-扩展需求。
+扩展需求。`workflow_family` 是必填 evaluation label，只用于分组统计，不进入
+Planner prompt，也不替代 `expected_recipe`。
 
 当前 query set 覆盖：
 
-- 英文 RNA-seq DEG 请求。
-- 中文 RNA-seq DEG 请求。
+- 英文和中文 bulk RNA-seq DEG / reference preparation 请求。
+- 英文和中文 ChIP-seq peak calling 请求。
 - 缩写表达，例如 DEG、RNAseq、bulk RNA。
 - 明确工具名请求，例如 use Salmon and DESeq2。
 - 只描述分析目标但不说工具名。
 - RNA-seq reference preparation，例如 Salmon index 和 GTF -> tx2gene。
 - edgeR 和 limma-voom 等 differential expression 替代后端。
-- Catalog 暂不支持的负例，例如 ChIP-seq、scRNA-seq、variant calling。
+- Catalog 暂不支持的负例，例如 ChIP-seq peak annotation、scRNA-seq、variant
+  calling 和 metagenomics。
 - 模糊需求，例如 quality report、quantification、gene-level counts。
 - 参数相关请求，例如 paired-end reads、contrast、threads。
 
@@ -137,24 +140,46 @@ tool 数量从 9 增加到 12，但 recipe 仍只有两个 RNA-seq workflow。�
 - 该中间 checkpoint 用于记录 top-K crowding，不用于决定 R3 backend。
 - 下一 checkpoint 应随 ChIP-seq recipe、family label 和跨 family query 一同建立。
 
+### R2d ChIP-seq Recipe And Cross-Family Baseline
+
+正式 Catalog 增加 `chipseq_peak_calling` 后，query set 扩展到 31 条并强制要求
+`workflow_family`：
+
+- 21 条 supported `bulk_rnaseq` query，其中包含一条 RNA-seq / ChIP-seq
+  cross-family confusion case。
+- 6 条 supported `chipseq` query，覆盖显式工具、隐式目标、中英文、参数和 QC
+  summary 表达。
+- 4 条 unsupported query；旧 ChIP-seq peak-calling 负例收窄为仍不支持的 peak
+  annotation / motif analysis。
+- 固定增加 Recipe Recall@1 和 Tool Recall@3/@5；动态 Recall@K 历史字段继续保留。
+- 输出 family-level metrics 和只对含 supported query 的 family 求平均的 macro
+  metrics。
+- `top_k_tools` 必须至少为 5，确保 Tool Recall@3/@5 有完整候选深度。
+
 ## Metrics
 
 第一版 eval 应保持轻量、可解释、可在本地稳定运行。
 
 | Metric | Definition | Purpose |
 | --- | --- | --- |
+| `Recipe Recall@1` | expected recipe 是否排在首位 | 在 recipe 数量接近动态 K 时衡量首选分类质量 |
 | `Recipe Recall@K` | expected recipe 是否出现在 top-K recipes | 判断分析类型召回是否可靠 |
+| `Tool Recall@3/@5` | expected tools 中有多少出现在固定 top-3 / top-5 | 比动态较大 K 更敏感地观察 catalog crowding |
 | `Tool Recall@K` | expected tools 中有多少出现在 top-K tools | 判断候选工具是否完整 |
 | `MRR` | 第一个正确 recipe 或 tool 的 reciprocal rank | 判断排序质量 |
 | `Role Coverage` | expected_roles 中每个 role 是否至少有一个正确 tool | 判断 workflow step 覆盖 |
 | `Planner Context Tool Recall` | raw retrieved tools 加上 retrieved recipes 的 allowed tools 后覆盖多少 expected tools | 判断 Planner prompt 候选上下文是否完整 |
 | `Planner Context Role Coverage` | Planner candidate context 是否覆盖每个 expected role | 区分 raw retriever miss 和 prompt context 可用性 |
 | `Fallback Rate` | 触发 fallback 的 query 占比 | 判断 catalog 覆盖和检索置信度 |
+| `Unsupported Direct-Match Rate` | unsupported query 未触发 fallback 的比例 | 暴露 Retriever 不具备 intent rejection 的风险 |
+| `Family / Macro Metrics` | 分 family 统计，并仅对 supported families 做宏平均 | 防止样本量较大的 family 掩盖新 family 的排序问题 |
 
 初始目标不是追求高分，而是建立可重复 baseline：
 
 ```text
 lexical_v1 Recipe Recall@3
+lexical_v1 Recipe Recall@1
+lexical_v1 Tool Recall@3/5
 lexical_v1 Tool Recall@8
 lexical_v1 Role Coverage
 lexical_v1 Planner Context Role Coverage
@@ -175,7 +200,9 @@ tests/test_retrieval_evaluation.py
 - 每条 query 的 retrieved recipes/tools。
 - missed expected recipe/tool。
 - aggregate metrics。
+- workflow-family metrics 和 supported-family macro metrics。
 - fallback queries。
+- unsupported direct-match queries。
 
 输出格式建议同时支持人类可读 summary 和 JSON artifact，便于后续前端或文档展示。
 
@@ -221,6 +248,26 @@ R2c ChIP-seq tool catalog 的 12-tool 中间 checkpoint：
 | Supported Fallback Rate | 0.0000 |
 | Unsupported Fallback Rate | 0.2500 |
 
+R2d ChIP-seq recipe 与 31-query cross-family baseline：
+
+| Metric | Overall | bulk_rnaseq | chipseq | Macro supported-family |
+| --- | ---: | ---: | ---: | ---: |
+| Query count | 31 | 21 | 7 | - |
+| Supported queries | 27 | 21 | 6 | 2 families |
+| Unsupported queries | 4 | 0 | 1 | - |
+| Recipe Recall@1 | 0.8519 | 0.8095 | 1.0000 | 0.9047 |
+| Recipe Recall@3 | 1.0000 | 1.0000 | 1.0000 | 1.0000 |
+| Recipe MRR | 0.9259 | 0.9048 | 1.0000 | 0.9524 |
+| Tool Recall@3 | 0.7136 | 0.7167 | 0.7028 | 0.7097 |
+| Tool Recall@5 | 0.8321 | 0.8191 | 0.8778 | 0.8485 |
+| Tool Recall@8 | 0.9185 | 0.8952 | 1.0000 | 0.9476 |
+| Tool MRR | 0.9506 | 0.9365 | 1.0000 | 0.9683 |
+| Role Coverage | 0.9210 | 0.8984 | 1.0000 | 0.9492 |
+| Planner Context Tool Recall | 1.0000 | 1.0000 | 1.0000 | 1.0000 |
+| Planner Context Role Coverage | 1.0000 | 1.0000 | 1.0000 | 1.0000 |
+| Fallback Rate | 0.0323 | 0.0000 | 0.0000 | - |
+| Unsupported Direct-Match Rate | 0.7500 | 0.0000 | 1.0000 | - |
+
 已知 baseline 观察：
 
 - 9-tool checkpoint 中，`rnaseq_deg_no_tool_names_en` 和
@@ -233,7 +280,12 @@ R2c ChIP-seq tool catalog 的 12-tool 中间 checkpoint：
 - Planner Context Tool Recall 和 Planner Context Role Coverage 均为 1.0000，
   说明当 top recipe 召回正确时，Planner prompt 中通过 recipe allowed tools
   补齐的候选上下文仍覆盖所需工具和 role。
-- `unsupported_chipseq_peak_calling_en`、`unsupported_scrnaseq_clustering_en`
+- R2d 中 ChIP-seq Recipe Recall@1 为 `1.0000`，说明新增 recipe 的 family intent
+  在当前样本上可以稳定排首位；bulk RNA-seq Recipe Recall@1 为 `0.8095`，说明
+  共享 QC、paired-end 和 reporting 词汇仍会造成首位排序 crowding。
+- R2d 的 macro Recipe Recall@1 为 `0.9047`，但当前只有两个 supported family，
+  尚不足以决定引入 vector / hybrid backend。
+- `unsupported_chipseq_peak_annotation_en`、`unsupported_scrnaseq_clustering_en`
   和 `unsupported_variant_calling_en` 产生 direct lexical match，说明当前
   lexical fallback 不是 unsupported intent detector；负例评估只用于暴露风险，
   不改变 full Catalog validation 边界。

--- a/docs/test-cases.md
+++ b/docs/test-cases.md
@@ -2016,6 +2016,8 @@ fixture，调用当前 Approved Catalog Retriever，并计算 expanded RNA-seq
 - `family_metrics` 包含 `bulk_rnaseq`、`chipseq`、`scrnaseq`、
   `variant_calling` 和 `metagenomics`。
 - bulk RNA-seq family 共 21 条 query；ChIP-seq family 共 7 条，其中 6 条 supported。
+- bulk RNA-seq Tool Recall@5 为 `0.8190`。
+- macro Recipe Recall@1 为 `0.9048`，macro Tool Recall@5 为 `0.8484`。
 - `macro_family_metrics` 中每个值都在 0 到 1 之间。
 
 覆盖点：
@@ -2025,6 +2027,24 @@ fixture，调用当前 Approved Catalog Retriever，并计算 expanded RNA-seq
 - Family-level 和 macro metrics 可以区分 overall 分数、样本量较大的 bulk RNA-seq
   family 与新增 ChIP-seq family。
 - Recipe expansion 保持 Planner context 完整，但 raw top-K crowding 仍可见。
+
+### `test_macro_family_metrics_use_unrounded_family_values`
+
+输入：
+
+- `family_a` 包含 21 条 supported query，其中 17 条 recipe rank-1 hit、4 条 miss。
+- `family_b` 包含 1 条 recipe rank-1 hit。
+
+执行：调用 `evaluate_retrieval_queries(..., retriever=fake_retriever)`。
+
+期望输出：
+
+- 对外暴露的 `family_a` Recipe Recall@1 舍入为 `0.8095`。
+- macro Recipe Recall@1 使用未舍入的 `17 / 21` 参与计算，最终为 `0.9048`，而非
+  从 `0.8095` 二次求平均得到的 `0.9047`。
+
+覆盖点：per-query、family 和 macro 聚合链路保持原始精度，只在最终 evaluation
+artifact 边界统一舍入四位。
 
 ### `test_computes_supported_metrics_and_tracks_unsupported_matches`
 

--- a/docs/test-cases.md
+++ b/docs/test-cases.md
@@ -309,9 +309,10 @@ OK (skipped=2)
 期望输出：
 
 - 至少包含一个 recipe。
-- 第一个 recipe id 为 `rnaseq_differential_expression`。
+- 可以按 id 找到 `rnaseq_differential_expression`。
 - `sample_ids` required input 类型为 `Array[String]`。
 - 第一个 step 的 allowed tools 为 `["fastp"]`。
+- recipe id 集合包含 `chipseq_peak_calling`。
 
 覆盖点：
 
@@ -418,11 +419,13 @@ OK (skipped=2)
 - HTTP status 为 `200`。
 - `catalog_service.list_recipes()` 被调用一次。
 - 响应中至少有一个 recipe。
-- 第一个 recipe id 为 `rnaseq_differential_expression`。
+- 响应 recipe id 集合同时包含 `rnaseq_differential_expression` 和
+  `chipseq_peak_calling`。
 
 覆盖点：
 
 - Recipe 列表 endpoint 复用 W0 catalog service。
+- API 测试不把按 id 排序的当前首项误当成稳定公开顺序契约。
 
 ### `test_get_recipe_uses_catalog_service`
 
@@ -1461,12 +1464,13 @@ OK (skipped=2)
   工具。
 - Catalog admission 不会被误写成 smoke-tested 或 e2e-validated。
 
-### `test_chipseq_tool_contracts_resolve_to_valid_renderable_ir`
+### `test_chipseq_peak_calling_recipe_resolves_to_valid_renderable_ir`
 
 输入：
 
-- 只存在于测试代码中的 `chipseq_tool_contract` recipe。
-- 串联 `bowtie2 -> samtools -> macs2` 的最小 Recipe Tool Plan。
+- 正式 `chipseq_peak_calling` recipe。
+- `examples/chipseq_peak_calling_recipe_plan.json` 中串联
+  `fastp -> bowtie2 -> samtools -> macs2 -> multiqc` 的单 treatment Recipe Tool Plan。
 - 当前正式 Tool Catalog。
 
 执行：
@@ -1478,27 +1482,30 @@ OK (skipped=2)
 期望输出：
 
 - Analyzer 返回 `is_valid=True`。
-- IR/WDL 包含 `bowtie2_align`、`samtools_prepare_bam` 和 `macs2_peaks`。
+- IR/WDL 包含 `fastp_qc`、`bowtie2_align`、`samtools_prepare_bam`、`macs2_peaks`
+  和 `multiqc_report`。
 - Bowtie 2 index archive 解包后解析 index prefix，并排除 `.rev.1.bt2` /
   `.rev.1.bt2l` reverse-index 文件。
 - `align.aligned_sam` 正确连接到 samtools，`prepare_bam.sorted_bam` 正确连接到
   MACS2。
 - samtools command 同一 task 内依次执行 coordinate sort 和 index。
 - 未提供 control 时 MACS2 command 不渲染 `-c`。
-- workflow 输出暴露 sorted BAM、BAI、narrowPeak 和 peak summits。
+- MultiQC 未显式传入 `report_files` 时，resolver 自动收集 fastp HTML/JSON、Bowtie 2
+  alignment log 和 MACS2 peak table 的 `multiqc_input` tags。
+- workflow 输出暴露 sorted BAM、BAI、narrowPeak、peak summits 和 MultiQC report。
 
 覆盖点：
 
-- 三个新增 ToolSpec 已通过 resolver/analyzer/renderer 阶段的结构和确定性渲染验证。
-- 测试 recipe 不写入正式 Recipe Catalog，因此不会提前宣称 ChIP-seq workflow
-  已受支持。
+- 正式 ChIP-seq recipe 已通过 resolver/analyzer/renderer 阶段的结构和确定性渲染验证。
+- 第一版产品能力明确限定为单个 paired-end treatment sample；不包含 control branch、
+  peak annotation 或 motif analysis。
 - Catalog output description 保留给 metadata/API/RAG；resolver 只将
   `type`、`value` 和 `tags` 投影到 Workflow IR OutputSpec。
 
-### `test_chipseq_tool_contract_wdl_passes_syntax_validation`
+### `test_chipseq_peak_calling_wdl_passes_syntax_validation`
 
-输入：与 `test_chipseq_tool_contracts_resolve_to_valid_renderable_ir` 相同的测试 recipe、
-Recipe Tool Plan 和正式 Tool Catalog。
+输入：与 `test_chipseq_peak_calling_recipe_resolves_to_valid_renderable_ir` 相同的正式
+recipe、example plan 和 Tool Catalog。
 
 执行：
 
@@ -1507,15 +1514,15 @@ Recipe Tool Plan 和正式 Tool Catalog。
 
 期望输出：validator 返回 `is_valid=True`；无可用 validator 时按现有测试约定跳过。
 
-覆盖点：为三个新增 ToolSpec 补齐 compile-ready policy 要求的外部 WDL 语法验证，
-并保持无 validator 环境下的纯 Catalog/Analyzer/Renderer 测试继续运行。
+覆盖点：为正式 ChIP-seq recipe 补齐外部 WDL 语法验证，并保持无 validator 环境下的
+纯 Catalog/Analyzer/Renderer 测试继续运行。
 
 本次 Catalog admission 使用 WOMtool 91 实际执行该测试并通过。
 
 ### `test_macs2_optional_control_is_rendered_when_provided`
 
-输入：在最小 ChIP-seq tool contract plan 中增加 `control_bam` workflow input，
-并传给 MACS2 call。
+输入：复制正式 ChIP-seq example plan，增加 `control_bam` workflow input，并传给
+MACS2 call。
 
 期望输出：
 
@@ -1525,7 +1532,7 @@ Recipe Tool Plan 和正式 Tool Catalog。
 - command 包含 `-c ~{control_bam}`。
 
 覆盖点：MACS2 control 输入的 optional schema 和 conditional command template
-保持一致。
+保持一致；该底层工具契约测试不扩张正式 recipe 的单 treatment 产品范围。
 
 ### `test_rnaseq_de_tool_alternatives_resolve_to_valid_wdl`
 
@@ -1866,11 +1873,26 @@ Recipe / Tool Catalog 中做确定性词法召回，不访问网络、不引入 
 - RAG / retrieval baseline 能覆盖同一 DE role 下的替代工具选择。
 - 新增 catalog 条目具备 aliases、description 和 role 词汇，便于自然语言 Planner 构造候选上下文。
 
-### `test_tokenizer_supports_rnaseq_variants_and_cjk_ngrams`
+### `test_retrieves_chipseq_recipe_and_compile_ready_tools`
+
+输入：显式请求 `fastp`、Bowtie 2、samtools、MACS2 和 MultiQC 的 paired-end
+ChIP-seq narrow peak calling query。
+
+期望输出：
+
+- 不触发 fallback。
+- 首位 recipe 为 `chipseq_peak_calling`。
+- top-8 tools 包含五个 recipe 工具。
+- `bowtie2`、`samtools` 和 `macs2` 的 execution verification 仍为 `unverified`。
+
+覆盖点：Retriever 可以召回新增 workflow family，同时 retrieval artifact 不会把
+compile-ready 工具误标记成已执行验证。
+
+### `test_tokenizer_supports_sequencing_variants_and_cjk_ngrams`
 
 输入：
 
-- 文本：`做差异表达 RNAseq`。
+- 文本：`做差异表达 RNAseq 和 ChIPseq`。
 
 执行：
 
@@ -1879,11 +1901,12 @@ Recipe / Tool Catalog 中做确定性词法召回，不访问网络、不引入 
 期望输出：
 
 - token 包含 `rna`、`seq` 和 `rnaseq`。
+- token 包含 `chip` 和 `chipseq`。
 - CJK token 包含单字 token 和重叠 2-gram，例如 `差`、`差异` 和 `表达`。
 
 覆盖点：
 
-- tokenization 在零新增依赖前提下支持常见 RNA-seq 写法和中文 query。
+- tokenization 在零新增依赖前提下支持常见 RNA-seq / ChIP-seq 写法和中文 query。
 
 ### `test_no_match_fallback_records_reason_and_approved_tools`
 
@@ -1932,8 +1955,8 @@ Recipe / Tool Catalog 中做确定性词法召回，不访问网络、不引入 
 
 该文件验证 R2 retrieval evaluation baseline。Evaluation 读取人工标注 query
 fixture，调用当前 Approved Catalog Retriever，并计算 expanded RNA-seq
-catalog baseline metrics。Fixture 不伪造工具；unsupported 负例单独统计，
-不污染当前 RNA-seq supported recall。
+与 ChIP-seq 的 cross-family baseline metrics。Fixture 不伪造工具；unsupported
+负例单独统计，不污染 supported recall。
 
 ### `test_loads_current_catalog_query_fixture`
 
@@ -1947,8 +1970,9 @@ catalog baseline metrics。Fixture 不伪造工具；unsupported 负例单独统
 
 期望输出：
 
-- fixture 共 24 条 query。
-- 20 条 `supported == True`，4 条 `supported == False`。
+- fixture 共 31 条 query。
+- 27 条 `supported == True`，4 条 `supported == False`。
+- 每条 query 都包含必填 `workflow_family`。
 - 第一条 query id 为 `rnaseq_deg_basic_en`。
 - 第一条 query 的 expected tools 包含 `fastp`。
 - fixture 包含 `rnaseq_reference_prep_basic_en`。
@@ -1956,11 +1980,14 @@ catalog baseline metrics。Fixture 不伪造工具；unsupported 负例单独统
 - 显式指定 DESeq2 的 query 将 `deseq2` 记录为 required expected tool。
 - 未指定 differential expression backend 的 query 允许 `deseq2`、`edger`
   或 `limma_voom` 任一 approved tool 覆盖该 role。
+- fixture 包含 6 条 supported ChIP-seq query；其 expected recipe 为
+  `chipseq_peak_calling`，expected tools 包含 `macs2`。
+- `unsupported_chipseq_peak_annotation_en` 保留为 ChIP-seq family 的负例。
 
 覆盖点：
 
 - R2 query set schema 可被稳定读取。
-- 当前 baseline 明确区分 supported RNA-seq 查询和 unsupported 负例。
+- 当前 baseline 明确区分 supported bulk RNA-seq / ChIP-seq 查询和 unsupported 负例。
 - Fixture 标注明确区分显式 tool intent 和通用 role intent。
 
 ### `test_evaluates_current_catalog_baseline`
@@ -1980,19 +2007,24 @@ catalog baseline metrics。Fixture 不伪造工具；unsupported 负例单独统
 - `strategy == "lexical_v1"`。
 - `top_k_recipes == 3`。
 - `top_k_tools == 8`。
-- `query_count == 24`。
-- `supported_query_count == 20`。
+- `query_count == 31`。
+- `supported_query_count == 27`。
 - `unsupported_query_count == 4`。
 - 每个 metric 均为 0 到 1 之间的稳定数值。
 - `planner_context_tool_recall == 1.0`。
 - `planner_context_role_coverage == 1.0`。
+- `family_metrics` 包含 `bulk_rnaseq`、`chipseq`、`scrnaseq`、
+  `variant_calling` 和 `metagenomics`。
+- bulk RNA-seq family 共 21 条 query；ChIP-seq family 共 7 条，其中 6 条 supported。
+- `macro_family_metrics` 中每个值都在 0 到 1 之间。
 
 覆盖点：
 
 - 当前 Catalog 可以生成可重复 retrieval baseline。
 - Baseline artifact 包含 per-query retrieval、miss、fallback 与 aggregate metrics。
-- 新增 ChIP-seq tools 挤动 raw top-K 时，现有 RNA-seq recipe expansion 仍保持
-  Planner context 完整；这不替代下一 PR 的 family-level baseline。
+- Family-level 和 macro metrics 可以区分 overall 分数、样本量较大的 bulk RNA-seq
+  family 与新增 ChIP-seq family。
+- Recipe expansion 保持 Planner context 完整，但 raw top-K crowding 仍可见。
 
 ### `test_computes_supported_metrics_and_tracks_unsupported_matches`
 
@@ -2010,9 +2042,10 @@ catalog baseline metrics。Fixture 不伪造工具；unsupported 负例单独统
 
 期望输出：
 
-- `recipe_recall_at_k == 0.5`。
+- `recipe_recall_at_1 == 0.5`，`recipe_recall_at_k == 0.5`。
 - `recipe_mrr == 0.5`。
-- `tool_recall_at_k == 0.25`。
+- `tool_recall_at_3 == 0.25`、`tool_recall_at_5 == 0.25`、
+  `tool_recall_at_k == 0.25`。
 - `tool_mrr == 0.5`。
 - `role_coverage == 0.25`。
 - `planner_context_tool_recall == 0.5`。
@@ -2020,7 +2053,10 @@ catalog baseline metrics。Fixture 不伪造工具；unsupported 负例单独统
 - `fallback_rate == 0.3333`。
 - `supported_fallback_rate == 0.5`。
 - `unsupported_fallback_rate == 0.0`。
+- `unsupported_direct_match_rate == 1.0`。
 - `unsupported_direct_match_query_ids == ["q3"]`。
+- `family_metrics` 分别记录 2 条 `bulk_rnaseq` 和 1 条 `chipseq` query。
+- 只对 supported family 求宏平均，`macro_family_metrics.recipe_recall_at_1 == 0.5`。
 - 第一条 query 的 `planner_context_tools` 包含 `deseq2`。
 - 第二条 query 的 `planner_context_missed_expected_tools == ["deseq2"]`。
 
@@ -2031,6 +2067,7 @@ catalog baseline metrics。Fixture 不伪造工具；unsupported 负例单独统
   区分 raw retrieval miss 和 Planner prompt candidate coverage。
 - Unsupported queries 不污染 supported recall，但会暴露 direct-match 风险。
 - Fallback rate 按 all / supported / unsupported 三个视角记录。
+- 固定 top-1/top-3/top-5 与 family macro 计算不依赖当前动态 K 的展示名称。
 
 ### `test_deduplicates_planner_context_tool_ids_from_multiple_versions`
 
@@ -2077,6 +2114,24 @@ catalog baseline metrics。Fixture 不伪造工具；unsupported 负例单独统
 
 - Unsupported negative cases 不能同时声明正例答案，避免 baseline 指标语义混乱。
 
+### `test_requires_workflow_family_in_query_schema`
+
+输入：一条缺少 `workflow_family` 的 supported query dict。
+
+期望输出：`RetrievalQuery.from_dict(...)` 抛出 `ValueError`，错误消息说明
+`workflow_family` 必须是非空字符串。
+
+覆盖点：每条 query 都可稳定进入 family-level 分组，避免静默归入隐式默认组。
+
+### `test_requires_enough_tool_results_for_fixed_recall_cutoffs`
+
+输入：一条合法 query，但调用 evaluation 时设置 `top_k_tools=4`。
+
+期望输出：抛出 `ValueError`，错误消息包含 `top_k_tools must be >= 5`。
+
+覆盖点：固定 Tool Recall@3/@5 不会在候选深度不足时产生看似有效、实际被截断的
+指标。
+
 ### `test_rejects_non_object_fixture_entries`
 
 输入：
@@ -2115,7 +2170,7 @@ catalog baseline metrics。Fixture 不伪造工具；unsupported 负例单独统
 期望输出：
 
 - 返回至少一个 recipe。
-- 第一个 recipe 的 `id` 为 `rnaseq_differential_expression`。
+- 从列表中可以按 `id` 找到 `rnaseq_differential_expression`。
 - 记录包含 `required_inputs` 和 `steps`。
 - 第一个 step 的 `id` 为 `qc`。
 - 第一个 step 的 `allowed_tools` 包含 `fastp`。
@@ -2145,6 +2200,20 @@ catalog baseline metrics。Fixture 不伪造工具；unsupported 负例单独统
 
 - Catalog service 能查询单个 recipe。
 - scatter metadata 被保留为 JSON-ready dict，便于后续 DAG/API 展示。
+
+### `test_get_chipseq_recipe_returns_compile_ready_steps`
+
+输入：recipe id `chipseq_peak_calling`。
+
+期望输出：
+
+- recipe name 为 `ChIP-seq peak calling`。
+- `genome_index` required input type 为 `File`。
+- step 顺序为 `qc`、`align_reads`、`sort_and_index`、`call_peaks`、`qc_report`。
+- `call_peaks` 只允许 `macs2`；`qc_report` 为 optional。
+
+覆盖点：正式 ChIP-seq recipe 可通过 Catalog service/API surface 查询，且 step role、
+顺序和 optional 边界保持可审计。
 
 ### `test_list_tools_returns_json_ready_tool_records`
 

--- a/examples/chipseq_peak_calling_recipe_plan.json
+++ b/examples/chipseq_peak_calling_recipe_plan.json
@@ -1,0 +1,79 @@
+{
+  "workflow": {
+    "name": "ChIPSeqPeakCalling",
+    "recipe": "chipseq_peak_calling",
+    "inputs": {
+      "raw_r1": "File",
+      "raw_r2": "File",
+      "genome_index": "File"
+    },
+    "tool_calls": [
+      {
+        "id": "qc",
+        "step": "qc",
+        "tool": "fastp",
+        "version": "1.3.3",
+        "inputs": {
+          "r1": "raw_r1",
+          "r2": "raw_r2"
+        },
+        "params": {
+          "thread": 4
+        }
+      },
+      {
+        "id": "align",
+        "step": "align_reads",
+        "tool": "bowtie2",
+        "version": "2.5.5",
+        "inputs": {
+          "r1": "qc.clean_r1",
+          "r2": "qc.clean_r2",
+          "index_archive": "genome_index"
+        },
+        "params": {
+          "threads": 8
+        }
+      },
+      {
+        "id": "prepare_bam",
+        "step": "sort_and_index",
+        "tool": "samtools",
+        "version": "1.24",
+        "inputs": {
+          "alignment": "align.aligned_sam"
+        },
+        "params": {
+          "threads": 4
+        }
+      },
+      {
+        "id": "peaks",
+        "step": "call_peaks",
+        "tool": "macs2",
+        "version": "2.2.9.1",
+        "inputs": {
+          "treatment_bam": "prepare_bam.sorted_bam"
+        },
+        "params": {
+          "genome_size": "hs",
+          "qvalue": 0.01
+        }
+      },
+      {
+        "id": "report",
+        "step": "qc_report",
+        "tool": "multiqc",
+        "version": "1.21",
+        "params": {}
+      }
+    ],
+    "outputs": {
+      "sorted_bam": "prepare_bam.sorted_bam",
+      "bam_index": "prepare_bam.bam_index",
+      "narrow_peaks": "peaks.narrow_peaks",
+      "peak_summits": "peaks.summits",
+      "multiqc_report": "report.multiqc_report"
+    }
+  }
+}

--- a/scripts/evaluate_retrieval.py
+++ b/scripts/evaluate_retrieval.py
@@ -45,7 +45,10 @@ def parse_args() -> argparse.Namespace:
         "--top-k-tools",
         type=int,
         default=DEFAULT_TOP_K_TOOLS,
-        help=f"Tool Recall@K cutoff. Default: {DEFAULT_TOP_K_TOOLS}",
+        help=(
+            "Tool Recall@K cutoff; must be at least 5 so fixed Recall@3/@5 "
+            f"can also be computed. Default: {DEFAULT_TOP_K_TOOLS}"
+        ),
     )
     parser.add_argument(
         "--json-output",
@@ -96,8 +99,11 @@ def _format_summary(evaluation: dict[str, Any]) -> str:
             f"({evaluation['supported_query_count']} supported, "
             f"{evaluation['unsupported_query_count']} unsupported)"
         ),
+        f"Recipe Recall@1: {metrics['recipe_recall_at_1']:.4f}",
         f"Recipe Recall@{evaluation['top_k_recipes']}: {metrics['recipe_recall_at_k']:.4f}",
         f"Recipe MRR: {metrics['recipe_mrr']:.4f}",
+        f"Tool Recall@3: {metrics['tool_recall_at_3']:.4f}",
+        f"Tool Recall@5: {metrics['tool_recall_at_5']:.4f}",
         f"Tool Recall@{evaluation['top_k_tools']}: {metrics['tool_recall_at_k']:.4f}",
         f"Tool MRR: {metrics['tool_mrr']:.4f}",
         f"Role Coverage: {metrics['role_coverage']:.4f}",
@@ -106,7 +112,26 @@ def _format_summary(evaluation: dict[str, Any]) -> str:
         f"Fallback Rate: {metrics['fallback_rate']:.4f}",
         f"Supported Fallback Rate: {metrics['supported_fallback_rate']:.4f}",
         f"Unsupported Fallback Rate: {metrics['unsupported_fallback_rate']:.4f}",
+        f"Unsupported Direct-Match Rate: {metrics['unsupported_direct_match_rate']:.4f}",
     ]
+
+    lines.append("Workflow-family metrics:")
+    for family_id, family in evaluation["family_metrics"].items():
+        family_values = family["metrics"]
+        lines.append(
+            f"  - {family_id}: {family['supported_query_count']} supported, "
+            f"{family['unsupported_query_count']} unsupported; "
+            f"Recipe@1={family_values['recipe_recall_at_1']:.4f}; "
+            f"Tool@3={family_values['tool_recall_at_3']:.4f}; "
+            f"Tool@5={family_values['tool_recall_at_5']:.4f}"
+        )
+    macro = evaluation["macro_family_metrics"]
+    lines.append(
+        "Macro supported-family metrics: "
+        f"Recipe@1={macro['recipe_recall_at_1']:.4f}; "
+        f"Tool@3={macro['tool_recall_at_3']:.4f}; "
+        f"Tool@5={macro['tool_recall_at_5']:.4f}"
+    )
 
     if evaluation["fallback_query_ids"]:
         lines.append("Fallback queries: " + ", ".join(evaluation["fallback_query_ids"]))

--- a/src/catalog/retrieval_eval.py
+++ b/src/catalog/retrieval_eval.py
@@ -15,6 +15,7 @@ from src.recipes.loader import RecipeCatalog
 
 DEFAULT_TOP_K_RECIPES = 3
 DEFAULT_TOP_K_TOOLS = 8
+METRIC_PRECISION = 4
 STRICT_TOOL_RECALL_CUTOFFS = (3, 5)
 MACRO_FAMILY_METRIC_KEYS = (
     "recipe_recall_at_1",
@@ -26,6 +27,16 @@ MACRO_FAMILY_METRIC_KEYS = (
     "tool_mrr",
     "role_coverage",
     "planner_context_tool_recall",
+    "planner_context_role_coverage",
+)
+PER_QUERY_METRIC_KEYS = (
+    "expected_recipe_reciprocal_rank",
+    "tool_recall_at_3",
+    "tool_recall_at_5",
+    "tool_recall",
+    "first_expected_tool_reciprocal_rank",
+    "planner_context_tool_recall",
+    "role_coverage",
     "planner_context_role_coverage",
 )
 RetrievalFn = Callable[[str, ToolCatalog, RecipeCatalog, int, int], dict[str, Any]]
@@ -141,6 +152,7 @@ def evaluate_retrieval_queries(
         result["id"] for result in unsupported_results if not result["fallback_used"]
     ]
     family_metrics = _family_metrics(per_query)
+    macro_family_metrics = _macro_family_metrics(family_metrics)
 
     return {
         "strategy": _first_strategy(per_query),
@@ -149,12 +161,12 @@ def evaluate_retrieval_queries(
         "query_count": len(per_query),
         "supported_query_count": len(supported_results),
         "unsupported_query_count": len(unsupported_results),
-        "metrics": _aggregate_metrics(per_query),
-        "family_metrics": family_metrics,
-        "macro_family_metrics": _macro_family_metrics(family_metrics),
+        "metrics": _round_metrics(_aggregate_metrics(per_query)),
+        "family_metrics": _round_family_metrics(family_metrics),
+        "macro_family_metrics": _round_metrics(macro_family_metrics),
         "fallback_query_ids": fallback_query_ids,
         "unsupported_direct_match_query_ids": unsupported_direct_match_query_ids,
-        "queries": per_query,
+        "queries": [_round_query_metrics(result) for result in per_query],
     }
 
 
@@ -342,6 +354,32 @@ def _macro_family_metrics(
     }
 
 
+def _round_metrics(metrics: dict[str, float]) -> dict[str, float]:
+    return {
+        metric: round(value, METRIC_PRECISION)
+        for metric, value in metrics.items()
+    }
+
+
+def _round_family_metrics(
+    family_metrics: dict[str, dict[str, Any]],
+) -> dict[str, dict[str, Any]]:
+    return {
+        family_id: {
+            **family,
+            "metrics": _round_metrics(family["metrics"]),
+        }
+        for family_id, family in family_metrics.items()
+    }
+
+
+def _round_query_metrics(result: dict[str, Any]) -> dict[str, Any]:
+    rounded = dict(result)
+    for metric in PER_QUERY_METRIC_KEYS:
+        rounded[metric] = round(rounded[metric], METRIC_PRECISION)
+    return rounded
+
+
 def _planner_context_tool_ids(
     retrieved_recipe_ids: list[str],
     retrieved_tool_ids: list[str],
@@ -428,13 +466,13 @@ def _mean(values: Any) -> float:
     concrete_values = list(values)
     if not concrete_values:
         return 0.0
-    return round(sum(concrete_values) / len(concrete_values), 4)
+    return sum(concrete_values) / len(concrete_values)
 
 
 def _rate(numerator: int, denominator: int) -> float:
     if denominator == 0:
         return 0.0
-    return round(numerator / denominator, 4)
+    return numerator / denominator
 
 
 def _required_str(data: dict[str, Any], key: str) -> str:

--- a/src/catalog/retrieval_eval.py
+++ b/src/catalog/retrieval_eval.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -15,6 +15,19 @@ from src.recipes.loader import RecipeCatalog
 
 DEFAULT_TOP_K_RECIPES = 3
 DEFAULT_TOP_K_TOOLS = 8
+STRICT_TOOL_RECALL_CUTOFFS = (3, 5)
+MACRO_FAMILY_METRIC_KEYS = (
+    "recipe_recall_at_1",
+    "recipe_recall_at_k",
+    "recipe_mrr",
+    "tool_recall_at_3",
+    "tool_recall_at_5",
+    "tool_recall_at_k",
+    "tool_mrr",
+    "role_coverage",
+    "planner_context_tool_recall",
+    "planner_context_role_coverage",
+)
 RetrievalFn = Callable[[str, ToolCatalog, RecipeCatalog, int, int], dict[str, Any]]
 
 
@@ -25,6 +38,7 @@ class RetrievalQuery:
     id: str
     query: str
     supported: bool
+    workflow_family: str
     expected_recipe: str | None
     expected_tools: list[str]
     expected_roles: dict[str, list[str]]
@@ -37,6 +51,7 @@ class RetrievalQuery:
         supported = data.get("supported", True)
         if not isinstance(supported, bool):
             raise ValueError(f"{query_id}: supported must be a boolean")
+        workflow_family = _required_str(data, "workflow_family")
 
         expected_recipe_raw = data.get("expected_recipe")
         if expected_recipe_raw is not None and not isinstance(expected_recipe_raw, str):
@@ -54,6 +69,7 @@ class RetrievalQuery:
             id=query_id,
             query=query,
             supported=supported,
+            workflow_family=workflow_family,
             expected_recipe=expected_recipe_raw,
             expected_tools=expected_tools,
             expected_roles=expected_roles,
@@ -99,8 +115,12 @@ def evaluate_retrieval_queries(
     """Evaluate a retriever over labeled current-catalog query fixtures."""
     if top_k_recipes < 1:
         raise ValueError("top_k_recipes must be >= 1")
-    if top_k_tools < 1:
-        raise ValueError("top_k_tools must be >= 1")
+    minimum_tool_cutoff = max(STRICT_TOOL_RECALL_CUTOFFS)
+    if top_k_tools < minimum_tool_cutoff:
+        raise ValueError(
+            f"top_k_tools must be >= {minimum_tool_cutoff} "
+            "to compute the fixed Tool Recall@3/@5 metrics"
+        )
 
     per_query = [
         _evaluate_one_query(
@@ -115,21 +135,12 @@ def evaluate_retrieval_queries(
     ]
 
     supported_results = [result for result in per_query if result["supported"]]
-    recipe_results = [result for result in supported_results if result["expected_recipe"]]
-    tool_results = [result for result in supported_results if result["expected_tools"]]
-    role_results = [result for result in supported_results if result["expected_roles"]]
-
     fallback_query_ids = [result["id"] for result in per_query if result["fallback_used"]]
-    supported_fallback_query_ids = [
-        result["id"] for result in supported_results if result["fallback_used"]
-    ]
     unsupported_results = [result for result in per_query if not result["supported"]]
-    unsupported_fallback_query_ids = [
-        result["id"] for result in unsupported_results if result["fallback_used"]
-    ]
     unsupported_direct_match_query_ids = [
         result["id"] for result in unsupported_results if not result["fallback_used"]
     ]
+    family_metrics = _family_metrics(per_query)
 
     return {
         "strategy": _first_strategy(per_query),
@@ -138,31 +149,9 @@ def evaluate_retrieval_queries(
         "query_count": len(per_query),
         "supported_query_count": len(supported_results),
         "unsupported_query_count": len(unsupported_results),
-        "metrics": {
-            "recipe_recall_at_k": _mean(
-                1.0 if result["expected_recipe_recalled"] else 0.0
-                for result in recipe_results
-            ),
-            "recipe_mrr": _mean(result["expected_recipe_reciprocal_rank"] for result in recipe_results),
-            "tool_recall_at_k": _mean(result["tool_recall"] for result in tool_results),
-            "tool_mrr": _mean(result["first_expected_tool_reciprocal_rank"] for result in tool_results),
-            "role_coverage": _mean(result["role_coverage"] for result in role_results),
-            "planner_context_tool_recall": _mean(
-                result["planner_context_tool_recall"] for result in tool_results
-            ),
-            "planner_context_role_coverage": _mean(
-                result["planner_context_role_coverage"] for result in role_results
-            ),
-            "fallback_rate": _rate(len(fallback_query_ids), len(per_query)),
-            "supported_fallback_rate": _rate(
-                len(supported_fallback_query_ids),
-                len(supported_results),
-            ),
-            "unsupported_fallback_rate": _rate(
-                len(unsupported_fallback_query_ids),
-                len(unsupported_results),
-            ),
-        },
+        "metrics": _aggregate_metrics(per_query),
+        "family_metrics": family_metrics,
+        "macro_family_metrics": _macro_family_metrics(family_metrics),
         "fallback_query_ids": fallback_query_ids,
         "unsupported_direct_match_query_ids": unsupported_direct_match_query_ids,
         "queries": per_query,
@@ -228,6 +217,7 @@ def _evaluate_one_query(
         "id": query.id,
         "query": query.query,
         "supported": query.supported,
+        "workflow_family": query.workflow_family,
         "expected_recipe": query.expected_recipe,
         "expected_tools": query.expected_tools,
         "expected_roles": query.expected_roles,
@@ -235,6 +225,7 @@ def _evaluate_one_query(
         "retrieved_tools": retrieved_tool_ids,
         "planner_context_tools": planner_context_tool_ids,
         "expected_recipe_recalled": expected_recipe_rank is not None,
+        "expected_recipe_recalled_at_1": expected_recipe_rank == 1,
         "expected_recipe_rank": expected_recipe_rank,
         "expected_recipe_reciprocal_rank": _reciprocal_rank(expected_recipe_rank),
         "missed_expected_recipe": (
@@ -243,6 +234,8 @@ def _evaluate_one_query(
         "recalled_expected_tools": recalled_tools,
         "missed_expected_tools": missed_tools,
         "tool_recall": _rate(len(recalled_tools), len(query.expected_tools)),
+        "tool_recall_at_3": _rank_recall(expected_tool_ranks.values(), 3),
+        "tool_recall_at_5": _rank_recall(expected_tool_ranks.values(), 5),
         "first_expected_tool_reciprocal_rank": _first_reciprocal_rank(expected_tool_ranks.values()),
         "planner_context_recalled_expected_tools": planner_context_recalled_tools,
         "planner_context_missed_expected_tools": planner_context_missed_tools,
@@ -260,6 +253,92 @@ def _evaluate_one_query(
         "fallback_reason": retrieval.get("fallback_reason"),
         "strategy": retrieval.get("strategy"),
         "notes": query.notes,
+    }
+
+
+def _aggregate_metrics(results: Sequence[dict[str, Any]]) -> dict[str, float]:
+    supported_results = [result for result in results if result["supported"]]
+    unsupported_results = [result for result in results if not result["supported"]]
+    recipe_results = [result for result in supported_results if result["expected_recipe"]]
+    tool_results = [result for result in supported_results if result["expected_tools"]]
+    role_results = [result for result in supported_results if result["expected_roles"]]
+
+    return {
+        "recipe_recall_at_1": _mean(
+            1.0 if result["expected_recipe_recalled_at_1"] else 0.0
+            for result in recipe_results
+        ),
+        "recipe_recall_at_k": _mean(
+            1.0 if result["expected_recipe_recalled"] else 0.0
+            for result in recipe_results
+        ),
+        "recipe_mrr": _mean(
+            result["expected_recipe_reciprocal_rank"] for result in recipe_results
+        ),
+        "tool_recall_at_3": _mean(result["tool_recall_at_3"] for result in tool_results),
+        "tool_recall_at_5": _mean(result["tool_recall_at_5"] for result in tool_results),
+        "tool_recall_at_k": _mean(result["tool_recall"] for result in tool_results),
+        "tool_mrr": _mean(
+            result["first_expected_tool_reciprocal_rank"] for result in tool_results
+        ),
+        "role_coverage": _mean(result["role_coverage"] for result in role_results),
+        "planner_context_tool_recall": _mean(
+            result["planner_context_tool_recall"] for result in tool_results
+        ),
+        "planner_context_role_coverage": _mean(
+            result["planner_context_role_coverage"] for result in role_results
+        ),
+        "fallback_rate": _rate(
+            sum(1 for result in results if result["fallback_used"]),
+            len(results),
+        ),
+        "supported_fallback_rate": _rate(
+            sum(1 for result in supported_results if result["fallback_used"]),
+            len(supported_results),
+        ),
+        "unsupported_fallback_rate": _rate(
+            sum(1 for result in unsupported_results if result["fallback_used"]),
+            len(unsupported_results),
+        ),
+        "unsupported_direct_match_rate": _rate(
+            sum(1 for result in unsupported_results if not result["fallback_used"]),
+            len(unsupported_results),
+        ),
+    }
+
+
+def _family_metrics(results: Sequence[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    families: dict[str, list[dict[str, Any]]] = {}
+    for result in results:
+        families.setdefault(result["workflow_family"], []).append(result)
+
+    metrics: dict[str, dict[str, Any]] = {}
+    for family, family_results in sorted(families.items()):
+        supported_results = [result for result in family_results if result["supported"]]
+        unsupported_results = [result for result in family_results if not result["supported"]]
+        metrics[family] = {
+            "query_count": len(family_results),
+            "supported_query_count": len(supported_results),
+            "unsupported_query_count": len(unsupported_results),
+            "query_ids": [result["id"] for result in family_results],
+            "supported_query_ids": [result["id"] for result in supported_results],
+            "unsupported_query_ids": [result["id"] for result in unsupported_results],
+            "metrics": _aggregate_metrics(family_results),
+        }
+    return metrics
+
+
+def _macro_family_metrics(
+    family_metrics: dict[str, dict[str, Any]],
+) -> dict[str, float]:
+    supported_family_metrics = [
+        family["metrics"]
+        for family in family_metrics.values()
+        if family["supported_query_count"] > 0
+    ]
+    return {
+        metric: _mean(family[metric] for family in supported_family_metrics)
+        for metric in MACRO_FAMILY_METRIC_KEYS
     }
 
 
@@ -330,11 +409,19 @@ def _reciprocal_rank(rank: int | None) -> float:
     return 0.0 if rank is None else 1.0 / rank
 
 
-def _first_reciprocal_rank(ranks: Sequence[int | None]) -> float:
+def _first_reciprocal_rank(ranks: Iterable[int | None]) -> float:
     concrete_ranks = [rank for rank in ranks if rank is not None]
     if not concrete_ranks:
         return 0.0
     return 1.0 / min(concrete_ranks)
+
+
+def _rank_recall(ranks: Iterable[int | None], cutoff: int) -> float:
+    rank_list = list(ranks)
+    return _rate(
+        sum(1 for rank in rank_list if rank is not None and rank <= cutoff),
+        len(rank_list),
+    )
 
 
 def _mean(values: Any) -> float:

--- a/src/catalog/retriever.py
+++ b/src/catalog/retriever.py
@@ -106,7 +106,8 @@ def tokenize_for_retrieval(text: str) -> list[str]:
 
 
 def _normalize_common_variants(text: str) -> str:
-    return re.sub(r"\brnaseq\b", "rna seq rnaseq", text)
+    normalized = re.sub(r"\brnaseq\b", "rna seq rnaseq", text)
+    return re.sub(r"\bchipseq\b", "chip seq chipseq", normalized)
 
 
 def _cjk_sequences(text: str) -> list[str]:

--- a/src/recipes/definitions/chipseq_peak_calling.yaml
+++ b/src/recipes/definitions/chipseq_peak_calling.yaml
@@ -1,0 +1,47 @@
+id: chipseq_peak_calling
+name: ChIP-seq peak calling
+description: Align paired-end ChIP-seq reads and call narrow enriched regions for one treatment sample.
+aliases:
+  - ChIP-seq peak workflow
+  - ChIPseq peak calling
+  - chromatin immunoprecipitation sequencing
+  - MACS2 peak workflow
+  - transcription factor binding peak detection
+
+required_inputs:
+  raw_r1:
+    type: File
+    description: First raw paired-end ChIP-seq FASTQ file for the treatment sample.
+  raw_r2:
+    type: File
+    description: Second raw paired-end ChIP-seq FASTQ file for the treatment sample.
+  genome_index:
+    type: File
+    description: Gzip-compressed tar archive containing the Bowtie 2 genome index.
+
+steps:
+  - id: qc
+    role: read_quality_control
+    allowed_tools:
+      - fastp
+
+  - id: align_reads
+    role: genome_alignment
+    allowed_tools:
+      - bowtie2
+
+  - id: sort_and_index
+    role: bam_sort_and_index
+    allowed_tools:
+      - samtools
+
+  - id: call_peaks
+    role: peak_calling
+    allowed_tools:
+      - macs2
+
+  - id: qc_report
+    role: quality_control_summary
+    optional: true
+    allowed_tools:
+      - multiqc

--- a/tests/api/test_models.py
+++ b/tests/api/test_models.py
@@ -174,10 +174,13 @@ class CatalogDtoTests(unittest.TestCase):
         response = RecipeListResponse.model_validate({"recipes": list_recipes()})
 
         self.assertGreaterEqual(len(response.recipes), 1)
-        recipe = response.recipes[0]
+        recipe = next(
+            recipe for recipe in response.recipes if recipe.id == "rnaseq_differential_expression"
+        )
         self.assertEqual(recipe.id, "rnaseq_differential_expression")
         self.assertEqual(recipe.required_inputs["sample_ids"].type, "Array[String]")
         self.assertEqual(recipe.steps[0].allowed_tools, ["fastp"])
+        self.assertIn("chipseq_peak_calling", {recipe.id for recipe in response.recipes})
 
     def test_tool_list_response_accepts_catalog_service_records(self):
         response = ToolListResponse.model_validate({"tools": list_tools()})

--- a/tests/api/test_routes.py
+++ b/tests/api/test_routes.py
@@ -39,7 +39,9 @@ class ApiRouteTests(unittest.TestCase):
         service.assert_called_once_with()
         body = response.json()
         self.assertGreaterEqual(len(body["recipes"]), 1)
-        self.assertEqual(body["recipes"][0]["id"], "rnaseq_differential_expression")
+        recipe_ids = {recipe["id"] for recipe in body["recipes"]}
+        self.assertIn("rnaseq_differential_expression", recipe_ids)
+        self.assertIn("chipseq_peak_calling", recipe_ids)
 
     def test_get_recipe_not_found(self):
         with patch(

--- a/tests/fixtures/retrieval_queries.json
+++ b/tests/fixtures/retrieval_queries.json
@@ -3,6 +3,7 @@
     "id": "rnaseq_deg_basic_en",
     "query": "Run bulk RNA-seq differential expression from paired-end FASTQ files with QC, transcript quantification, gene-level counts, and a workflow summary report.",
     "supported": true,
+    "workflow_family": "bulk_rnaseq",
     "expected_recipe": "rnaseq_differential_expression",
     "expected_tools": ["fastp", "salmon", "tximport", "multiqc"],
     "expected_roles": {
@@ -18,6 +19,7 @@
     "id": "rnaseq_deg_explicit_tools_en",
     "query": "Build a workflow using fastp, Salmon, tximport, DESeq2, and MultiQC for bulk RNA-seq differential expression.",
     "supported": true,
+    "workflow_family": "bulk_rnaseq",
     "expected_recipe": "rnaseq_differential_expression",
     "expected_tools": ["fastp", "salmon", "tximport", "deseq2", "multiqc"],
     "expected_roles": {
@@ -33,6 +35,7 @@
     "id": "rnaseq_deg_cn_mixed_tools",
     "query": "为 bulk RNAseq 样本做差异表达分析，使用 fastp 清理 FASTQ、Salmon 定量、tximport 汇总到 gene counts、DESeq2 输出 DEG 表，并生成 MultiQC 报告。",
     "supported": true,
+    "workflow_family": "bulk_rnaseq",
     "expected_recipe": "rnaseq_differential_expression",
     "expected_tools": ["fastp", "salmon", "tximport", "deseq2", "multiqc"],
     "expected_roles": {
@@ -48,6 +51,7 @@
     "id": "rnaseq_deg_abbrev_en",
     "query": "Create a DEG workflow for bulk RNAseq paired-end reads, including adapter trimming, transcript quantification, transcript-to-gene summarization, and a QC report.",
     "supported": true,
+    "workflow_family": "bulk_rnaseq",
     "expected_recipe": "rnaseq_differential_expression",
     "expected_tools": ["fastp", "salmon", "tximport", "multiqc"],
     "expected_roles": {
@@ -63,6 +67,7 @@
     "id": "rnaseq_deg_no_tool_names_en",
     "query": "Identify differentially expressed genes from RNA sequencing FASTQs and create a workflow-level quality-control summary.",
     "supported": true,
+    "workflow_family": "bulk_rnaseq",
     "expected_recipe": "rnaseq_differential_expression",
     "expected_tools": ["fastp", "salmon", "tximport", "multiqc"],
     "expected_roles": {
@@ -78,6 +83,7 @@
     "id": "rnaseq_deg_salmon_deseq2_en",
     "query": "Use Salmon quantification and DESeq2 for differential expression on paired-end bulk RNA-seq data, starting from raw FASTQs.",
     "supported": true,
+    "workflow_family": "bulk_rnaseq",
     "expected_recipe": "rnaseq_differential_expression",
     "expected_tools": ["fastp", "salmon", "tximport", "deseq2"],
     "expected_roles": {
@@ -92,6 +98,7 @@
     "id": "rnaseq_quant_gene_counts_en",
     "query": "Quantify bulk RNA-seq reads and produce a transcript-to-gene count matrix from quant.sf files.",
     "supported": true,
+    "workflow_family": "bulk_rnaseq",
     "expected_recipe": "rnaseq_differential_expression",
     "expected_tools": ["salmon", "tximport"],
     "expected_roles": {
@@ -104,6 +111,7 @@
     "id": "rnaseq_quality_report_en",
     "query": "Prepare a quality report for paired FASTQ RNA-seq samples with adapter trimming and a workflow summary.",
     "supported": true,
+    "workflow_family": "bulk_rnaseq",
     "expected_recipe": "rnaseq_differential_expression",
     "expected_tools": ["fastp", "multiqc"],
     "expected_roles": {
@@ -116,6 +124,7 @@
     "id": "rnaseq_params_threads_contrast_en",
     "query": "Run RNA-seq DEG analysis with 8 threads for quantification and a DESeq2 contrast named condition.",
     "supported": true,
+    "workflow_family": "bulk_rnaseq",
     "expected_recipe": "rnaseq_differential_expression",
     "expected_tools": ["salmon", "tximport", "deseq2"],
     "expected_roles": {
@@ -129,6 +138,7 @@
     "id": "rnaseq_inputs_metadata_en",
     "query": "Differential expression from sample metadata, a tx2gene mapping table, and a Salmon transcriptome index for paired-end RNA-seq.",
     "supported": true,
+    "workflow_family": "bulk_rnaseq",
     "expected_recipe": "rnaseq_differential_expression",
     "expected_tools": ["fastp", "salmon", "tximport"],
     "expected_roles": {
@@ -143,6 +153,7 @@
     "id": "rnaseq_gene_counts_cn_mixed",
     "query": "从 Salmon quant.sf 生成 gene-level counts，再做 DESeq2 差异分析和 QC 汇总。",
     "supported": true,
+    "workflow_family": "bulk_rnaseq",
     "expected_recipe": "rnaseq_differential_expression",
     "expected_tools": ["tximport", "deseq2", "multiqc"],
     "expected_roles": {
@@ -156,6 +167,7 @@
     "id": "rnaseq_multiqc_logs_en",
     "query": "Aggregate fastp JSON and HTML reports plus Salmon logs into MultiQC for an RNA-seq DEG workflow.",
     "supported": true,
+    "workflow_family": "bulk_rnaseq",
     "expected_recipe": "rnaseq_differential_expression",
     "expected_tools": ["fastp", "salmon", "multiqc"],
     "expected_roles": {
@@ -169,6 +181,7 @@
     "id": "rnaseq_reference_prep_basic_en",
     "query": "Prepare RNA-seq reference artifacts by building a Salmon transcriptome index from FASTA and extracting tx2gene from a GTF annotation.",
     "supported": true,
+    "workflow_family": "bulk_rnaseq",
     "expected_recipe": "rnaseq_reference_preparation",
     "expected_tools": ["salmon_index", "gtf_tx2gene"],
     "expected_roles": {
@@ -181,6 +194,7 @@
     "id": "rnaseq_reference_prep_cn_mixed",
     "query": "准备 RNA-seq reference：从 transcriptome FASTA 构建 Salmon index，并从 GTF 提取 tx2gene 映射表。",
     "supported": true,
+    "workflow_family": "bulk_rnaseq",
     "expected_recipe": "rnaseq_reference_preparation",
     "expected_tools": ["salmon_index", "gtf_tx2gene"],
     "expected_roles": {
@@ -193,6 +207,7 @@
     "id": "rnaseq_salmon_index_only_en",
     "query": "Build a Salmon index archive from a transcriptome FASTA for RNA-seq quantification.",
     "supported": true,
+    "workflow_family": "bulk_rnaseq",
     "expected_recipe": "rnaseq_reference_preparation",
     "expected_tools": ["salmon_index"],
     "expected_roles": {
@@ -204,6 +219,7 @@
     "id": "rnaseq_gtf_tx2gene_only_en",
     "query": "Extract a transcript-to-gene mapping table from a GTF annotation for tximport.",
     "supported": true,
+    "workflow_family": "bulk_rnaseq",
     "expected_recipe": "rnaseq_reference_preparation",
     "expected_tools": ["gtf_tx2gene"],
     "expected_roles": {
@@ -215,6 +231,7 @@
     "id": "rnaseq_deg_edger_en",
     "query": "Use edgeR quasi-likelihood testing for bulk RNA-seq differential expression from a gene count matrix.",
     "supported": true,
+    "workflow_family": "bulk_rnaseq",
     "expected_recipe": "rnaseq_differential_expression",
     "expected_tools": ["edger"],
     "expected_roles": {
@@ -226,6 +243,7 @@
     "id": "rnaseq_deg_limma_voom_en",
     "query": "Run limma voom differential expression for bulk RNA-seq gene counts and sample group metadata.",
     "supported": true,
+    "workflow_family": "bulk_rnaseq",
     "expected_recipe": "rnaseq_differential_expression",
     "expected_tools": ["limma_voom"],
     "expected_roles": {
@@ -237,6 +255,7 @@
     "id": "rnaseq_deg_alternative_backends_en",
     "query": "Evaluate bulk RNA-seq differential expression with edgeR or limma voom instead of DESeq2.",
     "supported": true,
+    "workflow_family": "bulk_rnaseq",
     "expected_recipe": "rnaseq_differential_expression",
     "expected_tools": ["edger", "limma_voom"],
     "expected_roles": {
@@ -248,6 +267,7 @@
     "id": "rnaseq_deg_alternative_backends_cn",
     "query": "bulk RNA-seq 差异表达不想用 DESeq2，想试 edgeR 或 limma voom。",
     "supported": true,
+    "workflow_family": "bulk_rnaseq",
     "expected_recipe": "rnaseq_differential_expression",
     "expected_tools": ["edger", "limma_voom"],
     "expected_roles": {
@@ -256,18 +276,20 @@
     "notes": "Chinese request for alternative differential expression backends."
   },
   {
-    "id": "unsupported_chipseq_peak_calling_en",
-    "query": "Run ChIP-seq peak calling with MACS2 and generate peak annotation tracks.",
+    "id": "unsupported_chipseq_peak_annotation_en",
+    "query": "Annotate MACS2 ChIP-seq peaks to nearby genes and generate motif tracks.",
     "supported": false,
+    "workflow_family": "chipseq",
     "expected_recipe": null,
     "expected_tools": [],
     "expected_roles": {},
-    "notes": "Negative case: ChIP-seq is outside the current approved catalog."
+    "notes": "Negative case: peak annotation and motif analysis are outside the current ChIP-seq recipe."
   },
   {
     "id": "unsupported_scrnaseq_clustering_en",
     "query": "Analyze single-cell RNA-seq UMI counts with normalization, clustering, marker genes, and UMAP plots.",
     "supported": false,
+    "workflow_family": "scrnaseq",
     "expected_recipe": null,
     "expected_tools": [],
     "expected_roles": {},
@@ -277,6 +299,7 @@
     "id": "unsupported_variant_calling_en",
     "query": "Call germline variants from WES BAM files and produce a filtered VCF.",
     "supported": false,
+    "workflow_family": "variant_calling",
     "expected_recipe": null,
     "expected_tools": [],
     "expected_roles": {},
@@ -286,9 +309,115 @@
     "id": "unsupported_metagenomics_cn",
     "query": "做宏基因组物种注释和丰度分析，输出 taxonomy profile 和可视化报告。",
     "supported": false,
+    "workflow_family": "metagenomics",
     "expected_recipe": null,
     "expected_tools": [],
     "expected_roles": {},
     "notes": "Negative case: metagenomics is outside the current approved catalog."
+  },
+  {
+    "id": "chipseq_peak_calling_basic_en",
+    "query": "Build a paired-end ChIP-seq workflow from raw FASTQs through read QC, genome alignment, sorted indexed BAM, narrow peak calling, and a summary report.",
+    "supported": true,
+    "workflow_family": "chipseq",
+    "expected_recipe": "chipseq_peak_calling",
+    "expected_tools": ["fastp", "bowtie2", "samtools", "macs2", "multiqc"],
+    "expected_roles": {
+      "read_quality_control": ["fastp"],
+      "genome_alignment": ["bowtie2"],
+      "bam_sort_and_index": ["samtools"],
+      "peak_calling": ["macs2"],
+      "quality_control_summary": ["multiqc"]
+    },
+    "notes": "Complete supported ChIP-seq request without explicit tool names."
+  },
+  {
+    "id": "chipseq_peak_calling_explicit_tools_en",
+    "query": "Use fastp, Bowtie 2, samtools, MACS2, and MultiQC to call narrow ChIP-seq peaks from paired-end treatment reads.",
+    "supported": true,
+    "workflow_family": "chipseq",
+    "expected_recipe": "chipseq_peak_calling",
+    "expected_tools": ["fastp", "bowtie2", "samtools", "macs2", "multiqc"],
+    "expected_roles": {
+      "read_quality_control": ["fastp"],
+      "genome_alignment": ["bowtie2"],
+      "bam_sort_and_index": ["samtools"],
+      "peak_calling": ["macs2"],
+      "quality_control_summary": ["multiqc"]
+    },
+    "notes": "Supported ChIP-seq request naming every approved tool."
+  },
+  {
+    "id": "chipseq_peak_calling_cn_mixed",
+    "query": "对 paired-end ChIPseq FASTQ 做 fastp 质控，用 Bowtie2 比对基因组，samtools 排序建索引，再用 MACS2 call peaks 并汇总 MultiQC。",
+    "supported": true,
+    "workflow_family": "chipseq",
+    "expected_recipe": "chipseq_peak_calling",
+    "expected_tools": ["fastp", "bowtie2", "samtools", "macs2", "multiqc"],
+    "expected_roles": {
+      "read_quality_control": ["fastp"],
+      "genome_alignment": ["bowtie2"],
+      "bam_sort_and_index": ["samtools"],
+      "peak_calling": ["macs2"],
+      "quality_control_summary": ["multiqc"]
+    },
+    "notes": "Chinese ChIPseq request with English tool and artifact names."
+  },
+  {
+    "id": "chipseq_peak_calling_goal_only_en",
+    "query": "Find narrow transcription-factor binding regions from paired-end chromatin immunoprecipitation sequencing reads aligned to a reference genome.",
+    "supported": true,
+    "workflow_family": "chipseq",
+    "expected_recipe": "chipseq_peak_calling",
+    "expected_tools": ["bowtie2", "samtools", "macs2"],
+    "expected_roles": {
+      "genome_alignment": ["bowtie2"],
+      "bam_sort_and_index": ["samtools"],
+      "peak_calling": ["macs2"]
+    },
+    "notes": "Goal-oriented request using domain language instead of tool names."
+  },
+  {
+    "id": "chipseq_peak_calling_params_en",
+    "query": "Align paired-end ChIP-seq reads with 8 threads, sort and index the BAM, then call MACS2 narrow peaks at q-value 0.01.",
+    "supported": true,
+    "workflow_family": "chipseq",
+    "expected_recipe": "chipseq_peak_calling",
+    "expected_tools": ["bowtie2", "samtools", "macs2"],
+    "expected_roles": {
+      "genome_alignment": ["bowtie2"],
+      "bam_sort_and_index": ["samtools"],
+      "peak_calling": ["macs2"]
+    },
+    "notes": "Supported request with alignment-thread and peak-threshold hints."
+  },
+  {
+    "id": "chipseq_qc_summary_en",
+    "query": "Trim paired ChIP-seq FASTQs and combine read QC, genome alignment logs, and peak-calling statistics into a MultiQC report.",
+    "supported": true,
+    "workflow_family": "chipseq",
+    "expected_recipe": "chipseq_peak_calling",
+    "expected_tools": ["fastp", "bowtie2", "macs2", "multiqc"],
+    "expected_roles": {
+      "read_quality_control": ["fastp"],
+      "genome_alignment": ["bowtie2"],
+      "peak_calling": ["macs2"],
+      "quality_control_summary": ["multiqc"]
+    },
+    "notes": "Supported request focused on tagged QC artifacts and summary reporting."
+  },
+  {
+    "id": "cross_family_rnaseq_not_chipseq_en",
+    "query": "Use Salmon, tximport, and DESeq2 for RNA-seq expression analysis rather than MACS2 ChIP-seq peak calling.",
+    "supported": true,
+    "workflow_family": "bulk_rnaseq",
+    "expected_recipe": "rnaseq_differential_expression",
+    "expected_tools": ["salmon", "tximport", "deseq2"],
+    "expected_roles": {
+      "expression_quantification": ["salmon"],
+      "transcript_to_gene_count_summary": ["tximport"],
+      "differential_expression": ["deseq2"]
+    },
+    "notes": "Cross-family confusion case that explicitly distinguishes RNA-seq from ChIP-seq."
   }
 ]

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1,4 +1,5 @@
 import copy
+import json
 import unittest
 from pathlib import Path
 from typing import Any
@@ -9,14 +10,13 @@ from src.analyzer import analyze_workflow_ir
 from src.catalog import load_tool_catalog, resolve_tool_plan
 from src.catalog.schema import ExecutionVerificationSpec, ToolSpec
 from src.recipes import load_recipe_catalog
-from src.recipes.loader import RecipeCatalog
-from src.recipes.schema import RecipeSpec
 from src.renderers import render_wdl
 from src.schema import flatten_workflow_calls
 from src.tools.validator import wdl_validator, wdl_validator_available
 
 
 CATALOG_TOOLS_DIR = Path(__file__).resolve().parents[1] / "src" / "catalog" / "tools"
+EXAMPLES_DIR = Path(__file__).resolve().parents[1] / "examples"
 
 
 def sample_rnaseq_tool_plan() -> dict[str, Any]:
@@ -149,86 +149,10 @@ def sample_rnaseq_reference_prep_plan() -> dict[str, Any]:
     }
 
 
-def chipseq_tool_contract_recipe_catalog() -> RecipeCatalog:
-    recipe = RecipeSpec.model_validate(
-        {
-            "id": "chipseq_tool_contract",
-            "name": "ChIP-seq tool contract test",
-            "required_inputs": {
-                "r1": {"type": "File"},
-                "r2": {"type": "File"},
-                "genome_index": {"type": "File"},
-            },
-            "steps": [
-                {
-                    "id": "align_reads",
-                    "role": "genome_alignment",
-                    "allowed_tools": ["bowtie2"],
-                },
-                {
-                    "id": "sort_and_index",
-                    "role": "bam_sort_and_index",
-                    "allowed_tools": ["samtools"],
-                },
-                {
-                    "id": "call_peaks",
-                    "role": "peak_calling",
-                    "allowed_tools": ["macs2"],
-                },
-            ],
-        }
+def sample_chipseq_peak_calling_plan() -> dict[str, Any]:
+    return json.loads(
+        (EXAMPLES_DIR / "chipseq_peak_calling_recipe_plan.json").read_text(encoding="utf-8")
     )
-    return RecipeCatalog({recipe.id: recipe})
-
-
-def sample_chipseq_tool_contract_plan() -> dict[str, Any]:
-    return {
-        "workflow": {
-            "name": "ChIPSeqToolContract",
-            "recipe": "chipseq_tool_contract",
-            "inputs": {
-                "r1": "File",
-                "r2": "File",
-                "genome_index": "File",
-            },
-            "tool_calls": [
-                {
-                    "id": "align",
-                    "step": "align_reads",
-                    "tool": "bowtie2",
-                    "version": "2.5.5",
-                    "inputs": {
-                        "r1": "r1",
-                        "r2": "r2",
-                        "index_archive": "genome_index",
-                    },
-                    "params": {"threads": 8},
-                },
-                {
-                    "id": "prepare_bam",
-                    "step": "sort_and_index",
-                    "tool": "samtools",
-                    "version": "1.24",
-                    "inputs": {"alignment": "align.aligned_sam"},
-                    "params": {"threads": 4},
-                },
-                {
-                    "id": "peaks",
-                    "step": "call_peaks",
-                    "tool": "macs2",
-                    "version": "2.2.9.1",
-                    "inputs": {"treatment_bam": "prepare_bam.sorted_bam"},
-                    "params": {"genome_size": "hs", "qvalue": 0.01},
-                },
-            ],
-            "outputs": {
-                "sorted_bam": "prepare_bam.sorted_bam",
-                "bam_index": "prepare_bam.bam_index",
-                "narrow_peaks": "peaks.narrow_peaks",
-                "peak_summits": "peaks.summits",
-            },
-        }
-    }
 
 
 class CatalogDefinitionTests(unittest.TestCase):
@@ -386,22 +310,31 @@ class CatalogResolutionTests(unittest.TestCase):
         self.assertIn("File transcriptome_index = index.index_archive", wdl)
         self.assertIn("File tx2gene = mapping.tx2gene", wdl)
 
-    def test_chipseq_tool_contracts_resolve_to_valid_renderable_ir(self):
+    def test_chipseq_peak_calling_recipe_resolves_to_valid_renderable_ir(self):
         workflow_ir = resolve_tool_plan(
-            sample_chipseq_tool_contract_plan(),
-            chipseq_tool_contract_recipe_catalog(),
+            sample_chipseq_peak_calling_plan(),
+            self.recipe_catalog,
             self.tool_catalog,
         )
         report = analyze_workflow_ir(workflow_ir)
         wdl = render_wdl(workflow_ir)
 
         self.assertTrue(report.is_valid, report.errors)
+        self.assertEqual(workflow_ir.workflow.name, "ChIPSeqPeakCalling")
+        self.assertIn("fastp_qc", workflow_ir.tasks)
         self.assertIn("bowtie2_align", workflow_ir.tasks)
         self.assertIn("samtools_prepare_bam", workflow_ir.tasks)
         self.assertIn("macs2_peaks", workflow_ir.tasks)
+        self.assertIn("multiqc_report", workflow_ir.tasks)
+        self.assertIn("call fastp_qc as qc", wdl)
         self.assertIn("call bowtie2_align as align", wdl)
         self.assertIn("call samtools_prepare_bam as prepare_bam", wdl)
         self.assertIn("call macs2_peaks as peaks", wdl)
+        self.assertIn("call multiqc_report as report", wdl)
+        self.assertIn("r1 = raw_r1", wdl)
+        self.assertIn("r2 = raw_r2", wdl)
+        self.assertIn("r1 = qc.clean_r1", wdl)
+        self.assertIn("r2 = qc.clean_r2", wdl)
         self.assertIn("index_archive = genome_index", wdl)
         self.assertIn("alignment = align.aligned_sam", wdl)
         self.assertIn("treatment_bam = prepare_bam.sorted_bam", wdl)
@@ -415,16 +348,21 @@ class CatalogResolutionTests(unittest.TestCase):
         self.assertNotIn("-c ~{control_bam}", wdl)
         self.assertIn('genome_size = "hs"', wdl)
         self.assertIn("qvalue = 0.01", wdl)
+        self.assertIn(
+            "report_files = [qc.html_report, qc.json_report, align.alignment_log, peaks.peak_table]",
+            wdl,
+        )
         self.assertIn("File sorted_bam = prepare_bam.sorted_bam", wdl)
         self.assertIn("File bam_index = prepare_bam.bam_index", wdl)
         self.assertIn("File narrow_peaks = peaks.narrow_peaks", wdl)
         self.assertIn("File peak_summits = peaks.summits", wdl)
+        self.assertIn("File multiqc_report = report.multiqc_report", wdl)
 
     @unittest.skipUnless(wdl_validator_available(), "WDL validator is not installed")
-    def test_chipseq_tool_contract_wdl_passes_syntax_validation(self):
+    def test_chipseq_peak_calling_wdl_passes_syntax_validation(self):
         workflow_ir = resolve_tool_plan(
-            sample_chipseq_tool_contract_plan(),
-            chipseq_tool_contract_recipe_catalog(),
+            sample_chipseq_peak_calling_plan(),
+            self.recipe_catalog,
             self.tool_catalog,
         )
         wdl = render_wdl(workflow_ir)
@@ -434,7 +372,7 @@ class CatalogResolutionTests(unittest.TestCase):
         self.assertTrue(result["is_valid"], result["message"])
 
     def test_macs2_optional_control_is_rendered_when_provided(self):
-        plan = sample_chipseq_tool_contract_plan()
+        plan = sample_chipseq_peak_calling_plan()
         plan["workflow"]["inputs"]["control_bam"] = "File"
         peaks_call = next(
             tool_call
@@ -445,7 +383,7 @@ class CatalogResolutionTests(unittest.TestCase):
 
         workflow_ir = resolve_tool_plan(
             plan,
-            chipseq_tool_contract_recipe_catalog(),
+            self.recipe_catalog,
             self.tool_catalog,
         )
         report = analyze_workflow_ir(workflow_ir)

--- a/tests/test_catalog_retriever.py
+++ b/tests/test_catalog_retriever.py
@@ -74,12 +74,36 @@ class CatalogRetrieverTests(unittest.TestCase):
         de_tool_ids = {tool["id"] for tool in de_result["tools"]}
         self.assertTrue({"edger", "limma_voom"}.issubset(de_tool_ids), de_result)
 
-    def test_tokenizer_supports_rnaseq_variants_and_cjk_ngrams(self):
-        tokens = tokenize_for_retrieval("做差异表达 RNAseq")
+    def test_retrieves_chipseq_recipe_and_compile_ready_tools(self):
+        result = retrieve_catalog_context(
+            (
+                "Use fastp, Bowtie 2, samtools, MACS2, and MultiQC to call "
+                "narrow ChIP-seq peaks from paired-end treatment reads."
+            ),
+            self.tool_catalog,
+            self.recipe_catalog,
+            top_k_recipes=3,
+            top_k_tools=8,
+        )
+
+        self.assertFalse(result["fallback_used"])
+        self.assertEqual(result["recipes"][0]["id"], "chipseq_peak_calling")
+        tools = {tool["id"]: tool for tool in result["tools"]}
+        self.assertTrue(
+            {"fastp", "bowtie2", "samtools", "macs2", "multiqc"}.issubset(tools),
+            result["tools"],
+        )
+        for tool_id in ("bowtie2", "samtools", "macs2"):
+            self.assertEqual(tools[tool_id]["execution_verification"]["status"], "unverified")
+
+    def test_tokenizer_supports_sequencing_variants_and_cjk_ngrams(self):
+        tokens = tokenize_for_retrieval("做差异表达 RNAseq 和 ChIPseq")
 
         self.assertIn("rna", tokens)
         self.assertIn("seq", tokens)
         self.assertIn("rnaseq", tokens)
+        self.assertIn("chip", tokens)
+        self.assertIn("chipseq", tokens)
         self.assertIn("差", tokens)
         self.assertIn("差异", tokens)
         self.assertIn("表达", tokens)

--- a/tests/test_catalog_service.py
+++ b/tests/test_catalog_service.py
@@ -8,7 +8,9 @@ class CatalogServiceTests(unittest.TestCase):
         recipes = list_recipes()
 
         self.assertGreaterEqual(len(recipes), 1)
-        recipe = recipes[0]
+        recipe = next(
+            recipe for recipe in recipes if recipe["id"] == "rnaseq_differential_expression"
+        )
         self.assertEqual(recipe["id"], "rnaseq_differential_expression")
         self.assertIn("required_inputs", recipe)
         self.assertIn("steps", recipe)
@@ -21,6 +23,18 @@ class CatalogServiceTests(unittest.TestCase):
         self.assertEqual(recipe["name"], "RNA-seq differential expression")
         self.assertEqual(recipe["required_inputs"]["sample_ids"]["type"], "Array[String]")
         self.assertEqual(recipe["steps"][0]["scatter"]["id"], "per_sample")
+
+    def test_get_chipseq_recipe_returns_compile_ready_steps(self):
+        recipe = get_recipe("chipseq_peak_calling")
+
+        self.assertEqual(recipe["name"], "ChIP-seq peak calling")
+        self.assertEqual(recipe["required_inputs"]["genome_index"]["type"], "File")
+        self.assertEqual(
+            [step["id"] for step in recipe["steps"]],
+            ["qc", "align_reads", "sort_and_index", "call_peaks", "qc_report"],
+        )
+        self.assertEqual(recipe["steps"][3]["allowed_tools"], ["macs2"])
+        self.assertTrue(recipe["steps"][4]["optional"])
 
     def test_list_tools_returns_json_ready_tool_records(self):
         tools = list_tools()

--- a/tests/test_retrieval_evaluation.py
+++ b/tests/test_retrieval_evaluation.py
@@ -147,9 +147,53 @@ class RetrievalEvaluationTests(unittest.TestCase):
         self.assertEqual(result["family_metrics"]["bulk_rnaseq"]["query_count"], 21)
         self.assertEqual(result["family_metrics"]["chipseq"]["query_count"], 7)
         self.assertEqual(result["family_metrics"]["chipseq"]["supported_query_count"], 6)
+        self.assertEqual(
+            result["family_metrics"]["bulk_rnaseq"]["metrics"]["tool_recall_at_5"],
+            0.819,
+        )
+        self.assertEqual(result["macro_family_metrics"]["recipe_recall_at_1"], 0.9048)
+        self.assertEqual(result["macro_family_metrics"]["tool_recall_at_5"], 0.8484)
         for metric in result["macro_family_metrics"].values():
             self.assertGreaterEqual(metric, 0.0)
             self.assertLessEqual(metric, 1.0)
+
+    def test_macro_family_metrics_use_unrounded_family_values(self):
+        queries = [
+            RetrievalQuery(
+                id=f"family-a-{index}",
+                query="supported hit" if index < 17 else "supported miss",
+                supported=True,
+                workflow_family="family_a",
+                expected_recipe="rnaseq_differential_expression",
+                expected_tools=[],
+                expected_roles={},
+            )
+            for index in range(21)
+        ]
+        queries.append(
+            RetrievalQuery(
+                id="family-b-0",
+                query="supported hit",
+                supported=True,
+                workflow_family="family_b",
+                expected_recipe="rnaseq_differential_expression",
+                expected_tools=[],
+                expected_roles={},
+            )
+        )
+
+        result = evaluate_retrieval_queries(
+            queries,
+            self.tool_catalog,
+            self.recipe_catalog,
+            retriever=fake_retriever,
+        )
+
+        self.assertEqual(
+            result["family_metrics"]["family_a"]["metrics"]["recipe_recall_at_1"],
+            0.8095,
+        )
+        self.assertEqual(result["macro_family_metrics"]["recipe_recall_at_1"], 0.9048)
 
     def test_computes_supported_metrics_and_tracks_unsupported_matches(self):
         queries = [

--- a/tests/test_retrieval_evaluation.py
+++ b/tests/test_retrieval_evaluation.py
@@ -78,10 +78,11 @@ class RetrievalEvaluationTests(unittest.TestCase):
     def test_loads_current_catalog_query_fixture(self):
         queries = load_retrieval_queries(FIXTURE_PATH)
 
-        self.assertEqual(len(queries), 24)
-        self.assertEqual(sum(1 for query in queries if query.supported), 20)
+        self.assertEqual(len(queries), 31)
+        self.assertEqual(sum(1 for query in queries if query.supported), 27)
         self.assertEqual(sum(1 for query in queries if not query.supported), 4)
         self.assertEqual(queries[0].id, "rnaseq_deg_basic_en")
+        self.assertEqual(queries[0].workflow_family, "bulk_rnaseq")
         self.assertIn("fastp", queries[0].expected_tools)
         self.assertIn(
             "rnaseq_reference_prep_basic_en",
@@ -110,6 +111,13 @@ class RetrievalEvaluationTests(unittest.TestCase):
             generic_deg.expected_roles["differential_expression"],
             ["deseq2", "edger", "limma_voom"],
         )
+        chipseq = queries_by_id["chipseq_peak_calling_basic_en"]
+        self.assertEqual(chipseq.workflow_family, "chipseq")
+        self.assertEqual(chipseq.expected_recipe, "chipseq_peak_calling")
+        self.assertIn("macs2", chipseq.expected_tools)
+        chipseq_annotation = queries_by_id["unsupported_chipseq_peak_annotation_en"]
+        self.assertFalse(chipseq_annotation.supported)
+        self.assertEqual(chipseq_annotation.workflow_family, "chipseq")
 
     def test_evaluates_current_catalog_baseline(self):
         queries = load_retrieval_queries(FIXTURE_PATH)
@@ -123,15 +131,25 @@ class RetrievalEvaluationTests(unittest.TestCase):
         self.assertEqual(result["strategy"], "lexical_v1")
         self.assertEqual(result["top_k_recipes"], 3)
         self.assertEqual(result["top_k_tools"], 8)
-        self.assertEqual(result["query_count"], 24)
-        self.assertEqual(result["supported_query_count"], 20)
+        self.assertEqual(result["query_count"], 31)
+        self.assertEqual(result["supported_query_count"], 27)
         self.assertEqual(result["unsupported_query_count"], 4)
-        self.assertEqual(len(result["queries"]), 24)
+        self.assertEqual(len(result["queries"]), 31)
         for metric in result["metrics"].values():
             self.assertGreaterEqual(metric, 0.0)
             self.assertLessEqual(metric, 1.0)
         self.assertEqual(result["metrics"]["planner_context_tool_recall"], 1.0)
         self.assertEqual(result["metrics"]["planner_context_role_coverage"], 1.0)
+        self.assertEqual(
+            set(result["family_metrics"]),
+            {"bulk_rnaseq", "chipseq", "metagenomics", "scrnaseq", "variant_calling"},
+        )
+        self.assertEqual(result["family_metrics"]["bulk_rnaseq"]["query_count"], 21)
+        self.assertEqual(result["family_metrics"]["chipseq"]["query_count"], 7)
+        self.assertEqual(result["family_metrics"]["chipseq"]["supported_query_count"], 6)
+        for metric in result["macro_family_metrics"].values():
+            self.assertGreaterEqual(metric, 0.0)
+            self.assertLessEqual(metric, 1.0)
 
     def test_computes_supported_metrics_and_tracks_unsupported_matches(self):
         queries = [
@@ -139,6 +157,7 @@ class RetrievalEvaluationTests(unittest.TestCase):
                 id="q1",
                 query="supported hit",
                 supported=True,
+                workflow_family="bulk_rnaseq",
                 expected_recipe="rnaseq_differential_expression",
                 expected_tools=["fastp", "deseq2"],
                 expected_roles={
@@ -150,6 +169,7 @@ class RetrievalEvaluationTests(unittest.TestCase):
                 id="q2",
                 query="supported miss",
                 supported=True,
+                workflow_family="bulk_rnaseq",
                 expected_recipe="rnaseq_differential_expression",
                 expected_tools=["deseq2"],
                 expected_roles={"differential_expression": ["deseq2"]},
@@ -158,6 +178,7 @@ class RetrievalEvaluationTests(unittest.TestCase):
                 id="q3",
                 query="unsupported direct match",
                 supported=False,
+                workflow_family="chipseq",
                 expected_recipe=None,
                 expected_tools=[],
                 expected_roles={},
@@ -172,8 +193,11 @@ class RetrievalEvaluationTests(unittest.TestCase):
         )
 
         self.assertEqual(result["strategy"], "fake_v1")
+        self.assertEqual(result["metrics"]["recipe_recall_at_1"], 0.5)
         self.assertEqual(result["metrics"]["recipe_recall_at_k"], 0.5)
         self.assertEqual(result["metrics"]["recipe_mrr"], 0.5)
+        self.assertEqual(result["metrics"]["tool_recall_at_3"], 0.25)
+        self.assertEqual(result["metrics"]["tool_recall_at_5"], 0.25)
         self.assertEqual(result["metrics"]["tool_recall_at_k"], 0.25)
         self.assertEqual(result["metrics"]["tool_mrr"], 0.5)
         self.assertEqual(result["metrics"]["role_coverage"], 0.25)
@@ -182,8 +206,12 @@ class RetrievalEvaluationTests(unittest.TestCase):
         self.assertEqual(result["metrics"]["fallback_rate"], 0.3333)
         self.assertEqual(result["metrics"]["supported_fallback_rate"], 0.5)
         self.assertEqual(result["metrics"]["unsupported_fallback_rate"], 0.0)
+        self.assertEqual(result["metrics"]["unsupported_direct_match_rate"], 1.0)
         self.assertEqual(result["fallback_query_ids"], ["q2"])
         self.assertEqual(result["unsupported_direct_match_query_ids"], ["q3"])
+        self.assertEqual(result["family_metrics"]["bulk_rnaseq"]["query_count"], 2)
+        self.assertEqual(result["family_metrics"]["chipseq"]["query_count"], 1)
+        self.assertEqual(result["macro_family_metrics"]["recipe_recall_at_1"], 0.5)
         self.assertIn("deseq2", result["queries"][0]["planner_context_tools"])
         self.assertEqual(result["queries"][1]["missed_expected_tools"], ["deseq2"])
         self.assertEqual(result["queries"][1]["missed_roles"], ["differential_expression"])
@@ -198,6 +226,7 @@ class RetrievalEvaluationTests(unittest.TestCase):
                 id="multi-version",
                 query="multi-version tool results",
                 supported=True,
+                workflow_family="bulk_rnaseq",
                 expected_recipe="rnaseq_differential_expression",
                 expected_tools=["salmon", "deseq2"],
                 expected_roles={
@@ -227,10 +256,44 @@ class RetrievalEvaluationTests(unittest.TestCase):
                     "id": "bad",
                     "query": "unsupported",
                     "supported": False,
+                    "workflow_family": "bulk_rnaseq",
                     "expected_recipe": "rnaseq_differential_expression",
                     "expected_tools": [],
                     "expected_roles": {},
                 }
+            )
+
+    def test_requires_workflow_family_in_query_schema(self):
+        with self.assertRaisesRegex(ValueError, "workflow_family must be a non-empty string"):
+            RetrievalQuery.from_dict(
+                {
+                    "id": "missing-family",
+                    "query": "quantify expression",
+                    "supported": True,
+                    "expected_recipe": "rnaseq_differential_expression",
+                    "expected_tools": ["salmon"],
+                    "expected_roles": {"expression_quantification": ["salmon"]},
+                }
+            )
+
+    def test_requires_enough_tool_results_for_fixed_recall_cutoffs(self):
+        query = RetrievalQuery(
+            id="q1",
+            query="supported hit",
+            supported=True,
+            workflow_family="bulk_rnaseq",
+            expected_recipe="rnaseq_differential_expression",
+            expected_tools=["fastp"],
+            expected_roles={"read_quality_control": ["fastp"]},
+        )
+
+        with self.assertRaisesRegex(ValueError, "top_k_tools must be >= 5"):
+            evaluate_retrieval_queries(
+                [query],
+                self.tool_catalog,
+                self.recipe_catalog,
+                top_k_tools=4,
+                retriever=fake_retriever,
             )
 
     def test_rejects_non_object_fixture_entries(self):


### PR DESCRIPTION
## Summary
- Add the formal chipseq_peak_calling recipe and a representative structured plan for fastp, Bowtie 2, samtools, MACS2, and MultiQC.
- Expand the retrieval fixture to 31 workflow-family-labeled queries and add Recipe Recall@1, Tool Recall@3/@5, family metrics, macro metrics, and unsupported direct-match reporting.
- Update Catalog/API tests and document the measured lexical baseline and execution-verification boundary.

## Validation
- .venv/Scripts/python.exe -m unittest discover -v (Ran 278 tests: OK, 2 skipped)
- Representative ChIP-seq WDL compilation and WOMtool syntax validation passed

## Capability boundary
The recipe is compile-ready for one paired-end treatment sample. It does not add a recipe-level control branch, peak annotation, or motif analysis, and Bowtie 2, samtools, and MACS2 remain execution-unverified.