### PR TITLE
Add baseline OSS governance

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,20 @@
+# Default repository owner
+* @yuanzhw
+
+# Governance, release, and CI/CD
+/.github/ @yuanzhw
+/AGENTS.md @yuanzhw
+/MAINTAINERS.md @yuanzhw
+/SECURITY.md @yuanzhw
+/pyproject.toml @yuanzhw
+/uv.lock @yuanzhw
+
+# Compiler, Catalog, execution, and deployment trust boundaries
+/src/ @yuanzhw
+/tests/ @yuanzhw
+/docs/workflow-ir.md @yuanzhw
+/containers/ @yuanzhw
+/deploy/ @yuanzhw
+
+# Product UI
+/web/ @yuanzhw

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,166 @@
+name: Bug report
+description: Report a reproducible compiler, Catalog, API, UI, or execution defect.
+title: "[Bug]: "
+labels:
+  - bug
+assignees: []
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve AI-bioworkflow.
+
+        **This is a public issue.** Never include API keys, `.env` contents, credentials, signed URLs, private endpoints, patient or sample identifiers, or restricted genomic or clinical data. Use synthetic or public fixtures.
+
+        Do not disclose a suspected security vulnerability here. Follow the security policy from the issue chooser.
+
+  - type: input
+    id: revision
+    attributes:
+      label: Version or revision
+      description: Release tag, commit SHA, or branch where the problem occurs.
+      placeholder: v0.1.0-alpha.1, 23c6660, or main
+    validations:
+      required: true
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Affected component
+      options:
+        - CLI or shared workflow service
+        - Natural-language Planner or Catalog retrieval
+        - Recipe or Tool Catalog resolution
+        - Workflow IR schema or normalization
+        - Analyzer, deterministic repair, or Reviewer patch
+        - Deterministic WDL Renderer or Checker
+        - FastAPI, run storage, or SSE
+        - Next.js workbench, history, or DAG
+        - Execution backend or Cromwell
+        - Project-maintained containers or deployment
+        - Documentation or examples
+        - Other or unsure
+    validations:
+      required: true
+
+  - type: dropdown
+    id: entry_point
+    attributes:
+      label: Entry point
+      options:
+        - CLI natural-language mode
+        - CLI structured mode (--input)
+        - API POST /api/runs
+        - API POST /api/compile
+        - API run snapshot, history, or SSE
+        - Web workspace, run history, DAG, or Catalog
+        - Direct Python service or library call
+        - GitHub Actions or container script
+        - Other or not applicable
+    validations:
+      required: true
+
+  - type: dropdown
+    id: input_contract
+    attributes:
+      label: Input contract
+      options:
+        - Natural-language request
+        - Recipe Tool Plan
+        - Workflow IR with canonical workflow.steps
+        - Legacy calls-only workflow JSON
+        - Not applicable or unknown
+    validations:
+      required: true
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: Briefly describe what is broken and its impact.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: Include the exact command, API route, page, and smallest reliable sequence.
+      placeholder: |
+        1. Run ...
+        2. Submit ...
+        3. Observe ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: sanitized_input
+    attributes:
+      label: Minimal sanitized input
+      description: Paste the smallest safe input that reproduces the issue. Use synthetic or public data and replace local paths and identifiers. Write "Not applicable" when there is no workflow input.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior and diagnostics
+      description: Include the relevant Analyzer, Reviewer, Renderer, Checker, API, or UI diagnostic. For WDL problems, include only the smallest useful excerpt.
+    validations:
+      required: true
+
+  - type: textarea
+    id: catalog_context
+    attributes:
+      label: Recipe, tool, runtime, and validator context
+      description: When relevant, provide recipe ID, tool ID/version, declared runtime.docker, execution_verification state, WDL validator, and execution backend. Do not include registry credentials.
+      placeholder: |
+        Recipe:
+        Tool and version:
+        Runtime image:
+        Execution verification:
+        WDL validator:
+        Execution backend:
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Include applicable OS, Python/uv, Node/browser, Java/WOMtool or miniwdl, and Cromwell/backend versions.
+      placeholder: |
+        OS:
+        Python and uv:
+        Node and browser:
+        Java and WDL validator:
+        Execution backend:
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Sanitized logs
+      description: Remove credentials, private URLs, local identity details, and sensitive data.
+      render: shell
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Submission checks
+      options:
+        - label: I searched existing open and closed issues for a duplicate.
+          required: true
+        - label: I included an exact revision and enough environment details to reproduce the issue.
+          required: true
+        - label: I removed secrets, credentials, private identifiers, and restricted genomic or clinical data.
+          required: true
+        - label: This report does not publicly disclose a suspected security vulnerability.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,9 @@
+blank_issues_enabled: false
+
+contact_links:
+  - name: Report a security vulnerability
+    url: https://github.com/yuanzhw/AI-bioworkflow/security/policy
+    about: Do not disclose vulnerabilities, credentials, or sensitive data in a public issue. Follow the private contact instructions in the security policy.
+  - name: Read the project documentation
+    url: https://github.com/yuanzhw/AI-bioworkflow#readme
+    about: Check setup, supported input contracts, architecture boundaries, and verification commands before filing an issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,166 @@
+name: Feature request
+description: Propose a compiler, Catalog, API, UI, execution, or documentation improvement.
+title: "[Feature]: "
+labels:
+  - enhancement
+assignees: []
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Describe the user problem before the implementation.
+
+        Keep examples public and sanitized. Do not include credentials, patient or sample identifiers, restricted genomic or clinical data, private registry details, or internal endpoints.
+
+        The current trust boundaries are intentional: a model may produce a Recipe Tool Plan or a bounded Workflow IR patch, but final WDL remains deterministically rendered from validated Workflow IR. Tool, command, and runtime choices remain owned by the formal Catalog.
+
+  - type: dropdown
+    id: feature_kind
+    attributes:
+      label: Request type
+      options:
+        - New Tool Catalog entry
+        - New or expanded recipe
+        - Workflow IR, Analyzer, repair, Renderer, or Checker
+        - Natural-language Planner or Catalog retrieval
+        - Reviewer policy or bounded IR repair
+        - CLI or shared service
+        - FastAPI, persistence, or SSE
+        - Next.js workbench, history, or DAG
+        - Execution backend or Cromwell integration
+        - Project-maintained container
+        - Documentation, examples, or contributor tooling
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem and user need
+      description: Who is affected, what bioinformatics task is blocked, and why is current behavior insufficient?
+    validations:
+      required: true
+
+  - type: textarea
+    id: use_case
+    attributes:
+      label: Concrete use case
+      description: Provide a safe example request or workflow shape using synthetic or public data.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed outcome
+      description: Describe observable behavior and contracts, not only an implementation.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: affected_areas
+    attributes:
+      label: Affected contracts or layers
+      multiple: true
+      options:
+        - Natural language to Recipe Tool Plan
+        - Approved Catalog retrieval and final Catalog validation
+        - Recipe Tool Plan to Workflow IR normalization
+        - Canonical workflow.steps DAG
+        - Analyzer or bounded repair
+        - Reviewer IR patch policy
+        - Deterministic Workflow IR to WDL rendering
+        - WDL syntax validation
+        - API, run persistence, or SSE
+        - Web visualization
+        - Execution backend policy
+        - Tool container or runtime supply chain
+        - Documentation only
+    validations:
+      required: true
+
+  - type: dropdown
+    id: boundary_impact
+    attributes:
+      label: Trust-boundary impact
+      options:
+        - Preserves the existing architecture boundaries
+        - Extends structured contracts while preserving the boundaries
+        - May change an architecture boundary and needs design review
+        - Not sure
+    validations:
+      required: true
+
+  - type: textarea
+    id: architecture
+    attributes:
+      label: Architecture and safety analysis
+      description: Explain the impact on Recipe Tool Plan, Catalog validation, workflow.steps, Analyzer/Renderer/Checker, Reviewer patch policy, src.execution, and the compile-time DAG. Write "Not applicable" for documentation-only requests.
+    validations:
+      required: true
+
+  - type: textarea
+    id: catalog_details
+    attributes:
+      label: Tool, recipe, or container admission details
+      description: Required for Catalog/container proposals. Include version, purpose, schemas, command, explicit runtime image, execution verification/evidence, trusted upstream source, license, and wrapper/smoke-test needs.
+      placeholder: |
+        Tool or recipe ID:
+        Version:
+        Inputs, outputs, and parameters:
+        Command:
+        Runtime image or digest:
+        Execution verification and evidence:
+        Upstream source and license:
+        Recipe role:
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: List measurable outcomes that would make the request complete.
+      placeholder: |
+        - [ ] ...
+        - [ ] ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: verification
+    attributes:
+      label: Test and documentation plan
+      description: Identify applicable tests, representative WDL validation, frontend checks, backend contracts, container smoke tests, and documentation updates.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Describe existing recipes, tools, or smaller solutions that were considered.
+
+  - type: dropdown
+    id: contribution
+    attributes:
+      label: Contribution
+      options:
+        - I can prepare a pull request after design agreement
+        - I can help with fixtures, testing, or documentation
+        - I can provide domain feedback
+        - I am not able to contribute an implementation
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Submission checks
+      options:
+        - label: I searched existing issues, recipes, Tool Catalog entries, and roadmap documents for overlap.
+          required: true
+        - label: I removed secrets, credentials, private identifiers, and restricted genomic or clinical data.
+          required: true
+        - label: I understand that architecture-boundary changes require explicit maintainer design review.
+          required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,67 @@
+## Summary
+
+<!-- What problem does this pull request solve, and why is the change needed? -->
+
+## Scope
+
+- [ ] Bug fix
+- [ ] Compiler or Workflow IR
+- [ ] Recipe or Tool Catalog
+- [ ] API or Web
+- [ ] Execution backend or container
+- [ ] Tests or documentation
+- [ ] Other
+
+## Architecture impact
+
+<!-- Describe affected boundaries, or write "None". Check only applicable items. -->
+
+- [ ] Natural-language processing still stops at Recipe Tool Plan.
+- [ ] Final WDL is produced only by the deterministic Renderer.
+- [ ] `workflow.steps` remains the canonical DAG; `workflow.calls` is compatibility-only.
+- [ ] Catalog tool, command, and runtime definitions remain explicit and validated.
+- [ ] Analyzer, Renderer, Checker, and `src.execution` boundaries are preserved.
+- [ ] Not applicable to this change.
+
+## Validation
+
+<!-- Check only commands that were actually run and add concise results below. -->
+
+- [ ] Python unit tests
+- [ ] `scripts/check_p0.ps1`
+- [ ] Representative WDL compile and syntax validation
+- [ ] Frontend lint
+- [ ] Frontend Catalog retrieval tests
+- [ ] Frontend workflow graph tests
+- [ ] Frontend production build
+- [ ] Container build or smoke test
+- [ ] Real execution test — explicit opt-in
+- [ ] Documentation-only change
+
+Commands and results:
+
+```text
+
+```
+
+Skipped checks and reasons:
+
+```text
+
+```
+
+## Documentation and contracts
+
+- [ ] `docs/workflow-ir.md` was updated, or no IR/backend contract changed.
+- [ ] `docs/test-cases.md` was updated, or no test input, expectation, or coverage intent changed.
+- [ ] New tools or wrappers include schemas, command/runtime definitions, verification status, and appropriate tests.
+- [ ] New dependencies are justified and lockfiles are updated.
+- [ ] No secrets, credentials, private data, or local `.env` files are included.
+
+## Evidence
+
+<!-- Add screenshots for UI changes and representative diagnostics or WDL excerpts where useful. -->
+
+## Risks and follow-ups
+
+<!-- Note compatibility risks, known limitations, rollout concerns, or write "None". -->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,122 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment include:
+
+- Demonstrating empathy and kindness toward other people.
+- Being respectful of differing opinions, viewpoints, and experiences.
+- Giving and gracefully accepting constructive feedback.
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience.
+- Focusing on what is best not just for us as individuals, but for the overall
+  community.
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances
+  of any kind.
+- Trolling, insulting or derogatory comments, and personal or political attacks.
+- Public or private harassment.
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission.
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting.
+
+## Enforcement Responsibilities
+
+Project maintainers are responsible for clarifying and enforcing these
+standards of acceptable behavior and will take appropriate and fair corrective
+action in response to behavior that they deem inappropriate, threatening,
+offensive, or harmful.
+
+Project maintainers have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned with this Code of Conduct, and will communicate reasons for
+moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all project spaces and also applies when an
+individual is officially representing the project in public spaces. Examples of
+representing the project include using an official email address, posting via an
+official social media account, or acting as an appointed representative at an
+online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported privately to `yuanzhw@vip.qq.com` with the subject
+`[AI-bioworkflow conduct] <short summary>`. All complaints will be reviewed and
+investigated promptly and fairly.
+
+All project maintainers are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Project maintainers will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct.
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from project maintainers, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the
+[Contributor Covenant, version 2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html),
+available under the
+[Creative Commons Attribution 4.0 International License](https://creativecommons.org/licenses/by/4.0/).
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,158 @@
+# Contributing to AI-bioworkflow
+
+Thank you for helping improve AI-bioworkflow. The project is an open-source
+bioinformatics workflow compiler: natural-language requests are constrained to
+a Catalog-bound Recipe Tool Plan, normalized into Workflow IR, and rendered as
+validated WDL 1.0 by deterministic code.
+
+Contributions should keep this path auditable, reproducible, and testable.
+
+## Before you start
+
+- Search existing issues and pull requests before opening a new one.
+- Small bug fixes, tests, and documentation improvements may go directly to a
+  pull request.
+- Open an issue before making a substantial change to Workflow IR semantics,
+  public APIs, dependencies, recipes, tools, containers, execution backends, or
+  renderer behavior.
+- Keep each pull request focused on one problem. Roadmap entries are not an
+  automatic approval to implement the full feature.
+
+Read these sources of truth before changing the corresponding area:
+
+- [DEVELOPMENT.md](./DEVELOPMENT.md) for architecture and roadmap decisions.
+- [Workflow IR specification](./docs/workflow-ir.md) before changing schemas,
+  expressions, Analyzer/Repairer behavior, renderers, Catalog resolution, or
+  backend mapping.
+- [Test cases](./docs/test-cases.md) before changing fixtures, expected output,
+  or coverage intent. Update it when those contracts change.
+
+## Development setup
+
+The project targets Python 3.13+ and uses `uv` with the repository `.venv`.
+Java 17+ and WOMtool 91 are used for the primary WDL validation path.
+
+```powershell
+git clone https://github.com/yuanzhw/AI-bioworkflow.git
+cd AI-bioworkflow
+uv sync
+
+# Complete Python suite plus representative WDL compilation and validation
+powershell -ExecutionPolicy Bypass -File scripts\check_p0.ps1
+```
+
+For the Web application:
+
+```powershell
+cd web
+npm ci
+npm run lint
+npm run test:catalog-retrieval
+npm run test:graph
+npm run build
+```
+
+On POSIX systems, run the Python suite with:
+
+```bash
+./.venv/bin/python -m unittest discover -v
+```
+
+Structured compilation through `--input` does not require an API key. Natural-
+language planning requires `DEEPSEEK_API_KEY`. Never commit `.env` files, API
+keys, credential paths, patient or controlled-access data, or private runtime
+logs.
+
+## Architecture boundaries
+
+Every contribution must preserve these invariants:
+
+- Natural-language input becomes a Recipe Tool Plan before Workflow IR. A
+  model must not generate final WDL directly.
+- Recipes and tools are admitted through the formal Catalog. The compiler must
+  not infer, search for, or silently replace container images.
+- `workflow.steps` is the canonical DAG. `workflow.calls` is a generated
+  compatibility view for older flat inputs.
+- Workflow IR is validated before deterministic rendering, and generated WDL
+  is checked before it is treated as successful output.
+- Reviewer repair may propose only policy-constrained Workflow IR patches. It
+  may not modify Catalog definitions, command templates, runtime images, or
+  final WDL, and every accepted patch must pass the complete compiler chain.
+- Execution goes through `src.execution`. The default backend remains disabled,
+  and real execution tests stay explicitly opt-in.
+- CLI stdout remains machine-consumable WDL or JSON. Logs and diagnostics go to
+  stderr.
+- API and Web layers reuse the application service; they do not duplicate
+  planning, Catalog resolution, or WDL generation logic.
+
+## Change-specific requirements
+
+### Workflow IR, Analyzer, Repairer, or Renderer
+
+- Add focused tests for the new or changed contract.
+- Update `docs/workflow-ir.md` when semantics or backend mapping changes.
+- Generate representative WDL and run WOMtool or `miniwdl check`.
+
+### Recipe or Tool Catalog
+
+- Define explicit input, output, parameter, command, version, and runtime
+  schemas.
+- Set an honest `execution_verification` state and provide evidence when the
+  state is `smoke-tested` or `e2e-validated`.
+- Add resolver, rendering, validation, and retrieval coverage as applicable.
+- Do not use an unpinned or silently discovered container image.
+
+### Project-maintained container or wrapper
+
+- Include a description, schemas, command example, explicit runtime reference,
+  Dockerfile, packaged helper scripts, `image_revision.txt`, and
+  `smoke_test.sh`.
+- Add minimal build and execution-path coverage.
+
+### Execution backend
+
+- Implement the `src.execution` interfaces.
+- Cover availability, submission, polling, outputs, metadata, and failure
+  semantics.
+- Explain any real execution verification that could not be run.
+
+### Frontend or API
+
+- Preserve the published API and artifact contracts, or document the change.
+- Run the relevant frontend checks listed above.
+- Include screenshots for visible UI changes.
+
+### Dependencies
+
+Explain why the dependency is required and update the appropriate lockfile.
+Avoid adding a dependency when the existing standard library or project
+tooling is sufficient.
+
+## Pull requests
+
+A pull request should include:
+
+- the problem and motivation;
+- the implemented scope and affected architecture boundaries;
+- commands run and their results;
+- skipped checks and the reason;
+- compatibility, deployment, or security risks;
+- documentation changes and useful screenshots or artifacts.
+
+Use a concise, imperative, maintainer-authored title. Branch names, commit
+messages, pull request text, and public documentation must not contain tool
+signatures, autogenerated-by lines, assistant branding, or unrelated PR-number
+suffixes.
+
+All required checks should pass before merge. Squash merges should use a clean
+subject without an automatic `(#PR_NUMBER)` suffix.
+
+## Security reports
+
+Do not open a public issue for a suspected vulnerability. Follow
+[SECURITY.md](./SECURITY.md) instead.
+
+## License
+
+By contributing, you agree that your contribution may be distributed under the
+repository's [Apache License 2.0](./LICENSE).

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,58 @@
+# Maintainers and Project Governance
+
+AI-bioworkflow is an Apache-2.0 open-source project in alpha. This document
+records operational maintainership and decision-making; it does not replace the
+license or grant ownership of contributor work.
+
+## Current maintainers
+
+| Maintainer | GitHub | Role | Scope |
+| --- | --- | --- | --- |
+| Yuanzhw | [@yuanzhw](https://github.com/yuanzhw) | Owner and lead maintainer | Repository-wide architecture, Catalog admission, releases, infrastructure, and security response |
+
+Operational review ownership is also recorded in
+[`.github/CODEOWNERS`](./.github/CODEOWNERS).
+
+## Responsibilities
+
+Maintainers are responsible for:
+
+- preserving the Recipe Tool Plan, Catalog, Workflow IR, deterministic Renderer,
+  Checker, and execution-backend boundaries;
+- reviewing issues and pull requests fairly and in a reasonable time;
+- keeping tests, documentation, releases, and security guidance accurate;
+- admitting tools, recipes, containers, and execution-verification evidence;
+- protecting repository credentials and release infrastructure;
+- enforcing the [Code of Conduct](./CODE_OF_CONDUCT.md) consistently.
+
+## Decisions
+
+Routine changes are decided through pull request review. Significant changes to
+Workflow IR, public APIs, dependencies, Catalog policy, execution, security, or
+project direction should begin with a public issue and a written proposal.
+
+The project prefers documented technical consensus. When consensus cannot be
+reached, the lead maintainer makes the final decision based on project scope,
+architecture invariants, evidence, maintenance cost, and user impact. Decisions
+may be revisited when new evidence becomes available.
+
+Security-sensitive details may be handled privately until coordinated
+disclosure is safe.
+
+## Becoming a maintainer
+
+Maintainer access may be offered after a sustained record of constructive
+contributions, reliable review, sound judgment around bioinformatics and
+compiler boundaries, and compliance with the Code of Conduct. Candidates must
+use two-factor authentication and accept the repository's security and release
+practices.
+
+There is no automatic contribution-count threshold. Maintainer access is based
+on demonstrated trust and an ongoing need for shared ownership.
+
+## Inactivity or removal
+
+A maintainer may step down at any time. Access may be reduced after prolonged
+inactivity, loss of two-factor authentication, repeated policy violations, or
+conduct that puts users, contributors, or release integrity at risk. Whenever
+practical, changes in maintainership will be documented in this file.

--- a/README.md
+++ b/README.md
@@ -360,6 +360,13 @@ Web 产品化拆解与当前 W6 收口计划详见：
 
 👉 **[部署与运维手册](./docs/deployment.md)**
 
+## 🤝 参与贡献与治理
+
+欢迎提交可复现的 bug、文档改进、测试、Recipe / Tool Catalog 扩展和聚焦的功能建议。
+开始前请阅读 [贡献指南](./CONTRIBUTING.md)。社区行为、安全报告和维护决策分别遵循
+[行为准则](./CODE_OF_CONDUCT.md)、[安全策略](./SECURITY.md) 与
+[维护者治理](./MAINTAINERS.md)。
+
 ## 📅 未来路线图 (Roadmap)
 
 - [x] 搭建基础 LangGraph 状态机。

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,61 @@
+# Security Policy
+
+AI-bioworkflow is currently an alpha engineering preview. Security fixes are
+provided on a best-effort basis for the current `0.1.x` pre-release line and the
+latest `main` branch. Older snapshots and unmaintained forks are not supported.
+
+## Reporting a vulnerability
+
+Do not disclose a suspected vulnerability in a public issue, pull request,
+discussion, screenshot, or demo run.
+
+Email the maintainer at `yuanzhw@vip.qq.com` with the subject
+`[AI-bioworkflow security] <short summary>`. Include only the information needed
+to reproduce and assess the issue:
+
+- the affected release or commit SHA;
+- the affected component and deployment mode;
+- the expected impact and attack prerequisites;
+- minimal reproduction steps or a proof of concept;
+- suggested mitigations, if known;
+- whether the issue has been disclosed elsewhere.
+
+Do not send API keys, credentials, patient data, controlled-access biological
+data, or unrelated private logs. Use synthetic or redacted inputs whenever
+possible.
+
+The maintainer aims to acknowledge a complete report within five business days
+and provide an initial assessment within fourteen business days. These are
+best-effort targets for a single-maintainer project, not guaranteed response
+times. Please allow time for a fix and coordinated disclosure before publishing
+details.
+
+## Useful report scope
+
+Security reports are especially useful when they concern:
+
+- command-template or parameter injection;
+- unintended file access or path traversal;
+- unsafe handling of API input, stored run artifacts, or diagnostics;
+- leakage of secrets or raw model/provider output;
+- bypasses of Catalog, Reviewer patch policy, validation, or execution policy;
+- unauthorized workflow execution or execution-backend boundary violations;
+- dependency, container, or build-pipeline supply-chain risks;
+- cross-site scripting, request forgery, or other Web/API vulnerabilities.
+
+The public demo intentionally has no user accounts, multi-tenancy, or production
+availability commitment. Reports that only restate these documented alpha
+limitations may not be treated as vulnerabilities, but a concrete bypass,
+credential exposure, unauthorized execution path, or material impact is in
+scope.
+
+## Coordinated disclosure
+
+Confirmed vulnerabilities will be addressed according to severity and project
+capacity. A fix may include a patch release, configuration guidance, credential
+rotation, or temporary feature disablement. Credit will be offered when desired
+and when disclosure is safe, but confidential or anonymous reporting is also
+respected.
+
+Only test repositories, systems, containers, and deployments that you own or
+are explicitly authorized to assess.


### PR DESCRIPTION
## Summary

- add contributor guidance, a Contributor Covenant code of conduct, a security policy, and maintainer governance
- add CODEOWNERS, structured bug and feature issue forms, issue chooser guidance, and a pull request template
- link the contribution and governance entry points from the README

## Validation

- parsed all Issue Form and issue configuration YAML with PyYAML
- verified Issue Form top-level fields, component types, and unique field IDs
- ran `git diff --cached --check` before commit

## Notes

- this is a documentation and GitHub configuration change; no runtime code paths changed
- the existing untracked `docs/portfolio/` material is intentionally excluded
- GitHub private vulnerability reporting is currently disabled, so the security policy uses the maintainer's public contact email
