### PR TITLE
Establish required CI gate

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -54,7 +54,9 @@
 - Local Windows-oriented P0 wrapper:
   - `powershell -ExecutionPolicy Bypass -File scripts/check_p0.ps1`
 - Real Cromwell tiny e2e is opt-in. Prefer the local wrapper `scripts/check_p0.ps1 -RunE2E`; a direct env-var unittest entry also exists for runner/debug workflows.
-- If a change affects generated WDL, recipes, renderers, or validation paths, also run `miniwdl check` on a representative generated WDL when `miniwdl` is available.
+- If a change affects generated WDL, recipes, renderers, or validation paths,
+  run WOMtool 92 as the canonical validator first, then run `miniwdl check` as
+  the production-compatibility check when miniwdl is available.
 
 ## Environment/setup notes for cloud agents
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -29,7 +29,8 @@
 
 - [ ] Python unit tests
 - [ ] `scripts/check_p0.ps1`
-- [ ] Representative WDL compile and syntax validation
+- [ ] Representative WDL compile and WOMtool 92 validation
+- [ ] miniwdl production-compatibility validation
 - [ ] Frontend lint
 - [ ] Frontend Catalog retrieval tests
 - [ ] Frontend workflow graph tests

--- a/.github/workflows/build-app-images.yml
+++ b/.github/workflows/build-app-images.yml
@@ -68,7 +68,9 @@ jobs:
       publish: ${{ steps.meta.outputs.publish }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
 
       - name: Prepare image metadata
         id: meta
@@ -140,7 +142,7 @@ jobs:
 
       - name: Log in to Alibaba Cloud ACR
         if: ${{ steps.meta.outputs.publish == 'true' }}
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ${{ secrets.ACR_REGISTRY }}
           username: ${{ secrets.ACR_USERNAME }}
@@ -225,7 +227,9 @@ jobs:
       IMAGE_TAG: ${{ needs.build.outputs.image_tag }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
 
       - name: Validate ECS deployment configuration
         run: |

--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -43,12 +43,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Compile build script
         run: python -m py_compile scripts/build_container.py
@@ -66,12 +68,14 @@ jobs:
       packages: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Validate inputs
         env:
@@ -93,7 +97,7 @@ jobs:
 
       - name: Log in to GHCR
         if: ${{ inputs.publish && github.ref == 'refs/heads/main' }}
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,236 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  UV_VERSION: "0.11.19"
+  PYTHON_VERSION: "3.13"
+  WOMTOOL_VERSION: "92"
+  WOMTOOL_SHA256: "99cd3675c48696470f4d4e8b397fc613d7b342eb2ef2fa96f86db114bd9ed5f8"
+  WOMTOOL_SIZE_BYTES: "123647806"
+  WOMTOOL_JAR: ${{ github.workspace }}/.cache/womtool/womtool-92.jar
+  AI_BIOWORKFLOW_RUN_BACKEND: disabled
+
+jobs:
+  python:
+    name: Python tests and WOMtool validation
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      WDL_VALIDATOR: womtool
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
+
+      - name: Set up uv and Python
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          version: ${{ env.UV_VERSION }}
+          python-version: ${{ env.PYTHON_VERSION }}
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+
+      - name: Set up Java
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Restore WOMtool
+        id: womtool-cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .cache/womtool/womtool-92.jar
+          key: >-
+            womtool-${{ runner.os }}-${{ env.WOMTOOL_VERSION }}-${{ env.WOMTOOL_SHA256 }}-${{ hashFiles('scripts/install_womtool.ps1') }}
+
+      - name: Install WOMtool
+        if: ${{ steps.womtool-cache.outputs.cache-hit != 'true' }}
+        shell: pwsh
+        run: >-
+          ./scripts/install_womtool.ps1
+          -Version $env:WOMTOOL_VERSION
+          -InstallDir ".cache/womtool"
+
+      - name: Verify WOMtool integrity and runtime
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          echo "${WOMTOOL_SHA256}  ${WOMTOOL_JAR}" | sha256sum --check --strict
+          test "$(stat -c '%s' "${WOMTOOL_JAR}")" -eq "${WOMTOOL_SIZE_BYTES}"
+          java -version
+          test "$(java -jar "${WOMTOOL_JAR}" --version)" = "womtool ${WOMTOOL_VERSION}"
+
+      - name: Sync locked Python environment
+        run: uv sync --locked --extra miniwdl
+
+      - name: Assert canonical validator selection
+        run: >-
+          .venv/bin/python -c
+          "from src.tools.validator import womtool_available, wdl_validator_available;
+          assert womtool_available() and wdl_validator_available(),
+          'WOMtool must be available before the test suite starts'"
+
+      - name: Run Python test suite
+        run: .venv/bin/python -m unittest discover -v
+
+      - name: Validate container build contracts
+        run: |
+          .venv/bin/python -m py_compile scripts/build_container.py
+          .venv/bin/python scripts/build_container.py --all --dry-run
+
+      - name: Compile and validate representative WDL
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          output_dir="${RUNNER_TEMP}/generated-wdl"
+          mkdir -p "${output_dir}"
+
+          inputs=(
+            examples/rnaseq_deg_recipe_plan.json
+            examples/rnaseq_deg_edger_recipe_plan.json
+            examples/rnaseq_deg_limma_voom_recipe_plan.json
+            examples/rnaseq_reference_prep_recipe_plan.json
+            examples/chipseq_peak_calling_recipe_plan.json
+            examples/rnaseq_workflow_ir.json
+          )
+
+          for input_path in "${inputs[@]}"; do
+            output_path="${output_dir}/$(basename "${input_path%.*}").wdl"
+            .venv/bin/python main.py --input "${input_path}" --output "${output_path}"
+            java -jar "${WOMTOOL_JAR}" validate "${output_path}"
+          done
+
+  miniwdl:
+    name: miniwdl production compatibility
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      WDL_VALIDATOR: miniwdl
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
+
+      - name: Set up uv and Python
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          version: ${{ env.UV_VERSION }}
+          python-version: ${{ env.PYTHON_VERSION }}
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+          cache-suffix: miniwdl
+
+      - name: Sync locked Python environment
+        run: uv sync --locked --extra miniwdl
+
+      - name: Verify miniwdl installation
+        run: .venv/bin/miniwdl --version
+
+      - name: Test validator compatibility
+        run: .venv/bin/python -m unittest tests.test_tools -v
+
+      - name: Compile and check production-compatible WDL
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          output_dir="${RUNNER_TEMP}/miniwdl"
+          mkdir -p "${output_dir}"
+
+          inputs=(
+            examples/rnaseq_deg_recipe_plan.json
+            examples/rnaseq_reference_prep_recipe_plan.json
+            examples/chipseq_peak_calling_recipe_plan.json
+          )
+
+          for input_path in "${inputs[@]}"; do
+            output_path="${output_dir}/$(basename "${input_path%.*}").wdl"
+            .venv/bin/python main.py --input "${input_path}" --output "${output_path}"
+            .venv/bin/miniwdl check "${output_path}"
+          done
+
+  web:
+    name: Web lint, tests and build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      NEXT_TELEMETRY_DISABLED: "1"
+    defaults:
+      run:
+        working-directory: web
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+
+      - name: Install locked dependencies
+        run: npm ci
+
+      - name: Lint Web application
+        run: npm run lint
+
+      - name: Test Catalog retrieval UI
+        run: npm run test:catalog-retrieval
+
+      - name: Test Workflow IR graph UI
+        run: npm run test:graph
+
+      - name: Build Web application
+        run: npm run build
+
+  gate:
+    name: CI gate
+    if: ${{ always() }}
+    needs:
+      - python
+      - miniwdl
+      - web
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Require every CI job to pass
+        env:
+          PYTHON_RESULT: ${{ needs.python.result }}
+          MINIWDL_RESULT: ${{ needs.miniwdl.result }}
+          WEB_RESULT: ${{ needs.web.result }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          printf 'Python: %s\nminiwdl: %s\nWeb: %s\n' \
+            "${PYTHON_RESULT}" "${MINIWDL_RESULT}" "${WEB_RESULT}"
+
+          if [[ "${PYTHON_RESULT}" != "success" \
+            || "${MINIWDL_RESULT}" != "success" \
+            || "${WEB_RESULT}" != "success" ]]; then
+            echo "::error::One or more required CI jobs did not succeed."
+            exit 1
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,7 +88,10 @@ review, or bounded IR repair only through explicit structured interfaces.
   `.\.venv\Scripts\python.exe -m unittest discover -v`
 - When a change affects generated WDL, recipes, renderers, or validation paths,
   generate representative WDL and run:
-  `miniwdl check path/to/generated.wdl`
+  `java -jar path/to/womtool-92.jar validate path/to/generated.wdl`
+- WOMtool 92 is the canonical CI validator aligned with Cromwell 92. Run
+  `miniwdl check path/to/generated.wdl` as a secondary production-compatibility
+  check when miniwdl is available.
 - When a change affects execution backend selection or behavior, include the
   execution backend tests in verification.
 - Do not invent required lint/typecheck commands that are not configured in the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,8 @@ Read these sources of truth before changing the corresponding area:
 ## Development setup
 
 The project targets Python 3.13+ and uses `uv` with the repository `.venv`.
-Java 17+ and WOMtool 91 are used for the primary WDL validation path.
+Java 17+ and WOMtool 92 are used for the canonical WDL validation path.
+miniwdl is a secondary compatibility check for the production API image.
 
 ```powershell
 git clone https://github.com/yuanzhw/AI-bioworkflow.git
@@ -91,7 +92,8 @@ Every contribution must preserve these invariants:
 
 - Add focused tests for the new or changed contract.
 - Update `docs/workflow-ir.md` when semantics or backend mapping changes.
-- Generate representative WDL and run WOMtool or `miniwdl check`.
+- Generate representative WDL and validate it with WOMtool 92.
+- Run `miniwdl check` as the secondary production-compatibility check.
 
 ### Recipe or Tool Catalog
 
@@ -146,6 +148,12 @@ suffixes.
 
 All required checks should pass before merge. Squash merges should use a clean
 subject without an automatic `(#PR_NUMBER)` suffix.
+
+The required GitHub check is `CI gate`. It aggregates the complete Python
+suite with WOMtool validation, production miniwdl compatibility, and Web
+lint/tests/build. The workflow and local equivalents are documented in
+[CI and merge gate](./docs/ci.md). Do not bypass or rename this check without
+updating the `Mainline Safeguard` ruleset in the same maintenance change.
 
 ## Security reports
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -189,6 +189,10 @@ P0 后续工作重点不再是证明 runner 能否运行，而是把已验证流
 | FastAPI 开发服务 | `.\.venv\Scripts\python.exe -m src.api.server` | 默认监听 `127.0.0.1:8010`，避开 Cromwell 的 `8000`。 |
 | 真实 Cromwell tiny e2e | `powershell -ExecutionPolicy Bypass -File scripts\check_p0.ps1 -RunE2E -CromwellUrl http://localhost:8000 -WindowsFixtureRoot C:\data\ai-bioworkflow-tiny -CromwellFixtureRoot /data/ai-bioworkflow-runner/tiny` | 显式 opt-in；`check_p0.ps1` 委托 `run_cromwell_tiny_e2e.ps1` 准备 fixture、同步 runner 并运行真实 e2e。 |
 
+GitHub pull request 门禁使用 WOMtool 92 作为 canonical WDL validator，与
+Cromwell 92 runner 对齐；生产 API 镜像当前使用的 miniwdl 作为必需的第二实现
+兼容检查。完整 job 拓扑、固定版本和本地等价命令见 `docs/ci.md`。
+
 ## 未来架构原则（规划中）
 
 后续智能化能力遵循以下总原则：

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![Python Version](https://img.shields.io/badge/Python-3.13+-3776AB.svg?style=flat-square&logo=python&logoColor=white)](https://www.python.org/)
 [![WDL](https://img.shields.io/badge/WDL-1.0-167D73.svg?style=flat-square)](https://github.com/openwdl/wdl)
 [![Package Manager: uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv)
+[![CI](https://github.com/yuanzhw/AI-bioworkflow/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/yuanzhw/AI-bioworkflow/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/License-Apache%202.0-4B5563.svg?style=flat-square)](./LICENSE)
 
 LLM 只在显式结构化边界内承担自然语言规划和可选的 Reviewer IR 修复；Catalog 约束 recipe、tool、command 与 runtime container。Workflow IR（包括应用 Reviewer patch 后的候选）必须通过 Analyzer，再由确定性 Renderer 生成 WDL；Checker 只校验生成结果。Next.js 工作台记录同一次 run 的 timeline、artifacts、diagnostics 与 Workflow IR DAG，便于审阅和失败回放。
@@ -74,7 +75,7 @@ Reviewer 不能生成 WDL、修改 Catalog、command template 或 runtime image�
 确保你的本地开发环境已安装以下基础工具：
 - Python 3.13+
 - [uv](https://github.com/astral-sh/uv) (极速的 Python 包管理器)
-- Java 17+（WOMtool 91 需要 Java 17 或更新版本）
+- Java 17+（WOMtool 92 需要 Java 17 或更新版本）
 
 ### 2. 克隆与安装
 
@@ -359,6 +360,10 @@ Web 产品化拆解与当前 W6 收口计划详见：
 部署拓扑、环境变量、CORS、SQLite 数据边界和回滚流程详见：
 
 👉 **[部署与运维手册](./docs/deployment.md)**
+
+PR 必需检查、WOMtool / miniwdl 分工和本地等价命令详见：
+
+👉 **[CI 与合并门禁](./docs/ci.md)**
 
 ## 🤝 参与贡献与治理
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,0 +1,115 @@
+# Continuous integration and merge gate
+
+Every pull request targeting `main` must produce the stable `CI gate` check.
+The workflow intentionally has no path filter: documentation-only changes must
+report the same required check as compiler, API, Web, and deployment changes.
+
+## Required check topology
+
+`CI gate` aggregates three independent jobs:
+
+1. **Python tests and WOMtool validation**
+   - Python 3.13 and the locked `uv` environment.
+   - The complete `unittest` suite.
+   - Container build-script compilation and a dry run of every maintained
+     container definition.
+   - Deterministic compilation of representative Recipe Tool Plans and
+     Workflow IR followed by WOMtool validation.
+2. **miniwdl production compatibility**
+   - The validator wrapper contract tests.
+   - Representative structured compilation and explicit `miniwdl check`.
+3. **Web lint, tests and build**
+   - Locked npm installation, ESLint, Catalog retrieval tests, Workflow IR DAG
+     tests, and the production Next.js build.
+
+The aggregate job uses `if: always()` and fails unless every dependency
+concludes with `success`. The `Mainline Safeguard` ruleset requires only the
+stable `CI gate` context, so internal job names and future matrices can evolve
+without weakening branch protection.
+
+## Canonical WDL validator
+
+WOMtool 92 is the canonical WDL syntax and type validation gate because the
+project's execution runner targets Cromwell 92. CI sets
+`WDL_VALIDATOR=womtool` and points `WOMTOOL_JAR` to the versioned JAR; it does
+not use `auto`, so a missing WOMtool installation cannot silently fall back to
+another validator.
+
+The release asset is pinned by version, byte size, and SHA-256:
+
+```text
+Version: 92
+Size: 123647806 bytes
+SHA-256: 99cd3675c48696470f4d4e8b397fc613d7b342eb2ef2fa96f86db114bd9ed5f8
+```
+
+The checksum matches the digest published for the official Broad Institute
+Cromwell 92 release asset. Java 17 is required and the workflow verifies both
+the Java runtime and `womtool 92` before any test can run.
+
+miniwdl remains a required secondary compatibility check while the production
+API image uses `WDL_VALIDATOR=miniwdl`. It is not the canonical compiler
+acceptance authority. If production moves to WOMtool later, miniwdl can become
+an advisory portability check after an explicit compatibility decision.
+
+## Local equivalents
+
+Install Java and the checksum-verified WOMtool release from the repository
+root:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts\install_java.ps1
+powershell -ExecutionPolicy Bypass -File scripts\install_womtool.ps1
+```
+
+Run the primary local checks:
+
+```powershell
+$env:WDL_VALIDATOR = "womtool"
+$env:WOMTOOL_JAR = (Resolve-Path ".cache\womtool\womtool-92.jar").Path
+powershell -ExecutionPolicy Bypass -File scripts\check_p0.ps1
+```
+
+Run the production validator compatibility check when changing WDL generation,
+validation, or deployment behavior from Linux, macOS, or WSL:
+
+```bash
+uv sync --locked --extra miniwdl
+WDL_VALIDATOR=miniwdl uv run --locked --extra miniwdl \
+  main.py --input examples/rnaseq_deg_recipe_plan.json \
+  --output .cache/ci/rnaseq_deg.wdl
+uv run --locked --extra miniwdl miniwdl check \
+  .cache/ci/rnaseq_deg.wdl
+```
+
+miniwdl imports POSIX-only modules and is not a native Windows validation
+path. Windows contributors can run this check through WSL or rely on the
+required Ubuntu CI job; WOMtool remains fully supported on native Windows.
+
+Run the Web checks from `web/`:
+
+```powershell
+npm ci
+npm run lint
+npm run test:catalog-retrieval
+npm run test:graph
+npm run build
+```
+
+Real Cromwell execution and full project-maintained container builds remain
+explicit opt-in checks. They require external services, images, or runner
+state and are not part of the deterministic pull-request gate.
+
+## Workflow security
+
+- Pull-request jobs receive read-only repository permissions and no deployment
+  secrets.
+- The workflow does not use `pull_request_target`.
+- Third-party actions are pinned to full commit SHAs.
+- Checkout credentials are not persisted.
+- Concurrent runs for an older commit on the same pull request are cancelled.
+- Dependency lockfiles are enforced through `uv sync --locked` and `npm ci`.
+
+The image publication and deployment workflows remain separate from this
+required validation gate. They may use credentials only in their guarded
+publish or deployment paths.

--- a/docs/test-cases.md
+++ b/docs/test-cases.md
@@ -48,16 +48,16 @@ powershell -ExecutionPolicy Bypass -File scripts\check_p0.ps1 `
 - `tests/test_tiny_run.py`：没有 miniwdl、Docker/Podman、本地镜像或 tiny 输入文件时跳过真实 tiny run。
 - `tests/test_container_build.py`：纯单元测试，不调用 Docker；只验证容器构建脚本的 tag contract。
 
-当前 P2.6 Reviewer IR 修复闭环收口后的最近一次完整验证结果：
+当前 WOMtool 92 CI 门禁实现后的完整验证结果：
 
 ```text
 .\.venv\Scripts\python.exe -m unittest discover -v
-Ran 274 tests
+Ran 283 tests
 OK (skipped=2)
 ```
 
 跳过项为需要设置 `AI_BIOWORKFLOW_RUN_E2E=1` 的真实 Cromwell tiny e2e，
-以及当前环境未安装 miniwdl 时按设计跳过的本地 miniwdl tiny run。
+以及当前环境缺少完整 miniwdl 容器运行条件时按设计跳过的本地 tiny run。
 
 真实 Cromwell tiny e2e 已在独立 runner 环境中手动运行过；默认单测仍保留
 显式 opt-in 机制，避免普通 Windows/Codex 开发环境误触发真实 workflow 执行。
@@ -5021,6 +5021,30 @@ workflow Bad {
 覆盖点：
 
 - Validator wrapper 能把 WDL 语法错误转成结构化失败结果。
+
+### `ValidatorSelectionTests`
+
+这些用例固定 CI 所依赖的校验器选择与 Java 版本边界，不调用真实下载。
+
+#### `test_auto_prefers_womtool_without_probing_miniwdl`
+
+- 模拟 WOMtool 和 miniwdl 均可用。
+- `WDL_VALIDATOR=auto` 必须选择 WOMtool，且不探测 miniwdl。
+
+#### `test_auto_falls_back_to_miniwdl_when_womtool_is_unavailable`
+
+- 模拟 WOMtool 不可用、miniwdl 可用。
+- `auto` 模式选择 miniwdl，保持本地和生产兼容回退能力。
+
+#### `test_explicit_womtool_does_not_fall_back_to_miniwdl`
+
+- 设置 `WDL_VALIDATOR=womtool` 并模拟 WOMtool 缺失。
+- 结果必须为无可用 validator，不能静默使用 miniwdl 形成 CI 假绿。
+
+#### `test_womtool_rejects_java_older_than_17`
+
+- 模拟找到 WOMtool JAR，但 Java major version 为 16。
+- WOMtool command 必须不可用，固定 Cromwell/WOMtool 92 的 Java 17 下限。
 
 ## `tests/test_tiny_run.py`
 

--- a/docs/workflow-ir.md
+++ b/docs/workflow-ir.md
@@ -786,7 +786,9 @@ task multiqc_report {
 }
 ```
 
-Renderer 只负责确定性渲染。生成后由 `miniwdl check` 做 WDL 语法校验。
+Renderer 只负责确定性渲染。生成后由项目配置的 Checker 做 WDL 语法和
+类型校验；CI 以与 Cromwell runner 对齐的 WOMtool 92 为 canonical gate，
+并使用 `miniwdl check` 覆盖生产 API 的第二实现兼容性。
 
 ## 后端中立约束
 

--- a/main.py
+++ b/main.py
@@ -162,7 +162,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--no-check",
         action="store_true",
-        help="Skip miniwdl syntax validation after rendering.",
+        help="Skip configured WDL syntax validation after rendering.",
     )
     parser.add_argument(
         "--planner-model",

--- a/scripts/install_womtool.ps1
+++ b/scripts/install_womtool.ps1
@@ -1,6 +1,7 @@
 param(
-    [string]$Version = "91",
-    [string]$InstallDir = ".cache/womtool"
+    [string]$Version = "92",
+    [string]$InstallDir = ".cache/womtool",
+    [string]$Sha256 = ""
 )
 
 $ErrorActionPreference = "Stop"
@@ -8,14 +9,42 @@ $ErrorActionPreference = "Stop"
 $root = Resolve-Path "."
 $targetDir = Join-Path $root $InstallDir
 $versionedJar = Join-Path $targetDir "womtool-$Version.jar"
+$downloadJar = Join-Path $targetDir ".womtool-$Version.jar.download"
 $defaultJar = Join-Path $targetDir "womtool.jar"
 $url = "https://github.com/broadinstitute/cromwell/releases/download/$Version/womtool-$Version.jar"
+$knownSha256 = @{
+    "92" = "99cd3675c48696470f4d4e8b397fc613d7b342eb2ef2fa96f86db114bd9ed5f8"
+}
+
+$expectedSha256 = $Sha256.Trim().ToLowerInvariant()
+if (-not $expectedSha256) {
+    $expectedSha256 = $knownSha256[$Version]
+}
+if (-not $expectedSha256) {
+    throw "No trusted SHA-256 is recorded for WOMtool $Version. Pass -Sha256 explicitly."
+}
+if ($expectedSha256 -notmatch "^[0-9a-f]{64}$") {
+    throw "Sha256 must be exactly 64 hexadecimal characters."
+}
 
 New-Item -ItemType Directory -Force -Path $targetDir | Out-Null
 
 Write-Host "Downloading WOMtool $Version..."
-Invoke-WebRequest -Uri $url -OutFile $versionedJar
+try {
+    Invoke-WebRequest -Uri $url -OutFile $downloadJar
+    $actualSha256 = (Get-FileHash -LiteralPath $downloadJar -Algorithm SHA256).Hash.ToLowerInvariant()
+    if ($actualSha256 -ne $expectedSha256) {
+        throw "WOMtool $Version SHA-256 mismatch. Expected $expectedSha256, got $actualSha256."
+    }
+    Move-Item -LiteralPath $downloadJar -Destination $versionedJar -Force
+}
+finally {
+    if (Test-Path -LiteralPath $downloadJar) {
+        Remove-Item -LiteralPath $downloadJar -Force
+    }
+}
 Copy-Item -LiteralPath $versionedJar -Destination $defaultJar -Force
 
 Write-Host "WOMTOOL_JAR=$defaultJar"
 Write-Host "Downloaded $versionedJar"
+Write-Host "SHA256=$actualSha256"

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,6 +1,10 @@
+import os
 import unittest
+from pathlib import Path
+from unittest.mock import patch
 
-from src.tools.validator import wdl_validator, wdl_validator_available
+import src.tools.validator as validator_module
+from src.tools.validator import ValidatorCommand, wdl_validator, wdl_validator_available
 
 VALID_WDL = """
 version 1.0
@@ -53,6 +57,64 @@ class ValidatorTests(unittest.TestCase):
 
         self.assertFalse(result["is_valid"])
         self.assertIn("WDL 语法校验失败", result["message"])
+
+
+class ValidatorSelectionTests(unittest.TestCase):
+    def test_auto_prefers_womtool_without_probing_miniwdl(self):
+        womtool = ValidatorCommand(
+            name="womtool",
+            label="WOMtool test",
+            command=["java", "-jar", "womtool.jar", "validate"],
+        )
+
+        with (
+            patch.dict(os.environ, {"WDL_VALIDATOR": "auto"}),
+            patch.object(validator_module, "_womtool_command", return_value=womtool),
+            patch.object(validator_module, "_miniwdl_command") as miniwdl_command,
+        ):
+            selected = validator_module._selected_validator()
+
+        self.assertIs(selected, womtool)
+        miniwdl_command.assert_not_called()
+
+    def test_auto_falls_back_to_miniwdl_when_womtool_is_unavailable(self):
+        miniwdl = ValidatorCommand(
+            name="miniwdl",
+            label="miniwdl",
+            command=["miniwdl", "check"],
+        )
+
+        with (
+            patch.dict(os.environ, {"WDL_VALIDATOR": "auto"}),
+            patch.object(validator_module, "_womtool_command", return_value=None),
+            patch.object(validator_module, "_miniwdl_command", return_value=miniwdl),
+        ):
+            selected = validator_module._selected_validator()
+
+        self.assertIs(selected, miniwdl)
+
+    def test_explicit_womtool_does_not_fall_back_to_miniwdl(self):
+        with (
+            patch.dict(os.environ, {"WDL_VALIDATOR": "womtool"}),
+            patch.object(validator_module, "_womtool_command", return_value=None),
+            patch.object(validator_module, "_miniwdl_command") as miniwdl_command,
+        ):
+            selected = validator_module._selected_validator()
+
+        self.assertIsNone(selected)
+        miniwdl_command.assert_not_called()
+
+    def test_womtool_rejects_java_older_than_17(self):
+        java = Path("java")
+
+        with (
+            patch.object(validator_module, "_womtool_jar", return_value=Path("womtool.jar")),
+            patch.object(validator_module, "_java_candidates", return_value=[java]),
+            patch.object(validator_module, "_java_major_version", return_value=16),
+        ):
+            selected = validator_module._womtool_command()
+
+        self.assertIsNone(selected)
 
 
 if __name__ == "__main__":

--- a/tools/womtool/README.md
+++ b/tools/womtool/README.md
@@ -8,9 +8,11 @@
 scripts/install_womtool.ps1
 ```
 
-默认情况下，脚本会从 Broad Institute Cromwell GitHub Releases 下载 `womtool-91.jar`，并保存到：
+默认情况下，脚本会从 Broad Institute Cromwell GitHub Releases 下载
+`womtool-92.jar`，校验仓库记录的 SHA-256 后保存到：
 
 ```text
+.cache/womtool/womtool-92.jar
 .cache/womtool/womtool.jar
 ```
 
@@ -20,7 +22,8 @@ scripts/install_womtool.ps1
 WOMTOOL_JAR="D:/path/to/womtool.jar"
 ```
 
-默认 WOMtool 91 release 需要 Java 17 或更新版本。如需安装项目本地的 Temurin JDK：
+默认 WOMtool 92 release 与项目 Cromwell 92 runner 保持一致，需要 Java 17
+或更新版本。如需安装项目本地的 Temurin JDK：
 
 ```powershell
 scripts/install_java.ps1


### PR DESCRIPTION
## Summary

Establish a stable, repository-wide merge gate for every pull request targeting `main`.

- Aggregate Python, canonical WOMtool 92, secondary miniwdl, and Web checks under the required `CI gate` context.
- Pin WOMtool 92 by version, byte size, and official SHA-256, and pin every third-party Action to a full commit SHA.
- Document validator authority, local equivalents, fork-safe permissions, and branch-ruleset rollout.

## Scope

- [ ] Bug fix
- [ ] Compiler or Workflow IR
- [ ] Recipe or Tool Catalog
- [ ] API or Web
- [ ] Execution backend or container
- [x] Tests or documentation
- [x] Other — CI and repository policy

## Architecture impact

- [x] Natural-language processing still stops at Recipe Tool Plan.
- [x] Final WDL is produced only by the deterministic Renderer.
- [x] `workflow.steps` remains the canonical DAG; `workflow.calls` is compatibility-only.
- [x] Catalog tool, command, and runtime definitions remain explicit and validated.
- [x] Analyzer, Renderer, Checker, and `src.execution` boundaries are preserved.
- [ ] Not applicable to this change.

## Validation

- [x] Python unit tests
- [ ] `scripts/check_p0.ps1`
- [x] Representative WDL compile and WOMtool 92 validation
- [ ] miniwdl production-compatibility validation
- [x] Frontend lint
- [x] Frontend Catalog retrieval tests
- [x] Frontend workflow graph tests
- [x] Frontend production build
- [ ] Container build or smoke test
- [ ] Real execution test — explicit opt-in
- [ ] Documentation-only change

Commands and results:

```text
.venv/Scripts/python.exe -m unittest discover -v
283 tests passed; 2 explicit opt-in/runtime tests skipped

java -jar .cache/womtool/womtool-92.jar validate <generated.wdl>
6 representative Recipe Tool Plan / Workflow IR outputs passed

.venv/Scripts/python.exe -m py_compile scripts/build_container.py
.venv/Scripts/python.exe scripts/build_container.py --all --dry-run
passed

npm ci
npm run lint
npm run test:catalog-retrieval
npm run test:graph
npm run build
passed

actionlint
passed with no findings
```

Skipped checks and reasons:

```text
Native Windows cannot import miniwdl's POSIX-only fcntl dependency. The new
required Ubuntu job runs the miniwdl compatibility checks on this PR.

Real Cromwell execution and image builds remain explicit opt-in operations;
the gate validates their deterministic build contracts with --all --dry-run.
```

## Documentation and contracts

- [x] `docs/workflow-ir.md` was updated, or no IR/backend contract changed.
- [x] `docs/test-cases.md` was updated, or no test input, expectation, or coverage intent changed.
- [x] New tools or wrappers include schemas, command/runtime definitions, verification status, and appropriate tests.
- [x] New dependencies are justified and lockfiles are updated.
- [x] No secrets, credentials, private data, or local `.env` files are included.

## Evidence

The workflow verifies WOMtool 92 against the official asset size and SHA-256 before running tests, then confirms the exact `womtool 92` version output.

## Risks and follow-ups

After this PR produces its first successful `CI gate` check, update the `Mainline Safeguard` ruleset to require that context with strict branch freshness, rerun the workflow to demonstrate the pending gate blocks merging, and merge only after the rerun succeeds.
