### PR TITLE
Record alpha.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to AI-bioworkflow are recorded here. The format follows [Kee
 
 ## [Unreleased]
 
+## [0.1.0-alpha.2] - 2026-09-02
+
 ### Added
 
 - A required `CI gate` that aggregates the complete Python suite, WOMtool validation, miniwdl production compatibility, and Web lint/tests/build.
@@ -32,7 +34,8 @@ First public engineering preview.
 
 ### Validation note
 
-The `v0.1.0-alpha.1` snapshot used WOMtool 91 in its documented local installation path. The WOMtool 92 required gate is part of the unreleased changes after that tag; the historical release record has not been rewritten.
+The `v0.1.0-alpha.1` snapshot used WOMtool 91 in its documented local installation path. The WOMtool 92 required gate was introduced in `v0.1.0-alpha.2`; the historical release record has not been rewritten.
 
-[Unreleased]: https://github.com/yuanzhw/AI-bioworkflow/compare/v0.1.0-alpha.1...HEAD
+[Unreleased]: https://github.com/yuanzhw/AI-bioworkflow/compare/v0.1.0-alpha.2...HEAD
+[0.1.0-alpha.2]: https://github.com/yuanzhw/AI-bioworkflow/compare/v0.1.0-alpha.1...v0.1.0-alpha.2
 [0.1.0-alpha.1]: https://github.com/yuanzhw/AI-bioworkflow/releases/tag/v0.1.0-alpha.1

--- a/README.en.md
+++ b/README.en.md
@@ -134,8 +134,8 @@ Passing WDL syntax and type validation does not establish that an analysis desig
 
 ## Status and roadmap
 
-- **Released:** [`v0.1.0-alpha.1`](https://github.com/yuanzhw/AI-bioworkflow/releases/tag/v0.1.0-alpha.1) established the public compiler workbench, DAG, Catalog, and deployment baseline.
-- **Current `main`:** required WOMtool 92 CI, OSS governance, bilingual entry points, a traceable case study, a compile-ready ChIP-seq recipe, cross-workflow-family retrieval evaluation, and public evidence pages form the next pre-release candidate.
+- **Released:** [`v0.1.0-alpha.2`](https://github.com/yuanzhw/AI-bioworkflow/releases/tag/v0.1.0-alpha.2) extends the public compiler workbench with required WOMtool 92 CI, OSS governance, bilingual entry points, and a traceable case study.
+- **Current `main`:** the published alpha.2 baseline includes the compile-ready ChIP-seq recipe, cross-workflow-family retrieval evaluation, and public evidence pages, with further changes kept incremental.
 - **Next:** layered Architect and Bioinfo Reviewer roles, more admitted recipes/tools, and reproducible evaluation of retrieval quality and scientific warnings.
 - **Not in the current scope:** direct model generation of final WDL, real execution enabled by default in the public demo, or premature investment in authentication, billing, and complex multi-tenant infrastructure.
 

--- a/README.md
+++ b/README.md
@@ -136,8 +136,8 @@ WDL 通过语法/类型校验并不证明某个分析方案适合任意研究设
 
 ## 状态与路线图
 
-- **Released:** [`v0.1.0-alpha.1`](https://github.com/yuanzhw/AI-bioworkflow/releases/tag/v0.1.0-alpha.1) 建立了公开编译工作台、DAG、Catalog 与部署基线。
-- **Current `main`:** WOMtool 92 required CI、OSS 治理、双语入口、可追溯案例、ChIP-seq compile-ready recipe、跨 workflow-family 检索评测与公共证据页已进入下一预发布候选。
+- **Released:** [`v0.1.0-alpha.2`](https://github.com/yuanzhw/AI-bioworkflow/releases/tag/v0.1.0-alpha.2) 在公开编译工作台基础上补齐 WOMtool 92 required CI、OSS 治理、双语入口与可追溯案例。
+- **Current `main`:** 已发布的 alpha.2 基线包含 ChIP-seq compile-ready recipe、跨 workflow-family 检索评测与公共证据页，并继续接受小步演进。
 - **Next:** 分层 Architect / Bioinfo Reviewer、更多正式 recipe/tool，以及对检索质量和科学性 warning 的可复现评测。
 - **当前不做:** 让模型直接生成最终 WDL、在公开 demo 默认开启真实执行，或为了展示提前建设登录、计费和复杂多租户平台。
 


### PR DESCRIPTION
## Summary

- promote the verified public-surface changes from Unreleased to `v0.1.0-alpha.2`
- update both public READMEs to point to the now-live pre-release
- preserve the historical WOMtool 91 note for `v0.1.0-alpha.1`

## Verification

- GitHub pre-release and tag are live and point to the verified `main` merge commit
- public-surface check passed for 33 tracked Markdown files
- 16 focused public-surface tests passed
